### PR TITLE
Releasing version 2.30.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 ====================
+2.30.0 - 2021-02-02
+====================
+
+Added
+-----
+* Support for checking if a contact for Exadata infrastructure is valid in My Oracle Support in the Database service
+* Support for checking if Exadata infrastructure is in a degraded state in the Database service
+* Support for updating the operating system on a VM cluster in the Database service
+* Support for external databases in the Database service
+* Support for uploading objects to the infrequent access storage tier in the Object Storage service
+* Support for changing the storage tier of existing objects in the Object Storage service
+* Support for private templates in the Resource Manager service
+* Support for multiple encryption domains on IPSec tunnels in the Networking service
+
+Breaking
+--------
+* Attribute `vnic_id` in response model `Ipv6` changed from required to optional in the Networking service
+
+====================
 2.29.0 - 2021-01-26
 ====================
 

--- a/docs/api/core.rst
+++ b/docs/api/core.rst
@@ -134,6 +134,7 @@ Core Services
     oci.core.models.CreateIPSecConnectionDetails
     oci.core.models.CreateIPSecConnectionTunnelDetails
     oci.core.models.CreateIPSecTunnelBgpSessionDetails
+    oci.core.models.CreateIPSecTunnelEncryptionDomainDetails
     oci.core.models.CreateImageDetails
     oci.core.models.CreateInstanceConfigurationBase
     oci.core.models.CreateInstanceConfigurationDetails
@@ -188,6 +189,7 @@ Core Services
     oci.core.models.DrgRedundancyStatus
     oci.core.models.EgressSecurityRule
     oci.core.models.EmulatedVolumeAttachment
+    oci.core.models.EncryptionDomainConfig
     oci.core.models.EnumIntegerImageCapabilityDescriptor
     oci.core.models.EnumStringImageCapabilitySchemaDescriptor
     oci.core.models.ExportImageDetails
@@ -316,6 +318,7 @@ Core Services
     oci.core.models.UpdateIPSecConnectionTunnelDetails
     oci.core.models.UpdateIPSecConnectionTunnelSharedSecretDetails
     oci.core.models.UpdateIPSecTunnelBgpSessionDetails
+    oci.core.models.UpdateIPSecTunnelEncryptionDomainDetails
     oci.core.models.UpdateImageDetails
     oci.core.models.UpdateInstanceAgentConfigDetails
     oci.core.models.UpdateInstanceAvailabilityConfigDetails

--- a/docs/api/core/models/oci.core.models.CreateIPSecTunnelEncryptionDomainDetails.rst
+++ b/docs/api/core/models/oci.core.models.CreateIPSecTunnelEncryptionDomainDetails.rst
@@ -1,0 +1,11 @@
+CreateIPSecTunnelEncryptionDomainDetails
+========================================
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: CreateIPSecTunnelEncryptionDomainDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/core/models/oci.core.models.EncryptionDomainConfig.rst
+++ b/docs/api/core/models/oci.core.models.EncryptionDomainConfig.rst
@@ -1,0 +1,11 @@
+EncryptionDomainConfig
+======================
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: EncryptionDomainConfig
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/core/models/oci.core.models.UpdateIPSecTunnelEncryptionDomainDetails.rst
+++ b/docs/api/core/models/oci.core.models.UpdateIPSecTunnelEncryptionDomainDetails.rst
@@ -1,0 +1,11 @@
+UpdateIPSecTunnelEncryptionDomainDetails
+========================================
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: UpdateIPSecTunnelEncryptionDomainDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database.rst
+++ b/docs/api/database.rst
@@ -105,6 +105,12 @@ Database
     oci.database.models.CreateDbHomeWithVmClusterIdFromBackupDetails
     oci.database.models.CreateExadataInfrastructureDetails
     oci.database.models.CreateExternalBackupJobDetails
+    oci.database.models.CreateExternalContainerDatabaseDetails
+    oci.database.models.CreateExternalDatabaseConnectorDetails
+    oci.database.models.CreateExternalDatabaseDetailsBase
+    oci.database.models.CreateExternalMacsConnectorDetails
+    oci.database.models.CreateExternalNonContainerDatabaseDetails
+    oci.database.models.CreateExternalPluggableDatabaseDetails
     oci.database.models.CreateKeyStoreDetails
     oci.database.models.CreateNFSBackupDestinationDetails
     oci.database.models.CreateNewDatabaseDetails
@@ -114,7 +120,12 @@ Database
     oci.database.models.DataGuardAssociation
     oci.database.models.DataGuardAssociationSummary
     oci.database.models.Database
+    oci.database.models.DatabaseConnectionCredentailsByName
+    oci.database.models.DatabaseConnectionCredentials
+    oci.database.models.DatabaseConnectionCredentialsByDetails
+    oci.database.models.DatabaseConnectionString
     oci.database.models.DatabaseConnectionStrings
+    oci.database.models.DatabaseManagementConfig
     oci.database.models.DatabaseSoftwareImage
     oci.database.models.DatabaseSoftwareImageSummary
     oci.database.models.DatabaseSummary
@@ -138,6 +149,10 @@ Database
     oci.database.models.DbSystemSummary
     oci.database.models.DbVersionSummary
     oci.database.models.DeregisterAutonomousDatabaseDataSafeDetails
+    oci.database.models.EnableExternalContainerDatabaseDatabaseManagementDetails
+    oci.database.models.EnableExternalDatabaseManagementDetailsBase
+    oci.database.models.EnableExternalNonContainerDatabaseDatabaseManagementDetails
+    oci.database.models.EnableExternalPluggableDatabaseDatabaseManagementDetails
     oci.database.models.ExadataDbSystemMigration
     oci.database.models.ExadataDbSystemMigrationSummary
     oci.database.models.ExadataInfrastructure
@@ -146,6 +161,17 @@ Database
     oci.database.models.ExadataIormConfig
     oci.database.models.ExadataIormConfigUpdateDetails
     oci.database.models.ExternalBackupJob
+    oci.database.models.ExternalContainerDatabase
+    oci.database.models.ExternalContainerDatabaseSummary
+    oci.database.models.ExternalDatabaseBase
+    oci.database.models.ExternalDatabaseConnector
+    oci.database.models.ExternalDatabaseConnectorSummary
+    oci.database.models.ExternalMacsConnector
+    oci.database.models.ExternalMacsConnectorSummary
+    oci.database.models.ExternalNonContainerDatabase
+    oci.database.models.ExternalNonContainerDatabaseSummary
+    oci.database.models.ExternalPluggableDatabase
+    oci.database.models.ExternalPluggableDatabaseSummary
     oci.database.models.FailoverDataGuardAssociationDetails
     oci.database.models.FlexComponentCollection
     oci.database.models.FlexComponentSummary
@@ -200,6 +226,12 @@ Database
     oci.database.models.UpdateDbSystemDetails
     oci.database.models.UpdateDetails
     oci.database.models.UpdateExadataInfrastructureDetails
+    oci.database.models.UpdateExternalContainerDatabaseDetails
+    oci.database.models.UpdateExternalDatabaseConnectorDetails
+    oci.database.models.UpdateExternalDatabaseDetailsBase
+    oci.database.models.UpdateExternalMacsConnectorDetails
+    oci.database.models.UpdateExternalNonContainerDatabaseDetails
+    oci.database.models.UpdateExternalPluggableDatabaseDetails
     oci.database.models.UpdateHistoryEntry
     oci.database.models.UpdateHistoryEntrySummary
     oci.database.models.UpdateKeyStoreDetails

--- a/docs/api/database/models/oci.database.models.CreateExternalContainerDatabaseDetails.rst
+++ b/docs/api/database/models/oci.database.models.CreateExternalContainerDatabaseDetails.rst
@@ -1,0 +1,11 @@
+CreateExternalContainerDatabaseDetails
+======================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: CreateExternalContainerDatabaseDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.CreateExternalDatabaseConnectorDetails.rst
+++ b/docs/api/database/models/oci.database.models.CreateExternalDatabaseConnectorDetails.rst
@@ -1,0 +1,11 @@
+CreateExternalDatabaseConnectorDetails
+======================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: CreateExternalDatabaseConnectorDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.CreateExternalDatabaseDetailsBase.rst
+++ b/docs/api/database/models/oci.database.models.CreateExternalDatabaseDetailsBase.rst
@@ -1,0 +1,11 @@
+CreateExternalDatabaseDetailsBase
+=================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: CreateExternalDatabaseDetailsBase
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.CreateExternalMacsConnectorDetails.rst
+++ b/docs/api/database/models/oci.database.models.CreateExternalMacsConnectorDetails.rst
@@ -1,0 +1,11 @@
+CreateExternalMacsConnectorDetails
+==================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: CreateExternalMacsConnectorDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.CreateExternalNonContainerDatabaseDetails.rst
+++ b/docs/api/database/models/oci.database.models.CreateExternalNonContainerDatabaseDetails.rst
@@ -1,0 +1,11 @@
+CreateExternalNonContainerDatabaseDetails
+=========================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: CreateExternalNonContainerDatabaseDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.CreateExternalPluggableDatabaseDetails.rst
+++ b/docs/api/database/models/oci.database.models.CreateExternalPluggableDatabaseDetails.rst
@@ -1,0 +1,11 @@
+CreateExternalPluggableDatabaseDetails
+======================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: CreateExternalPluggableDatabaseDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.DatabaseConnectionCredentailsByName.rst
+++ b/docs/api/database/models/oci.database.models.DatabaseConnectionCredentailsByName.rst
@@ -1,0 +1,11 @@
+DatabaseConnectionCredentailsByName
+===================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: DatabaseConnectionCredentailsByName
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.DatabaseConnectionCredentials.rst
+++ b/docs/api/database/models/oci.database.models.DatabaseConnectionCredentials.rst
@@ -1,0 +1,11 @@
+DatabaseConnectionCredentials
+=============================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: DatabaseConnectionCredentials
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.DatabaseConnectionCredentialsByDetails.rst
+++ b/docs/api/database/models/oci.database.models.DatabaseConnectionCredentialsByDetails.rst
@@ -1,0 +1,11 @@
+DatabaseConnectionCredentialsByDetails
+======================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: DatabaseConnectionCredentialsByDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.DatabaseConnectionString.rst
+++ b/docs/api/database/models/oci.database.models.DatabaseConnectionString.rst
@@ -1,0 +1,11 @@
+DatabaseConnectionString
+========================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: DatabaseConnectionString
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.DatabaseManagementConfig.rst
+++ b/docs/api/database/models/oci.database.models.DatabaseManagementConfig.rst
@@ -1,0 +1,11 @@
+DatabaseManagementConfig
+========================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: DatabaseManagementConfig
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.EnableExternalContainerDatabaseDatabaseManagementDetails.rst
+++ b/docs/api/database/models/oci.database.models.EnableExternalContainerDatabaseDatabaseManagementDetails.rst
@@ -1,0 +1,11 @@
+EnableExternalContainerDatabaseDatabaseManagementDetails
+========================================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: EnableExternalContainerDatabaseDatabaseManagementDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.EnableExternalDatabaseManagementDetailsBase.rst
+++ b/docs/api/database/models/oci.database.models.EnableExternalDatabaseManagementDetailsBase.rst
@@ -1,0 +1,11 @@
+EnableExternalDatabaseManagementDetailsBase
+===========================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: EnableExternalDatabaseManagementDetailsBase
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.EnableExternalNonContainerDatabaseDatabaseManagementDetails.rst
+++ b/docs/api/database/models/oci.database.models.EnableExternalNonContainerDatabaseDatabaseManagementDetails.rst
@@ -1,0 +1,11 @@
+EnableExternalNonContainerDatabaseDatabaseManagementDetails
+===========================================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: EnableExternalNonContainerDatabaseDatabaseManagementDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.EnableExternalPluggableDatabaseDatabaseManagementDetails.rst
+++ b/docs/api/database/models/oci.database.models.EnableExternalPluggableDatabaseDatabaseManagementDetails.rst
@@ -1,0 +1,11 @@
+EnableExternalPluggableDatabaseDatabaseManagementDetails
+========================================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: EnableExternalPluggableDatabaseDatabaseManagementDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.ExternalContainerDatabase.rst
+++ b/docs/api/database/models/oci.database.models.ExternalContainerDatabase.rst
@@ -1,0 +1,11 @@
+ExternalContainerDatabase
+=========================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: ExternalContainerDatabase
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.ExternalContainerDatabaseSummary.rst
+++ b/docs/api/database/models/oci.database.models.ExternalContainerDatabaseSummary.rst
@@ -1,0 +1,11 @@
+ExternalContainerDatabaseSummary
+================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: ExternalContainerDatabaseSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.ExternalDatabaseBase.rst
+++ b/docs/api/database/models/oci.database.models.ExternalDatabaseBase.rst
@@ -1,0 +1,11 @@
+ExternalDatabaseBase
+====================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: ExternalDatabaseBase
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.ExternalDatabaseConnector.rst
+++ b/docs/api/database/models/oci.database.models.ExternalDatabaseConnector.rst
@@ -1,0 +1,11 @@
+ExternalDatabaseConnector
+=========================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: ExternalDatabaseConnector
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.ExternalDatabaseConnectorSummary.rst
+++ b/docs/api/database/models/oci.database.models.ExternalDatabaseConnectorSummary.rst
@@ -1,0 +1,11 @@
+ExternalDatabaseConnectorSummary
+================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: ExternalDatabaseConnectorSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.ExternalMacsConnector.rst
+++ b/docs/api/database/models/oci.database.models.ExternalMacsConnector.rst
@@ -1,0 +1,11 @@
+ExternalMacsConnector
+=====================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: ExternalMacsConnector
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.ExternalMacsConnectorSummary.rst
+++ b/docs/api/database/models/oci.database.models.ExternalMacsConnectorSummary.rst
@@ -1,0 +1,11 @@
+ExternalMacsConnectorSummary
+============================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: ExternalMacsConnectorSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.ExternalNonContainerDatabase.rst
+++ b/docs/api/database/models/oci.database.models.ExternalNonContainerDatabase.rst
@@ -1,0 +1,11 @@
+ExternalNonContainerDatabase
+============================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: ExternalNonContainerDatabase
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.ExternalNonContainerDatabaseSummary.rst
+++ b/docs/api/database/models/oci.database.models.ExternalNonContainerDatabaseSummary.rst
@@ -1,0 +1,11 @@
+ExternalNonContainerDatabaseSummary
+===================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: ExternalNonContainerDatabaseSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.ExternalPluggableDatabase.rst
+++ b/docs/api/database/models/oci.database.models.ExternalPluggableDatabase.rst
@@ -1,0 +1,11 @@
+ExternalPluggableDatabase
+=========================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: ExternalPluggableDatabase
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.ExternalPluggableDatabaseSummary.rst
+++ b/docs/api/database/models/oci.database.models.ExternalPluggableDatabaseSummary.rst
@@ -1,0 +1,11 @@
+ExternalPluggableDatabaseSummary
+================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: ExternalPluggableDatabaseSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.UpdateExternalContainerDatabaseDetails.rst
+++ b/docs/api/database/models/oci.database.models.UpdateExternalContainerDatabaseDetails.rst
@@ -1,0 +1,11 @@
+UpdateExternalContainerDatabaseDetails
+======================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: UpdateExternalContainerDatabaseDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.UpdateExternalDatabaseConnectorDetails.rst
+++ b/docs/api/database/models/oci.database.models.UpdateExternalDatabaseConnectorDetails.rst
@@ -1,0 +1,11 @@
+UpdateExternalDatabaseConnectorDetails
+======================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: UpdateExternalDatabaseConnectorDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.UpdateExternalDatabaseDetailsBase.rst
+++ b/docs/api/database/models/oci.database.models.UpdateExternalDatabaseDetailsBase.rst
@@ -1,0 +1,11 @@
+UpdateExternalDatabaseDetailsBase
+=================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: UpdateExternalDatabaseDetailsBase
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.UpdateExternalMacsConnectorDetails.rst
+++ b/docs/api/database/models/oci.database.models.UpdateExternalMacsConnectorDetails.rst
@@ -1,0 +1,11 @@
+UpdateExternalMacsConnectorDetails
+==================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: UpdateExternalMacsConnectorDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.UpdateExternalNonContainerDatabaseDetails.rst
+++ b/docs/api/database/models/oci.database.models.UpdateExternalNonContainerDatabaseDetails.rst
@@ -1,0 +1,11 @@
+UpdateExternalNonContainerDatabaseDetails
+=========================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: UpdateExternalNonContainerDatabaseDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.UpdateExternalPluggableDatabaseDetails.rst
+++ b/docs/api/database/models/oci.database.models.UpdateExternalPluggableDatabaseDetails.rst
@@ -1,0 +1,11 @@
+UpdateExternalPluggableDatabaseDetails
+======================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: UpdateExternalPluggableDatabaseDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/object_storage.rst
+++ b/docs/api/object_storage.rst
@@ -56,6 +56,7 @@ Object Storage
     oci.object_storage.models.SSECustomerKeyDetails
     oci.object_storage.models.UpdateBucketDetails
     oci.object_storage.models.UpdateNamespaceMetadataDetails
+    oci.object_storage.models.UpdateObjectStorageTierDetails
     oci.object_storage.models.UpdateRetentionRuleDetails
     oci.object_storage.models.WorkRequest
     oci.object_storage.models.WorkRequestError

--- a/docs/api/object_storage/models/oci.object_storage.models.UpdateObjectStorageTierDetails.rst
+++ b/docs/api/object_storage/models/oci.object_storage.models.UpdateObjectStorageTierDetails.rst
@@ -1,0 +1,11 @@
+UpdateObjectStorageTierDetails
+==============================
+
+.. currentmodule:: oci.object_storage.models
+
+.. autoclass:: UpdateObjectStorageTierDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/resource_manager.rst
+++ b/docs/api/resource_manager.rst
@@ -23,6 +23,7 @@ Resource Manager
     oci.resource_manager.models.ApplyJobPlanResolution
     oci.resource_manager.models.ChangeConfigurationSourceProviderCompartmentDetails
     oci.resource_manager.models.ChangeStackCompartmentDetails
+    oci.resource_manager.models.ChangeTemplateCompartmentDetails
     oci.resource_manager.models.CompartmentConfigSource
     oci.resource_manager.models.ConfigSource
     oci.resource_manager.models.ConfigSourceRecord
@@ -42,6 +43,10 @@ Resource Manager
     oci.resource_manager.models.CreateJobOperationDetails
     oci.resource_manager.models.CreatePlanJobOperationDetails
     oci.resource_manager.models.CreateStackDetails
+    oci.resource_manager.models.CreateStackTemplateConfigSourceDetails
+    oci.resource_manager.models.CreateTemplateConfigSourceDetails
+    oci.resource_manager.models.CreateTemplateDetails
+    oci.resource_manager.models.CreateTemplateZipUploadConfigSourceDetails
     oci.resource_manager.models.CreateZipUploadConfigSourceDetails
     oci.resource_manager.models.DestroyJobOperationDetails
     oci.resource_manager.models.DestroyJobOperationDetailsSummary
@@ -68,6 +73,13 @@ Resource Manager
     oci.resource_manager.models.StackResourceDriftCollection
     oci.resource_manager.models.StackResourceDriftSummary
     oci.resource_manager.models.StackSummary
+    oci.resource_manager.models.Template
+    oci.resource_manager.models.TemplateCategorySummary
+    oci.resource_manager.models.TemplateCategorySummaryCollection
+    oci.resource_manager.models.TemplateConfigSource
+    oci.resource_manager.models.TemplateSummary
+    oci.resource_manager.models.TemplateSummaryCollection
+    oci.resource_manager.models.TemplateZipUploadConfigSource
     oci.resource_manager.models.TerraformVersionCollection
     oci.resource_manager.models.TerraformVersionSummary
     oci.resource_manager.models.UpdateConfigSourceDetails
@@ -77,6 +89,9 @@ Resource Manager
     oci.resource_manager.models.UpdateGitlabAccessTokenConfigurationSourceProviderDetails
     oci.resource_manager.models.UpdateJobDetails
     oci.resource_manager.models.UpdateStackDetails
+    oci.resource_manager.models.UpdateTemplateConfigSourceDetails
+    oci.resource_manager.models.UpdateTemplateDetails
+    oci.resource_manager.models.UpdateTemplateZipUploadConfigSourceDetails
     oci.resource_manager.models.UpdateZipUploadConfigSourceDetails
     oci.resource_manager.models.WorkRequest
     oci.resource_manager.models.WorkRequestError

--- a/docs/api/resource_manager/models/oci.resource_manager.models.ChangeTemplateCompartmentDetails.rst
+++ b/docs/api/resource_manager/models/oci.resource_manager.models.ChangeTemplateCompartmentDetails.rst
@@ -1,0 +1,11 @@
+ChangeTemplateCompartmentDetails
+================================
+
+.. currentmodule:: oci.resource_manager.models
+
+.. autoclass:: ChangeTemplateCompartmentDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/resource_manager/models/oci.resource_manager.models.CreateStackTemplateConfigSourceDetails.rst
+++ b/docs/api/resource_manager/models/oci.resource_manager.models.CreateStackTemplateConfigSourceDetails.rst
@@ -1,0 +1,11 @@
+CreateStackTemplateConfigSourceDetails
+======================================
+
+.. currentmodule:: oci.resource_manager.models
+
+.. autoclass:: CreateStackTemplateConfigSourceDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/resource_manager/models/oci.resource_manager.models.CreateTemplateConfigSourceDetails.rst
+++ b/docs/api/resource_manager/models/oci.resource_manager.models.CreateTemplateConfigSourceDetails.rst
@@ -1,0 +1,11 @@
+CreateTemplateConfigSourceDetails
+=================================
+
+.. currentmodule:: oci.resource_manager.models
+
+.. autoclass:: CreateTemplateConfigSourceDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/resource_manager/models/oci.resource_manager.models.CreateTemplateDetails.rst
+++ b/docs/api/resource_manager/models/oci.resource_manager.models.CreateTemplateDetails.rst
@@ -1,0 +1,11 @@
+CreateTemplateDetails
+=====================
+
+.. currentmodule:: oci.resource_manager.models
+
+.. autoclass:: CreateTemplateDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/resource_manager/models/oci.resource_manager.models.CreateTemplateZipUploadConfigSourceDetails.rst
+++ b/docs/api/resource_manager/models/oci.resource_manager.models.CreateTemplateZipUploadConfigSourceDetails.rst
@@ -1,0 +1,11 @@
+CreateTemplateZipUploadConfigSourceDetails
+==========================================
+
+.. currentmodule:: oci.resource_manager.models
+
+.. autoclass:: CreateTemplateZipUploadConfigSourceDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/resource_manager/models/oci.resource_manager.models.Template.rst
+++ b/docs/api/resource_manager/models/oci.resource_manager.models.Template.rst
@@ -1,0 +1,11 @@
+Template
+========
+
+.. currentmodule:: oci.resource_manager.models
+
+.. autoclass:: Template
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/resource_manager/models/oci.resource_manager.models.TemplateCategorySummary.rst
+++ b/docs/api/resource_manager/models/oci.resource_manager.models.TemplateCategorySummary.rst
@@ -1,0 +1,11 @@
+TemplateCategorySummary
+=======================
+
+.. currentmodule:: oci.resource_manager.models
+
+.. autoclass:: TemplateCategorySummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/resource_manager/models/oci.resource_manager.models.TemplateCategorySummaryCollection.rst
+++ b/docs/api/resource_manager/models/oci.resource_manager.models.TemplateCategorySummaryCollection.rst
@@ -1,0 +1,11 @@
+TemplateCategorySummaryCollection
+=================================
+
+.. currentmodule:: oci.resource_manager.models
+
+.. autoclass:: TemplateCategorySummaryCollection
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/resource_manager/models/oci.resource_manager.models.TemplateConfigSource.rst
+++ b/docs/api/resource_manager/models/oci.resource_manager.models.TemplateConfigSource.rst
@@ -1,0 +1,11 @@
+TemplateConfigSource
+====================
+
+.. currentmodule:: oci.resource_manager.models
+
+.. autoclass:: TemplateConfigSource
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/resource_manager/models/oci.resource_manager.models.TemplateSummary.rst
+++ b/docs/api/resource_manager/models/oci.resource_manager.models.TemplateSummary.rst
@@ -1,0 +1,11 @@
+TemplateSummary
+===============
+
+.. currentmodule:: oci.resource_manager.models
+
+.. autoclass:: TemplateSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/resource_manager/models/oci.resource_manager.models.TemplateSummaryCollection.rst
+++ b/docs/api/resource_manager/models/oci.resource_manager.models.TemplateSummaryCollection.rst
@@ -1,0 +1,11 @@
+TemplateSummaryCollection
+=========================
+
+.. currentmodule:: oci.resource_manager.models
+
+.. autoclass:: TemplateSummaryCollection
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/resource_manager/models/oci.resource_manager.models.TemplateZipUploadConfigSource.rst
+++ b/docs/api/resource_manager/models/oci.resource_manager.models.TemplateZipUploadConfigSource.rst
@@ -1,0 +1,11 @@
+TemplateZipUploadConfigSource
+=============================
+
+.. currentmodule:: oci.resource_manager.models
+
+.. autoclass:: TemplateZipUploadConfigSource
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/resource_manager/models/oci.resource_manager.models.UpdateTemplateConfigSourceDetails.rst
+++ b/docs/api/resource_manager/models/oci.resource_manager.models.UpdateTemplateConfigSourceDetails.rst
@@ -1,0 +1,11 @@
+UpdateTemplateConfigSourceDetails
+=================================
+
+.. currentmodule:: oci.resource_manager.models
+
+.. autoclass:: UpdateTemplateConfigSourceDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/resource_manager/models/oci.resource_manager.models.UpdateTemplateDetails.rst
+++ b/docs/api/resource_manager/models/oci.resource_manager.models.UpdateTemplateDetails.rst
@@ -1,0 +1,11 @@
+UpdateTemplateDetails
+=====================
+
+.. currentmodule:: oci.resource_manager.models
+
+.. autoclass:: UpdateTemplateDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/resource_manager/models/oci.resource_manager.models.UpdateTemplateZipUploadConfigSourceDetails.rst
+++ b/docs/api/resource_manager/models/oci.resource_manager.models.UpdateTemplateZipUploadConfigSourceDetails.rst
@@ -1,0 +1,11 @@
+UpdateTemplateZipUploadConfigSourceDetails
+==========================================
+
+.. currentmodule:: oci.resource_manager.models
+
+.. autoclass:: UpdateTemplateZipUploadConfigSourceDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/src/oci/core/blockstorage_client.py
+++ b/src/oci/core/blockstorage_client.py
@@ -1407,7 +1407,7 @@ class BlockstorageClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -1482,7 +1482,7 @@ class BlockstorageClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -1557,7 +1557,7 @@ class BlockstorageClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -1637,7 +1637,7 @@ class BlockstorageClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -1712,7 +1712,7 @@ class BlockstorageClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -1797,7 +1797,7 @@ class BlockstorageClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -1874,7 +1874,7 @@ class BlockstorageClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -1952,7 +1952,7 @@ class BlockstorageClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -2019,7 +2019,8 @@ class BlockstorageClient(object):
 
     def delete_volume_group_backup(self, volume_group_backup_id, **kwargs):
         """
-        Deletes a volume group backup. This operation deletes all the backups in the volume group. For more information, see `Volume Groups`__.
+        Deletes a volume group backup. This operation deletes all the backups in
+        the volume group. For more information, see `Volume Groups`__.
 
         __ https://docs.cloud.oracle.com/Content/Block/Concepts/volumegroups.htm
 
@@ -2029,7 +2030,7 @@ class BlockstorageClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -2104,7 +2105,7 @@ class BlockstorageClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -2311,7 +2312,7 @@ class BlockstorageClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -2874,7 +2875,7 @@ class BlockstorageClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -2995,7 +2996,8 @@ class BlockstorageClient(object):
             Allowed values are: "ASC", "DESC"
 
         :param str lifecycle_state: (optional)
-            A filter to only return resources that match the given lifecycle state.  The state value is case-insensitive.
+            A filter to only return resources that match the given lifecycle state. The state value is
+            case-insensitive.
 
             Allowed values are: "CREATING", "AVAILABLE", "TERMINATING", "TERMINATED", "FAULTY", "REQUEST_RECEIVED"
 
@@ -3334,7 +3336,8 @@ class BlockstorageClient(object):
             Allowed values are: "ASC", "DESC"
 
         :param str lifecycle_state: (optional)
-            A filter to only return resources that match the given lifecycle state.  The state value is case-insensitive.
+            A filter to only return resources that match the given lifecycle state. The state
+            value is case-insensitive.
 
             Allowed values are: "CREATING", "AVAILABLE", "TERMINATING", "TERMINATED", "FAULTY", "REQUEST_RECEIVED"
 
@@ -3622,7 +3625,8 @@ class BlockstorageClient(object):
             Allowed values are: "ASC", "DESC"
 
         :param str lifecycle_state: (optional)
-            A filter to only return resources that match the given lifecycle state.  The state value is case-insensitive.
+            A filter to only return resources that match the given lifecycle
+            state. The state value is case-insensitive.
 
             Allowed values are: "PROVISIONING", "AVAILABLE", "TERMINATING", "TERMINATED", "FAULTY"
 
@@ -3773,7 +3777,8 @@ class BlockstorageClient(object):
             The OCID of the volume group.
 
         :param str lifecycle_state: (optional)
-            A filter to only return resources that match the given lifecycle state.  The state value is case-insensitive.
+            A filter to only return resources that match the given lifecycle state. The state
+            value is case-insensitive.
 
             Allowed values are: "PROVISIONING", "RESTORING", "AVAILABLE", "TERMINATING", "TERMINATED", "FAULTY"
 
@@ -3883,7 +3888,7 @@ class BlockstorageClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -3966,7 +3971,7 @@ class BlockstorageClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -4048,7 +4053,7 @@ class BlockstorageClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -4131,7 +4136,7 @@ class BlockstorageClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -4214,7 +4219,7 @@ class BlockstorageClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -4302,7 +4307,7 @@ class BlockstorageClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param str opc_request_id: (optional)
@@ -4408,7 +4413,7 @@ class BlockstorageClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -4492,7 +4497,7 @@ class BlockstorageClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -4574,7 +4579,7 @@ class BlockstorageClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)

--- a/src/oci/core/compute_client.py
+++ b/src/oci/core/compute_client.py
@@ -493,7 +493,7 @@ class ComputeClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param str opc_request_id: (optional)
@@ -590,7 +590,7 @@ class ComputeClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param str opc_request_id: (optional)
@@ -693,7 +693,7 @@ class ComputeClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param str opc_request_id: (optional)
@@ -797,7 +797,7 @@ class ComputeClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param str opc_request_id: (optional)
@@ -1209,7 +1209,7 @@ class ComputeClient(object):
         After the console connection has been created and is available,
         you connect to the console using SSH.
 
-        For more information about console access, see `Accessing the Console`__.
+        For more information about instance console connections, see `Troubleshooting Instances Using Instance Console Connections`__.
 
         __ https://docs.cloud.oracle.com/Content/Compute/References/serialconsole.htm
 
@@ -1359,7 +1359,7 @@ class ComputeClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -1434,7 +1434,7 @@ class ComputeClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -1588,7 +1588,7 @@ class ComputeClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -1663,7 +1663,7 @@ class ComputeClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -1741,7 +1741,7 @@ class ComputeClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -1827,7 +1827,7 @@ class ComputeClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -1905,7 +1905,7 @@ class ComputeClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -2006,7 +2006,7 @@ class ComputeClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -3294,12 +3294,14 @@ class ComputeClient(object):
         - **RESET** - Powers off the instance and then powers it back on.
 
         - **SOFTSTOP** - Gracefully shuts down the instance by sending a shutdown command to the operating system.
-        If the applications that run on the instance take a long time to shut down, they could be improperly stopped, resulting
-        in data corruption. To avoid this, shut down the instance using the commands available in the OS before you softstop the
+        After waiting 15 minutes for the OS to shut down, the instance is powered off.
+        If the applications that run on the instance take more than 15 minutes to shut down, they could be improperly stopped, resulting
+        in data corruption. To avoid this, manually shut down the instance using the commands available in the OS before you softstop the
         instance.
 
-        - **SOFTRESET** - Gracefully reboots the instance by sending a shutdown command to the operating system, and
-        then powers the instance back on.
+        - **SOFTRESET** - Gracefully reboots the instance by sending a shutdown command to the operating system.
+        After waiting 15 minutes for the OS to shut down, the instance is powered off and
+        then powered back on.
 
         - **SENDDIAGNOSTICINTERRUPT** - For advanced users. **Warning: Sending a diagnostic interrupt to a live system can
         cause data corruption or system failure.** Sends a diagnostic interrupt that causes the instance's
@@ -3307,6 +3309,7 @@ class ComputeClient(object):
         crash dump file when it crashes. The crash dump captures information about the state of the OS at the time of
         the crash. After the OS restarts, you can analyze the crash dump to diagnose the issue. For more information, see
         `Sending a Diagnostic Interrupt`__.
+
 
         For more information about managing instance lifecycle states, see
         `Stopping and Starting an Instance`__.
@@ -3332,7 +3335,7 @@ class ComputeClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -4424,7 +4427,8 @@ class ComputeClient(object):
             Allowed values are: "ASC", "DESC"
 
         :param str lifecycle_state: (optional)
-            A filter to only return resources that match the given lifecycle state.  The state value is case-insensitive.
+            A filter to only return resources that match the given lifecycle state. The state
+            value is case-insensitive.
 
             Allowed values are: "REQUESTED", "GETTING-HISTORY", "SUCCEEDED", "FAILED"
 
@@ -5218,7 +5222,8 @@ class ComputeClient(object):
             Allowed values are: "ASC", "DESC"
 
         :param str lifecycle_state: (optional)
-            A filter to only return resources that match the given lifecycle state.  The state value is case-insensitive.
+            A filter to only return resources that match the given lifecycle state. The state
+            value is case-insensitive.
 
             Allowed values are: "PROVISIONING", "IMPORTING", "AVAILABLE", "EXPORTING", "DISABLED", "DELETED"
 
@@ -5321,7 +5326,7 @@ class ComputeClient(object):
         """
         Lists the console connections for the specified compartment or instance.
 
-        For more information about console access, see `Accessing the Console`__.
+        For more information about instance console connections, see `Troubleshooting Instances Using Instance Console Connections`__.
 
         __ https://docs.cloud.oracle.com/Content/Compute/References/serialconsole.htm
 
@@ -5615,7 +5620,8 @@ class ComputeClient(object):
             Allowed values are: "ASC", "DESC"
 
         :param str lifecycle_state: (optional)
-            A filter to only return resources that match the given lifecycle state.  The state value is case-insensitive.
+            A filter to only return resources that match the given lifecycle state. The state
+            value is case-insensitive.
 
             Allowed values are: "MOVING", "PROVISIONING", "RUNNING", "STARTING", "STOPPING", "STOPPED", "CREATING_IMAGE", "TERMINATING", "TERMINATED"
 
@@ -6110,7 +6116,7 @@ class ComputeClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param bool preserve_boot_volume: (optional)
@@ -6200,7 +6206,7 @@ class ComputeClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -6282,7 +6288,7 @@ class ComputeClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -6365,7 +6371,7 @@ class ComputeClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param str opc_request_id: (optional)
@@ -6473,7 +6479,7 @@ class ComputeClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -6572,7 +6578,7 @@ class ComputeClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -6662,7 +6668,7 @@ class ComputeClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)

--- a/src/oci/core/compute_management_client.py
+++ b/src/oci/core/compute_management_client.py
@@ -113,7 +113,7 @@ class ComputeManagementClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -208,7 +208,7 @@ class ComputeManagementClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param str opc_request_id: (optional)
@@ -320,7 +320,7 @@ class ComputeManagementClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param str opc_request_id: (optional)
@@ -426,7 +426,7 @@ class ComputeManagementClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param str opc_request_id: (optional)
@@ -737,7 +737,7 @@ class ComputeManagementClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -824,7 +824,7 @@ class ComputeManagementClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -1863,7 +1863,8 @@ class ComputeManagementClient(object):
             Allowed values are: "ASC", "DESC"
 
         :param str lifecycle_state: (optional)
-            A filter to only return resources that match the given lifecycle state.  The state value is case-insensitive.
+            A filter to only return resources that match the given lifecycle state. The state
+            value is case-insensitive.
 
             Allowed values are: "PROVISIONING", "SCALING", "STARTING", "STOPPING", "TERMINATING", "STOPPED", "TERMINATED", "RUNNING"
 
@@ -1958,7 +1959,7 @@ class ComputeManagementClient(object):
 
     def reset_instance_pool(self, instance_pool_id, **kwargs):
         """
-        Performs the reset (power off and power on) action on the specified instance pool,
+        Performs the reset (immediate power off and power on) action on the specified instance pool,
         which performs the action on all the instances in the pool.
 
 
@@ -1976,7 +1977,7 @@ class ComputeManagementClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -2052,6 +2053,9 @@ class ComputeManagementClient(object):
         Performs the softreset (ACPI shutdown and power on) action on the specified instance pool,
         which performs the action on all the instances in the pool.
 
+        Softreset gracefully reboots the instances by sending a shutdown command to the operating systems.
+        After waiting 15 minutes for the OS to shut down, the instances are powered off and then powered back on.
+
 
         :param str instance_pool_id: (required)
             The `OCID`__ of the instance pool.
@@ -2067,7 +2071,7 @@ class ComputeManagementClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -2158,7 +2162,7 @@ class ComputeManagementClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -2231,7 +2235,7 @@ class ComputeManagementClient(object):
 
     def stop_instance_pool(self, instance_pool_id, **kwargs):
         """
-        Performs the stop (power off) action on the specified instance pool,
+        Performs the stop (immediate power off) action on the specified instance pool,
         which performs the action on all the instances in the pool.
 
 
@@ -2249,7 +2253,7 @@ class ComputeManagementClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -2335,7 +2339,7 @@ class ComputeManagementClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -2419,7 +2423,7 @@ class ComputeManagementClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -2506,7 +2510,7 @@ class ComputeManagementClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -2599,7 +2603,7 @@ class ComputeManagementClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -2696,7 +2700,7 @@ class ComputeManagementClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)

--- a/src/oci/core/models/__init__.py
+++ b/src/oci/core/models/__init__.py
@@ -114,6 +114,7 @@ from .create_drg_details import CreateDrgDetails
 from .create_ip_sec_connection_details import CreateIPSecConnectionDetails
 from .create_ip_sec_connection_tunnel_details import CreateIPSecConnectionTunnelDetails
 from .create_ip_sec_tunnel_bgp_session_details import CreateIPSecTunnelBgpSessionDetails
+from .create_ip_sec_tunnel_encryption_domain_details import CreateIPSecTunnelEncryptionDomainDetails
 from .create_image_details import CreateImageDetails
 from .create_instance_configuration_base import CreateInstanceConfigurationBase
 from .create_instance_configuration_details import CreateInstanceConfigurationDetails
@@ -168,6 +169,7 @@ from .drg_attachment import DrgAttachment
 from .drg_redundancy_status import DrgRedundancyStatus
 from .egress_security_rule import EgressSecurityRule
 from .emulated_volume_attachment import EmulatedVolumeAttachment
+from .encryption_domain_config import EncryptionDomainConfig
 from .enum_integer_image_capability_descriptor import EnumIntegerImageCapabilityDescriptor
 from .enum_string_image_capability_schema_descriptor import EnumStringImageCapabilitySchemaDescriptor
 from .export_image_details import ExportImageDetails
@@ -296,6 +298,7 @@ from .update_ip_sec_connection_details import UpdateIPSecConnectionDetails
 from .update_ip_sec_connection_tunnel_details import UpdateIPSecConnectionTunnelDetails
 from .update_ip_sec_connection_tunnel_shared_secret_details import UpdateIPSecConnectionTunnelSharedSecretDetails
 from .update_ip_sec_tunnel_bgp_session_details import UpdateIPSecTunnelBgpSessionDetails
+from .update_ip_sec_tunnel_encryption_domain_details import UpdateIPSecTunnelEncryptionDomainDetails
 from .update_image_details import UpdateImageDetails
 from .update_instance_agent_config_details import UpdateInstanceAgentConfigDetails
 from .update_instance_availability_config_details import UpdateInstanceAvailabilityConfigDetails
@@ -470,6 +473,7 @@ core_type_mapping = {
     "CreateIPSecConnectionDetails": CreateIPSecConnectionDetails,
     "CreateIPSecConnectionTunnelDetails": CreateIPSecConnectionTunnelDetails,
     "CreateIPSecTunnelBgpSessionDetails": CreateIPSecTunnelBgpSessionDetails,
+    "CreateIPSecTunnelEncryptionDomainDetails": CreateIPSecTunnelEncryptionDomainDetails,
     "CreateImageDetails": CreateImageDetails,
     "CreateInstanceConfigurationBase": CreateInstanceConfigurationBase,
     "CreateInstanceConfigurationDetails": CreateInstanceConfigurationDetails,
@@ -524,6 +528,7 @@ core_type_mapping = {
     "DrgRedundancyStatus": DrgRedundancyStatus,
     "EgressSecurityRule": EgressSecurityRule,
     "EmulatedVolumeAttachment": EmulatedVolumeAttachment,
+    "EncryptionDomainConfig": EncryptionDomainConfig,
     "EnumIntegerImageCapabilityDescriptor": EnumIntegerImageCapabilityDescriptor,
     "EnumStringImageCapabilitySchemaDescriptor": EnumStringImageCapabilitySchemaDescriptor,
     "ExportImageDetails": ExportImageDetails,
@@ -652,6 +657,7 @@ core_type_mapping = {
     "UpdateIPSecConnectionTunnelDetails": UpdateIPSecConnectionTunnelDetails,
     "UpdateIPSecConnectionTunnelSharedSecretDetails": UpdateIPSecConnectionTunnelSharedSecretDetails,
     "UpdateIPSecTunnelBgpSessionDetails": UpdateIPSecTunnelBgpSessionDetails,
+    "UpdateIPSecTunnelEncryptionDomainDetails": UpdateIPSecTunnelEncryptionDomainDetails,
     "UpdateImageDetails": UpdateImageDetails,
     "UpdateInstanceAgentConfigDetails": UpdateInstanceAgentConfigDetails,
     "UpdateInstanceAvailabilityConfigDetails": UpdateInstanceAvailabilityConfigDetails,

--- a/src/oci/core/models/add_security_rule_details.py
+++ b/src/oci/core/models/add_security_rule_details.py
@@ -278,7 +278,8 @@ class AddSecurityRuleDetails(object):
     def direction(self):
         """
         **[Required]** Gets the direction of this AddSecurityRuleDetails.
-        Direction of the security rule. Set to `EGRESS` for rules to allow outbound IP packets, or `INGRESS` for rules to allow inbound IP packets.
+        Direction of the security rule. Set to `EGRESS` for rules to allow outbound IP packets,
+        or `INGRESS` for rules to allow inbound IP packets.
 
         Allowed values for this property are: "EGRESS", "INGRESS"
 
@@ -292,7 +293,8 @@ class AddSecurityRuleDetails(object):
     def direction(self, direction):
         """
         Sets the direction of this AddSecurityRuleDetails.
-        Direction of the security rule. Set to `EGRESS` for rules to allow outbound IP packets, or `INGRESS` for rules to allow inbound IP packets.
+        Direction of the security rule. Set to `EGRESS` for rules to allow outbound IP packets,
+        or `INGRESS` for rules to allow inbound IP packets.
 
 
         :param direction: The direction of this AddSecurityRuleDetails.

--- a/src/oci/core/models/attach_load_balancer_details.py
+++ b/src/oci/core/models/attach_load_balancer_details.py
@@ -134,7 +134,9 @@ class AttachLoadBalancerDetails(object):
     def vnic_selection(self):
         """
         **[Required]** Gets the vnic_selection of this AttachLoadBalancerDetails.
-        Indicates which VNIC on each instance in the pool should be used to associate with the load balancer. Possible values are \"PrimaryVnic\" or the displayName of one of the secondary VNICs on the instance configuration that is associated with the instance pool.
+        Indicates which VNIC on each instance in the pool should be used to associate with the load balancer.
+        Possible values are \"PrimaryVnic\" or the displayName of one of the secondary VNICs on the instance configuration
+        that is associated with the instance pool.
 
 
         :return: The vnic_selection of this AttachLoadBalancerDetails.
@@ -146,7 +148,9 @@ class AttachLoadBalancerDetails(object):
     def vnic_selection(self, vnic_selection):
         """
         Sets the vnic_selection of this AttachLoadBalancerDetails.
-        Indicates which VNIC on each instance in the pool should be used to associate with the load balancer. Possible values are \"PrimaryVnic\" or the displayName of one of the secondary VNICs on the instance configuration that is associated with the instance pool.
+        Indicates which VNIC on each instance in the pool should be used to associate with the load balancer.
+        Possible values are \"PrimaryVnic\" or the displayName of one of the secondary VNICs on the instance configuration
+        that is associated with the instance pool.
 
 
         :param vnic_selection: The vnic_selection of this AttachLoadBalancerDetails.

--- a/src/oci/core/models/boot_volume.py
+++ b/src/oci/core/models/boot_volume.py
@@ -420,7 +420,8 @@ class BootVolume(object):
     def is_hydrated(self):
         """
         Gets the is_hydrated of this BootVolume.
-        Specifies whether the boot volume's data has finished copying from the source boot volume or boot volume backup.
+        Specifies whether the boot volume's data has finished copying
+        from the source boot volume or boot volume backup.
 
 
         :return: The is_hydrated of this BootVolume.
@@ -432,7 +433,8 @@ class BootVolume(object):
     def is_hydrated(self, is_hydrated):
         """
         Sets the is_hydrated of this BootVolume.
-        Specifies whether the boot volume's data has finished copying from the source boot volume or boot volume backup.
+        Specifies whether the boot volume's data has finished copying
+        from the source boot volume or boot volume backup.
 
 
         :param is_hydrated: The is_hydrated of this BootVolume.

--- a/src/oci/core/models/cpe.py
+++ b/src/oci/core/models/cpe.py
@@ -20,9 +20,6 @@ class Cpe(object):
     talk to an administrator. If you're an administrator who needs to write policies to give users access, see
     `Getting Started with Policies`__.
 
-    **Warning:** Oracle recommends that you avoid using any confidential information when you
-    supply string values using the API.
-
     __ https://docs.cloud.oracle.com/Content/Network/Concepts/overview.htm
     __ https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm
     """

--- a/src/oci/core/models/cpe_device_config_question.py
+++ b/src/oci/core/models/cpe_device_config_question.py
@@ -79,6 +79,7 @@ class CpeDeviceConfigQuestion(object):
         """
         Gets the display_name of this CpeDeviceConfigQuestion.
         A descriptive label for the question (for example, to display in a form in a graphical interface).
+        Avoid entering confidential information.
 
 
         :return: The display_name of this CpeDeviceConfigQuestion.
@@ -91,6 +92,7 @@ class CpeDeviceConfigQuestion(object):
         """
         Sets the display_name of this CpeDeviceConfigQuestion.
         A descriptive label for the question (for example, to display in a form in a graphical interface).
+        Avoid entering confidential information.
 
 
         :param display_name: The display_name of this CpeDeviceConfigQuestion.

--- a/src/oci/core/models/create_cluster_network_instance_pool_details.py
+++ b/src/oci/core/models/create_cluster_network_instance_pool_details.py
@@ -189,12 +189,6 @@ class CreateClusterNetworkInstancePoolDetails(object):
         **[Required]** Gets the size of this CreateClusterNetworkInstancePoolDetails.
         The number of instances that should be in the instance pool.
 
-        For cluster networks with 10 or more instances, the cluster network is created if the required
-        number of instances is available and at least 95% of the instances in the pool launch
-        successfully. For cluster networks with less than 10 instances, all instances in the pool must
-        launch successfully. If the cluster network fails to launch, wait a few minutes, and then try
-        creating it again.
-
 
         :return: The size of this CreateClusterNetworkInstancePoolDetails.
         :rtype: int
@@ -206,12 +200,6 @@ class CreateClusterNetworkInstancePoolDetails(object):
         """
         Sets the size of this CreateClusterNetworkInstancePoolDetails.
         The number of instances that should be in the instance pool.
-
-        For cluster networks with 10 or more instances, the cluster network is created if the required
-        number of instances is available and at least 95% of the instances in the pool launch
-        successfully. For cluster networks with less than 10 instances, all instances in the pool must
-        launch successfully. If the cluster network fails to launch, wait a few minutes, and then try
-        creating it again.
 
 
         :param size: The size of this CreateClusterNetworkInstancePoolDetails.

--- a/src/oci/core/models/create_cpe_details.py
+++ b/src/oci/core/models/create_cpe_details.py
@@ -130,7 +130,8 @@ class CreateCpeDetails(object):
     def display_name(self):
         """
         Gets the display_name of this CreateCpeDetails.
-        A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
+        A user-friendly name. Does not have to be unique, and it's changeable.
+        Avoid entering confidential information.
 
 
         :return: The display_name of this CreateCpeDetails.
@@ -142,7 +143,8 @@ class CreateCpeDetails(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this CreateCpeDetails.
-        A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
+        A user-friendly name. Does not have to be unique, and it's changeable.
+        Avoid entering confidential information.
 
 
         :param display_name: The display_name of this CreateCpeDetails.

--- a/src/oci/core/models/create_dhcp_details.py
+++ b/src/oci/core/models/create_dhcp_details.py
@@ -130,7 +130,8 @@ class CreateDhcpDetails(object):
     def display_name(self):
         """
         Gets the display_name of this CreateDhcpDetails.
-        A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
+        A user-friendly name. Does not have to be unique, and it's changeable.
+        Avoid entering confidential information.
 
 
         :return: The display_name of this CreateDhcpDetails.
@@ -142,7 +143,8 @@ class CreateDhcpDetails(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this CreateDhcpDetails.
-        A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
+        A user-friendly name. Does not have to be unique, and it's changeable.
+        Avoid entering confidential information.
 
 
         :param display_name: The display_name of this CreateDhcpDetails.

--- a/src/oci/core/models/create_drg_attachment_details.py
+++ b/src/oci/core/models/create_drg_attachment_details.py
@@ -58,7 +58,8 @@ class CreateDrgAttachmentDetails(object):
     def display_name(self):
         """
         Gets the display_name of this CreateDrgAttachmentDetails.
-        A user-friendly name. Does not have to be unique. Avoid entering confidential information.
+        A user-friendly name. Does not have to be unique. Avoid entering
+        confidential information.
 
 
         :return: The display_name of this CreateDrgAttachmentDetails.
@@ -70,7 +71,8 @@ class CreateDrgAttachmentDetails(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this CreateDrgAttachmentDetails.
-        A user-friendly name. Does not have to be unique. Avoid entering confidential information.
+        A user-friendly name. Does not have to be unique. Avoid entering
+        confidential information.
 
 
         :param display_name: The display_name of this CreateDrgAttachmentDetails.

--- a/src/oci/core/models/create_drg_details.py
+++ b/src/oci/core/models/create_drg_details.py
@@ -116,7 +116,8 @@ class CreateDrgDetails(object):
     def display_name(self):
         """
         Gets the display_name of this CreateDrgDetails.
-        A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
+        A user-friendly name. Does not have to be unique, and it's changeable.
+        Avoid entering confidential information.
 
 
         :return: The display_name of this CreateDrgDetails.
@@ -128,7 +129,8 @@ class CreateDrgDetails(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this CreateDrgDetails.
-        A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
+        A user-friendly name. Does not have to be unique, and it's changeable.
+        Avoid entering confidential information.
 
 
         :param display_name: The display_name of this CreateDrgDetails.

--- a/src/oci/core/models/create_instance_configuration_base.py
+++ b/src/oci/core/models/create_instance_configuration_base.py
@@ -159,7 +159,7 @@ class CreateInstanceConfigurationBase(object):
     def display_name(self):
         """
         Gets the display_name of this CreateInstanceConfigurationBase.
-        A user-friendly name for the instance configuration.  Does not have to be unique,
+        A user-friendly name for the instance configuration. Does not have to be unique,
         and it's changeable. Avoid entering confidential information.
 
 
@@ -172,7 +172,7 @@ class CreateInstanceConfigurationBase(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this CreateInstanceConfigurationBase.
-        A user-friendly name for the instance configuration.  Does not have to be unique,
+        A user-friendly name for the instance configuration. Does not have to be unique,
         and it's changeable. Avoid entering confidential information.
 
 

--- a/src/oci/core/models/create_internet_gateway_details.py
+++ b/src/oci/core/models/create_internet_gateway_details.py
@@ -130,7 +130,8 @@ class CreateInternetGatewayDetails(object):
     def display_name(self):
         """
         Gets the display_name of this CreateInternetGatewayDetails.
-        A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
+        A user-friendly name. Does not have to be unique, and it's changeable.
+        Avoid entering confidential information.
 
 
         :return: The display_name of this CreateInternetGatewayDetails.
@@ -142,7 +143,8 @@ class CreateInternetGatewayDetails(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this CreateInternetGatewayDetails.
-        A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
+        A user-friendly name. Does not have to be unique, and it's changeable.
+        Avoid entering confidential information.
 
 
         :param display_name: The display_name of this CreateInternetGatewayDetails.

--- a/src/oci/core/models/create_ip_sec_connection_details.py
+++ b/src/oci/core/models/create_ip_sec_connection_details.py
@@ -191,7 +191,8 @@ class CreateIPSecConnectionDetails(object):
     def display_name(self):
         """
         Gets the display_name of this CreateIPSecConnectionDetails.
-        A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
+        A user-friendly name. Does not have to be unique, and it's changeable.
+        Avoid entering confidential information.
 
 
         :return: The display_name of this CreateIPSecConnectionDetails.
@@ -203,7 +204,8 @@ class CreateIPSecConnectionDetails(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this CreateIPSecConnectionDetails.
-        A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
+        A user-friendly name. Does not have to be unique, and it's changeable.
+        Avoid entering confidential information.
 
 
         :param display_name: The display_name of this CreateIPSecConnectionDetails.

--- a/src/oci/core/models/create_ip_sec_connection_tunnel_details.py
+++ b/src/oci/core/models/create_ip_sec_connection_tunnel_details.py
@@ -21,6 +21,10 @@ class CreateIPSecConnectionTunnelDetails(object):
     #: This constant has a value of "STATIC"
     ROUTING_STATIC = "STATIC"
 
+    #: A constant which can be used with the routing property of a CreateIPSecConnectionTunnelDetails.
+    #: This constant has a value of "POLICY"
+    ROUTING_POLICY = "POLICY"
+
     #: A constant which can be used with the ike_version property of a CreateIPSecConnectionTunnelDetails.
     #: This constant has a value of "V1"
     IKE_VERSION_V1 = "V1"
@@ -40,7 +44,7 @@ class CreateIPSecConnectionTunnelDetails(object):
 
         :param routing:
             The value to assign to the routing property of this CreateIPSecConnectionTunnelDetails.
-            Allowed values for this property are: "BGP", "STATIC"
+            Allowed values for this property are: "BGP", "STATIC", "POLICY"
         :type routing: str
 
         :param ike_version:
@@ -56,13 +60,18 @@ class CreateIPSecConnectionTunnelDetails(object):
             The value to assign to the bgp_session_config property of this CreateIPSecConnectionTunnelDetails.
         :type bgp_session_config: oci.core.models.CreateIPSecTunnelBgpSessionDetails
 
+        :param encryption_domain_config:
+            The value to assign to the encryption_domain_config property of this CreateIPSecConnectionTunnelDetails.
+        :type encryption_domain_config: oci.core.models.CreateIPSecTunnelEncryptionDomainDetails
+
         """
         self.swagger_types = {
             'display_name': 'str',
             'routing': 'str',
             'ike_version': 'str',
             'shared_secret': 'str',
-            'bgp_session_config': 'CreateIPSecTunnelBgpSessionDetails'
+            'bgp_session_config': 'CreateIPSecTunnelBgpSessionDetails',
+            'encryption_domain_config': 'CreateIPSecTunnelEncryptionDomainDetails'
         }
 
         self.attribute_map = {
@@ -70,7 +79,8 @@ class CreateIPSecConnectionTunnelDetails(object):
             'routing': 'routing',
             'ike_version': 'ikeVersion',
             'shared_secret': 'sharedSecret',
-            'bgp_session_config': 'bgpSessionConfig'
+            'bgp_session_config': 'bgpSessionConfig',
+            'encryption_domain_config': 'encryptionDomainConfig'
         }
 
         self._display_name = None
@@ -78,6 +88,7 @@ class CreateIPSecConnectionTunnelDetails(object):
         self._ike_version = None
         self._shared_secret = None
         self._bgp_session_config = None
+        self._encryption_domain_config = None
 
     @property
     def display_name(self):
@@ -111,7 +122,7 @@ class CreateIPSecConnectionTunnelDetails(object):
         Gets the routing of this CreateIPSecConnectionTunnelDetails.
         The type of routing to use for this tunnel (either BGP dynamic routing or static routing).
 
-        Allowed values for this property are: "BGP", "STATIC"
+        Allowed values for this property are: "BGP", "STATIC", "POLICY"
 
 
         :return: The routing of this CreateIPSecConnectionTunnelDetails.
@@ -129,7 +140,7 @@ class CreateIPSecConnectionTunnelDetails(object):
         :param routing: The routing of this CreateIPSecConnectionTunnelDetails.
         :type: str
         """
-        allowed_values = ["BGP", "STATIC"]
+        allowed_values = ["BGP", "STATIC", "POLICY"]
         if not value_allowed_none_or_none_sentinel(routing, allowed_values):
             raise ValueError(
                 "Invalid value for `routing`, must be None or one of {0}"
@@ -218,6 +229,26 @@ class CreateIPSecConnectionTunnelDetails(object):
         :type: oci.core.models.CreateIPSecTunnelBgpSessionDetails
         """
         self._bgp_session_config = bgp_session_config
+
+    @property
+    def encryption_domain_config(self):
+        """
+        Gets the encryption_domain_config of this CreateIPSecConnectionTunnelDetails.
+
+        :return: The encryption_domain_config of this CreateIPSecConnectionTunnelDetails.
+        :rtype: oci.core.models.CreateIPSecTunnelEncryptionDomainDetails
+        """
+        return self._encryption_domain_config
+
+    @encryption_domain_config.setter
+    def encryption_domain_config(self, encryption_domain_config):
+        """
+        Sets the encryption_domain_config of this CreateIPSecConnectionTunnelDetails.
+
+        :param encryption_domain_config: The encryption_domain_config of this CreateIPSecConnectionTunnelDetails.
+        :type: oci.core.models.CreateIPSecTunnelEncryptionDomainDetails
+        """
+        self._encryption_domain_config = encryption_domain_config
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/core/models/create_ip_sec_tunnel_encryption_domain_details.py
+++ b/src/oci/core/models/create_ip_sec_tunnel_encryption_domain_details.py
@@ -1,0 +1,102 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateIPSecTunnelEncryptionDomainDetails(object):
+    """
+    Request to enable a multi-encryption domain policy on the VPNaaS tunnel.
+    The cross product of oracleTrafficSelector and cpeTrafficSelector can't be more than 50.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateIPSecTunnelEncryptionDomainDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param oracle_traffic_selector:
+            The value to assign to the oracle_traffic_selector property of this CreateIPSecTunnelEncryptionDomainDetails.
+        :type oracle_traffic_selector: list[str]
+
+        :param cpe_traffic_selector:
+            The value to assign to the cpe_traffic_selector property of this CreateIPSecTunnelEncryptionDomainDetails.
+        :type cpe_traffic_selector: list[str]
+
+        """
+        self.swagger_types = {
+            'oracle_traffic_selector': 'list[str]',
+            'cpe_traffic_selector': 'list[str]'
+        }
+
+        self.attribute_map = {
+            'oracle_traffic_selector': 'oracleTrafficSelector',
+            'cpe_traffic_selector': 'cpeTrafficSelector'
+        }
+
+        self._oracle_traffic_selector = None
+        self._cpe_traffic_selector = None
+
+    @property
+    def oracle_traffic_selector(self):
+        """
+        Gets the oracle_traffic_selector of this CreateIPSecTunnelEncryptionDomainDetails.
+        Lists IPv4 or IPv6-enabled subnets in your Oracle tenancy.
+
+
+        :return: The oracle_traffic_selector of this CreateIPSecTunnelEncryptionDomainDetails.
+        :rtype: list[str]
+        """
+        return self._oracle_traffic_selector
+
+    @oracle_traffic_selector.setter
+    def oracle_traffic_selector(self, oracle_traffic_selector):
+        """
+        Sets the oracle_traffic_selector of this CreateIPSecTunnelEncryptionDomainDetails.
+        Lists IPv4 or IPv6-enabled subnets in your Oracle tenancy.
+
+
+        :param oracle_traffic_selector: The oracle_traffic_selector of this CreateIPSecTunnelEncryptionDomainDetails.
+        :type: list[str]
+        """
+        self._oracle_traffic_selector = oracle_traffic_selector
+
+    @property
+    def cpe_traffic_selector(self):
+        """
+        Gets the cpe_traffic_selector of this CreateIPSecTunnelEncryptionDomainDetails.
+        Lists IPv4 or IPv6-enabled subnets in your on-premises network.
+
+
+        :return: The cpe_traffic_selector of this CreateIPSecTunnelEncryptionDomainDetails.
+        :rtype: list[str]
+        """
+        return self._cpe_traffic_selector
+
+    @cpe_traffic_selector.setter
+    def cpe_traffic_selector(self, cpe_traffic_selector):
+        """
+        Sets the cpe_traffic_selector of this CreateIPSecTunnelEncryptionDomainDetails.
+        Lists IPv4 or IPv6-enabled subnets in your on-premises network.
+
+
+        :param cpe_traffic_selector: The cpe_traffic_selector of this CreateIPSecTunnelEncryptionDomainDetails.
+        :type: list[str]
+        """
+        self._cpe_traffic_selector = cpe_traffic_selector
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/create_ipv6_details.py
+++ b/src/oci/core/models/create_ipv6_details.py
@@ -237,7 +237,7 @@ class CreateIpv6Details(object):
     @property
     def vnic_id(self):
         """
-        **[Required]** Gets the vnic_id of this CreateIpv6Details.
+        Gets the vnic_id of this CreateIpv6Details.
         The `OCID`__ of the VNIC to assign the IPv6 to. The
         IPv6 will be in the VNIC's subnet.
 

--- a/src/oci/core/models/create_route_table_details.py
+++ b/src/oci/core/models/create_route_table_details.py
@@ -130,7 +130,8 @@ class CreateRouteTableDetails(object):
     def display_name(self):
         """
         Gets the display_name of this CreateRouteTableDetails.
-        A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
+        A user-friendly name. Does not have to be unique, and it's changeable.
+        Avoid entering confidential information.
 
 
         :return: The display_name of this CreateRouteTableDetails.
@@ -142,7 +143,8 @@ class CreateRouteTableDetails(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this CreateRouteTableDetails.
-        A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
+        A user-friendly name. Does not have to be unique, and it's changeable.
+        Avoid entering confidential information.
 
 
         :param display_name: The display_name of this CreateRouteTableDetails.

--- a/src/oci/core/models/create_security_list_details.py
+++ b/src/oci/core/models/create_security_list_details.py
@@ -137,7 +137,8 @@ class CreateSecurityListDetails(object):
     def display_name(self):
         """
         Gets the display_name of this CreateSecurityListDetails.
-        A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
+        A user-friendly name. Does not have to be unique, and it's changeable.
+        Avoid entering confidential information.
 
 
         :return: The display_name of this CreateSecurityListDetails.
@@ -149,7 +150,8 @@ class CreateSecurityListDetails(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this CreateSecurityListDetails.
-        A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
+        A user-friendly name. Does not have to be unique, and it's changeable.
+        Avoid entering confidential information.
 
 
         :param display_name: The display_name of this CreateSecurityListDetails.

--- a/src/oci/core/models/create_subnet_details.py
+++ b/src/oci/core/models/create_subnet_details.py
@@ -287,7 +287,8 @@ class CreateSubnetDetails(object):
     def display_name(self):
         """
         Gets the display_name of this CreateSubnetDetails.
-        A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
+        A user-friendly name. Does not have to be unique, and it's changeable.
+        Avoid entering confidential information.
 
 
         :return: The display_name of this CreateSubnetDetails.
@@ -299,7 +300,8 @@ class CreateSubnetDetails(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this CreateSubnetDetails.
-        A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
+        A user-friendly name. Does not have to be unique, and it's changeable.
+        Avoid entering confidential information.
 
 
         :param display_name: The display_name of this CreateSubnetDetails.

--- a/src/oci/core/models/create_vcn_details.py
+++ b/src/oci/core/models/create_vcn_details.py
@@ -279,7 +279,8 @@ class CreateVcnDetails(object):
     def display_name(self):
         """
         Gets the display_name of this CreateVcnDetails.
-        A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
+        A user-friendly name. Does not have to be unique, and it's changeable.
+        Avoid entering confidential information.
 
 
         :return: The display_name of this CreateVcnDetails.
@@ -291,7 +292,8 @@ class CreateVcnDetails(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this CreateVcnDetails.
-        A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
+        A user-friendly name. Does not have to be unique, and it's changeable.
+        Avoid entering confidential information.
 
 
         :param display_name: The display_name of this CreateVcnDetails.

--- a/src/oci/core/models/create_virtual_circuit_details.py
+++ b/src/oci/core/models/create_virtual_circuit_details.py
@@ -151,7 +151,7 @@ class CreateVirtualCircuitDetails(object):
     def bandwidth_shape_name(self):
         """
         Gets the bandwidth_shape_name of this CreateVirtualCircuitDetails.
-        The provisioned data rate of the connection.  To get a list of the
+        The provisioned data rate of the connection. To get a list of the
         available bandwidth levels (that is, shapes), see
         :func:`list_fast_connect_provider_virtual_circuit_bandwidth_shapes`.
 
@@ -167,7 +167,7 @@ class CreateVirtualCircuitDetails(object):
     def bandwidth_shape_name(self, bandwidth_shape_name):
         """
         Sets the bandwidth_shape_name of this CreateVirtualCircuitDetails.
-        The provisioned data rate of the connection.  To get a list of the
+        The provisioned data rate of the connection. To get a list of the
         available bandwidth levels (that is, shapes), see
         :func:`list_fast_connect_provider_virtual_circuit_bandwidth_shapes`.
 

--- a/src/oci/core/models/create_vlan_details.py
+++ b/src/oci/core/models/create_vlan_details.py
@@ -222,7 +222,8 @@ class CreateVlanDetails(object):
     def display_name(self):
         """
         Gets the display_name of this CreateVlanDetails.
-        A descriptive name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
+        A descriptive name. Does not have to be unique, and it's changeable.
+        Avoid entering confidential information.
 
 
         :return: The display_name of this CreateVlanDetails.
@@ -234,7 +235,8 @@ class CreateVlanDetails(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this CreateVlanDetails.
-        A descriptive name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
+        A descriptive name. Does not have to be unique, and it's changeable.
+        Avoid entering confidential information.
 
 
         :param display_name: The display_name of this CreateVlanDetails.

--- a/src/oci/core/models/create_volume_group_backup_details.py
+++ b/src/oci/core/models/create_volume_group_backup_details.py
@@ -81,7 +81,9 @@ class CreateVolumeGroupBackupDetails(object):
     def compartment_id(self):
         """
         Gets the compartment_id of this CreateVolumeGroupBackupDetails.
-        The OCID of the compartment that will contain the volume group backup. This parameter is optional, by default backup will be created in the same compartment and source volume group.
+        The OCID of the compartment that will contain the volume group
+        backup. This parameter is optional, by default backup will be created in
+        the same compartment and source volume group.
 
 
         :return: The compartment_id of this CreateVolumeGroupBackupDetails.
@@ -93,7 +95,9 @@ class CreateVolumeGroupBackupDetails(object):
     def compartment_id(self, compartment_id):
         """
         Sets the compartment_id of this CreateVolumeGroupBackupDetails.
-        The OCID of the compartment that will contain the volume group backup. This parameter is optional, by default backup will be created in the same compartment and source volume group.
+        The OCID of the compartment that will contain the volume group
+        backup. This parameter is optional, by default backup will be created in
+        the same compartment and source volume group.
 
 
         :param compartment_id: The compartment_id of this CreateVolumeGroupBackupDetails.

--- a/src/oci/core/models/create_volume_group_details.py
+++ b/src/oci/core/models/create_volume_group_details.py
@@ -187,7 +187,8 @@ class CreateVolumeGroupDetails(object):
     def display_name(self):
         """
         Gets the display_name of this CreateVolumeGroupDetails.
-        A user-friendly name for the volume group. Does not have to be unique, and it's changeable. Avoid entering confidential information.
+        A user-friendly name for the volume group. Does not have to be
+        unique, and it's changeable. Avoid entering confidential information.
 
 
         :return: The display_name of this CreateVolumeGroupDetails.
@@ -199,7 +200,8 @@ class CreateVolumeGroupDetails(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this CreateVolumeGroupDetails.
-        A user-friendly name for the volume group. Does not have to be unique, and it's changeable. Avoid entering confidential information.
+        A user-friendly name for the volume group. Does not have to be
+        unique, and it's changeable. Avoid entering confidential information.
 
 
         :param display_name: The display_name of this CreateVolumeGroupDetails.

--- a/src/oci/core/models/cross_connect.py
+++ b/src/oci/core/models/cross_connect.py
@@ -27,9 +27,6 @@ class CrossConnect(object):
     talk to an administrator. If you're an administrator who needs to write policies to give users access, see
     `Getting Started with Policies`__.
 
-    **Warning:** Oracle recommends that you avoid using any confidential information when you
-    supply string values using the API.
-
     __ https://docs.cloud.oracle.com/Content/Network/Concepts/fastconnect.htm
     __ https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm
     """

--- a/src/oci/core/models/cross_connect_group.py
+++ b/src/oci/core/models/cross_connect_group.py
@@ -24,9 +24,6 @@ class CrossConnectGroup(object):
     talk to an administrator. If you're an administrator who needs to write policies to give users access, see
     `Getting Started with Policies`__.
 
-    **Warning:** Oracle recommends that you avoid using any confidential information when you
-    supply string values using the API.
-
     __ https://docs.cloud.oracle.com/Content/Network/Concepts/fastconnect.htm
     __ https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm
     """

--- a/src/oci/core/models/cross_connect_mapping.py
+++ b/src/oci/core/models/cross_connect_mapping.py
@@ -293,7 +293,7 @@ class CrossConnectMapping(object):
     def oracle_bgp_peering_ipv6(self):
         """
         Gets the oracle_bgp_peering_ipv6 of this CrossConnectMapping.
-        The IPv6 address for Oracle's end of the BGP session.  Only subnet masks from /64 up to /127 are allowed.
+        The IPv6 address for Oracle's end of the BGP session. Only subnet masks from /64 up to /127 are allowed.
         If the session goes from Oracle to a customer's edge router,
         the customer specifies this information. If the session goes from Oracle to
         a provider's edge router, the provider specifies this.
@@ -317,7 +317,7 @@ class CrossConnectMapping(object):
     def oracle_bgp_peering_ipv6(self, oracle_bgp_peering_ipv6):
         """
         Sets the oracle_bgp_peering_ipv6 of this CrossConnectMapping.
-        The IPv6 address for Oracle's end of the BGP session.  Only subnet masks from /64 up to /127 are allowed.
+        The IPv6 address for Oracle's end of the BGP session. Only subnet masks from /64 up to /127 are allowed.
         If the session goes from Oracle to a customer's edge router,
         the customer specifies this information. If the session goes from Oracle to
         a provider's edge router, the provider specifies this.

--- a/src/oci/core/models/dhcp_options.py
+++ b/src/oci/core/models/dhcp_options.py
@@ -26,9 +26,6 @@ class DhcpOptions(object):
     talk to an administrator. If you're an administrator who needs to write policies to give users access, see
     `Getting Started with Policies`__.
 
-    **Warning:** Oracle recommends that you avoid using any confidential information when you
-    supply string values using the API.
-
     __ https://docs.cloud.oracle.com/Content/Network/Concepts/dns.htm
     __ https://docs.cloud.oracle.com/Content/Network/Tasks/managingDHCP.htm
     __ https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm

--- a/src/oci/core/models/drg.py
+++ b/src/oci/core/models/drg.py
@@ -20,9 +20,6 @@ class Drg(object):
     talk to an administrator. If you're an administrator who needs to write policies to give users access, see
     `Getting Started with Policies`__.
 
-    **Warning:** Oracle recommends that you avoid using any confidential information when you
-    supply string values using the API.
-
     __ https://docs.cloud.oracle.com/Content/Network/Concepts/overview.htm
     __ https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm
     """

--- a/src/oci/core/models/drg_attachment.py
+++ b/src/oci/core/models/drg_attachment.py
@@ -13,9 +13,6 @@ class DrgAttachment(object):
     A link between a DRG and VCN. For more information, see
     `Overview of the Networking Service`__.
 
-    **Warning:** Oracle recommends that you avoid using any confidential information when you
-    supply string values using the API.
-
     __ https://docs.cloud.oracle.com/Content/Network/Concepts/overview.htm
     """
 

--- a/src/oci/core/models/encryption_domain_config.py
+++ b/src/oci/core/models/encryption_domain_config.py
@@ -1,0 +1,101 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class EncryptionDomainConfig(object):
+    """
+    Configuration information used by the encryption domain policy.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new EncryptionDomainConfig object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param oracle_traffic_selector:
+            The value to assign to the oracle_traffic_selector property of this EncryptionDomainConfig.
+        :type oracle_traffic_selector: list[str]
+
+        :param cpe_traffic_selector:
+            The value to assign to the cpe_traffic_selector property of this EncryptionDomainConfig.
+        :type cpe_traffic_selector: list[str]
+
+        """
+        self.swagger_types = {
+            'oracle_traffic_selector': 'list[str]',
+            'cpe_traffic_selector': 'list[str]'
+        }
+
+        self.attribute_map = {
+            'oracle_traffic_selector': 'oracleTrafficSelector',
+            'cpe_traffic_selector': 'cpeTrafficSelector'
+        }
+
+        self._oracle_traffic_selector = None
+        self._cpe_traffic_selector = None
+
+    @property
+    def oracle_traffic_selector(self):
+        """
+        Gets the oracle_traffic_selector of this EncryptionDomainConfig.
+        Lists IPv4 or IPv6-enabled subnets in your Oracle tenancy.
+
+
+        :return: The oracle_traffic_selector of this EncryptionDomainConfig.
+        :rtype: list[str]
+        """
+        return self._oracle_traffic_selector
+
+    @oracle_traffic_selector.setter
+    def oracle_traffic_selector(self, oracle_traffic_selector):
+        """
+        Sets the oracle_traffic_selector of this EncryptionDomainConfig.
+        Lists IPv4 or IPv6-enabled subnets in your Oracle tenancy.
+
+
+        :param oracle_traffic_selector: The oracle_traffic_selector of this EncryptionDomainConfig.
+        :type: list[str]
+        """
+        self._oracle_traffic_selector = oracle_traffic_selector
+
+    @property
+    def cpe_traffic_selector(self):
+        """
+        Gets the cpe_traffic_selector of this EncryptionDomainConfig.
+        Lists IPv4 or IPv6-enabled subnets in your on-premises network.
+
+
+        :return: The cpe_traffic_selector of this EncryptionDomainConfig.
+        :rtype: list[str]
+        """
+        return self._cpe_traffic_selector
+
+    @cpe_traffic_selector.setter
+    def cpe_traffic_selector(self, cpe_traffic_selector):
+        """
+        Sets the cpe_traffic_selector of this EncryptionDomainConfig.
+        Lists IPv4 or IPv6-enabled subnets in your on-premises network.
+
+
+        :param cpe_traffic_selector: The cpe_traffic_selector of this EncryptionDomainConfig.
+        :type: list[str]
+        """
+        self._cpe_traffic_selector = cpe_traffic_selector
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/export_image_via_object_storage_uri_details.py
+++ b/src/oci/core/models/export_image_via_object_storage_uri_details.py
@@ -46,8 +46,10 @@ class ExportImageViaObjectStorageUriDetails(ExportImageDetails):
     def destination_uri(self):
         """
         **[Required]** Gets the destination_uri of this ExportImageViaObjectStorageUriDetails.
-        The Object Storage URL to export the image to. See `Object Storage URLs`__
-        and `Using Pre-Authenticated Requests`__ for constructing URLs for image import/export.
+        The Object Storage URL to export the image to. See `Object
+        Storage URLs`__
+        and `Using Pre-Authenticated Requests`__
+        for constructing URLs for image import/export.
 
         __ https://docs.cloud.oracle.com/Content/Compute/Tasks/imageimportexport.htm#URLs
         __ https://docs.cloud.oracle.com/Content/Object/Tasks/usingpreauthenticatedrequests.htm
@@ -62,8 +64,10 @@ class ExportImageViaObjectStorageUriDetails(ExportImageDetails):
     def destination_uri(self, destination_uri):
         """
         Sets the destination_uri of this ExportImageViaObjectStorageUriDetails.
-        The Object Storage URL to export the image to. See `Object Storage URLs`__
-        and `Using Pre-Authenticated Requests`__ for constructing URLs for image import/export.
+        The Object Storage URL to export the image to. See `Object
+        Storage URLs`__
+        and `Using Pre-Authenticated Requests`__
+        for constructing URLs for image import/export.
 
         __ https://docs.cloud.oracle.com/Content/Compute/Tasks/imageimportexport.htm#URLs
         __ https://docs.cloud.oracle.com/Content/Object/Tasks/usingpreauthenticatedrequests.htm

--- a/src/oci/core/models/fast_connect_provider_service_key.py
+++ b/src/oci/core/models/fast_connect_provider_service_key.py
@@ -82,7 +82,7 @@ class FastConnectProviderServiceKey(object):
     def bandwidth_shape_name(self):
         """
         Gets the bandwidth_shape_name of this FastConnectProviderServiceKey.
-        The provisioned data rate of the connection.  To get a list of the
+        The provisioned data rate of the connection. To get a list of the
         available bandwidth levels (that is, shapes), see
         :func:`list_fast_connect_provider_virtual_circuit_bandwidth_shapes`.
 
@@ -98,7 +98,7 @@ class FastConnectProviderServiceKey(object):
     def bandwidth_shape_name(self, bandwidth_shape_name):
         """
         Sets the bandwidth_shape_name of this FastConnectProviderServiceKey.
-        The provisioned data rate of the connection.  To get a list of the
+        The provisioned data rate of the connection. To get a list of the
         available bandwidth levels (that is, shapes), see
         :func:`list_fast_connect_provider_virtual_circuit_bandwidth_shapes`.
 

--- a/src/oci/core/models/i_scsi_volume_attachment.py
+++ b/src/oci/core/models/i_scsi_volume_attachment.py
@@ -159,7 +159,8 @@ class IScsiVolumeAttachment(VolumeAttachment):
     def chap_secret(self):
         """
         Gets the chap_secret of this IScsiVolumeAttachment.
-        The Challenge-Handshake-Authentication-Protocol (CHAP) secret valid for the associated CHAP user name.
+        The Challenge-Handshake-Authentication-Protocol (CHAP) secret
+        valid for the associated CHAP user name.
         (Also called the \"CHAP password\".)
 
 
@@ -172,7 +173,8 @@ class IScsiVolumeAttachment(VolumeAttachment):
     def chap_secret(self, chap_secret):
         """
         Sets the chap_secret of this IScsiVolumeAttachment.
-        The Challenge-Handshake-Authentication-Protocol (CHAP) secret valid for the associated CHAP user name.
+        The Challenge-Handshake-Authentication-Protocol (CHAP) secret
+        valid for the associated CHAP user name.
         (Also called the \"CHAP password\".)
 
 
@@ -185,7 +187,8 @@ class IScsiVolumeAttachment(VolumeAttachment):
     def chap_username(self):
         """
         Gets the chap_username of this IScsiVolumeAttachment.
-        The volume's system-generated Challenge-Handshake-Authentication-Protocol (CHAP) user name. See `RFC 1994`__ for more on CHAP.
+        The volume's system-generated Challenge-Handshake-Authentication-Protocol
+        (CHAP) user name. See `RFC 1994`__ for more on CHAP.
 
         Example: `ocid1.volume.oc1.phx.<unique_ID>`
 
@@ -201,7 +204,8 @@ class IScsiVolumeAttachment(VolumeAttachment):
     def chap_username(self, chap_username):
         """
         Sets the chap_username of this IScsiVolumeAttachment.
-        The volume's system-generated Challenge-Handshake-Authentication-Protocol (CHAP) user name. See `RFC 1994`__ for more on CHAP.
+        The volume's system-generated Challenge-Handshake-Authentication-Protocol
+        (CHAP) user name. See `RFC 1994`__ for more on CHAP.
 
         Example: `ocid1.volume.oc1.phx.<unique_ID>`
 
@@ -245,7 +249,8 @@ class IScsiVolumeAttachment(VolumeAttachment):
     def iqn(self):
         """
         **[Required]** Gets the iqn of this IScsiVolumeAttachment.
-        The target volume's iSCSI Qualified Name in the format defined by `RFC 3720`__.
+        The target volume's iSCSI Qualified Name in the format defined
+        by `RFC 3720`__.
 
         Example: `iqn.2015-12.us.oracle.com:<CHAP_username>`
 
@@ -261,7 +266,8 @@ class IScsiVolumeAttachment(VolumeAttachment):
     def iqn(self, iqn):
         """
         Sets the iqn of this IScsiVolumeAttachment.
-        The target volume's iSCSI Qualified Name in the format defined by `RFC 3720`__.
+        The target volume's iSCSI Qualified Name in the format defined
+        by `RFC 3720`__.
 
         Example: `iqn.2015-12.us.oracle.com:<CHAP_username>`
 

--- a/src/oci/core/models/image_source_details.py
+++ b/src/oci/core/models/image_source_details.py
@@ -128,7 +128,7 @@ class ImageSourceDetails(object):
     def source_image_type(self):
         """
         Gets the source_image_type of this ImageSourceDetails.
-        The format of the image to be imported.  Only monolithic
+        The format of the image to be imported. Only monolithic
         images are supported. This attribute is not used for exported Oracle images with the OCI image format.
 
         Allowed values for this property are: "QCOW2", "VMDK"
@@ -143,7 +143,7 @@ class ImageSourceDetails(object):
     def source_image_type(self, source_image_type):
         """
         Sets the source_image_type of this ImageSourceDetails.
-        The format of the image to be imported.  Only monolithic
+        The format of the image to be imported. Only monolithic
         images are supported. This attribute is not used for exported Oracle images with the OCI image format.
 
 

--- a/src/oci/core/models/instance_agent_config.py
+++ b/src/oci/core/models/instance_agent_config.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class InstanceAgentConfig(object):
     """
-    Instance agent configuration on the instance
+    Configuration options for the Oracle Cloud Agent software running on the instance.
     """
 
     def __init__(self, **kwargs):
@@ -44,7 +44,8 @@ class InstanceAgentConfig(object):
     def is_monitoring_disabled(self):
         """
         Gets the is_monitoring_disabled of this InstanceAgentConfig.
-        Whether the agent running on the instance can gather performance metrics and monitor the instance.
+        Whether Oracle Cloud Agent can gather performance metrics and monitor the instance using the
+        monitoring plugins.
 
 
         :return: The is_monitoring_disabled of this InstanceAgentConfig.
@@ -56,7 +57,8 @@ class InstanceAgentConfig(object):
     def is_monitoring_disabled(self, is_monitoring_disabled):
         """
         Sets the is_monitoring_disabled of this InstanceAgentConfig.
-        Whether the agent running on the instance can gather performance metrics and monitor the instance.
+        Whether Oracle Cloud Agent can gather performance metrics and monitor the instance using the
+        monitoring plugins.
 
 
         :param is_monitoring_disabled: The is_monitoring_disabled of this InstanceAgentConfig.
@@ -68,7 +70,7 @@ class InstanceAgentConfig(object):
     def is_management_disabled(self):
         """
         Gets the is_management_disabled of this InstanceAgentConfig.
-        Whether the agent running on the instance can run all the available management plugins.
+        Whether Oracle Cloud Agent can run all the available management plugins.
 
 
         :return: The is_management_disabled of this InstanceAgentConfig.
@@ -80,7 +82,7 @@ class InstanceAgentConfig(object):
     def is_management_disabled(self, is_management_disabled):
         """
         Sets the is_management_disabled of this InstanceAgentConfig.
-        Whether the agent running on the instance can run all the available management plugins.
+        Whether Oracle Cloud Agent can run all the available management plugins.
 
 
         :param is_management_disabled: The is_management_disabled of this InstanceAgentConfig.

--- a/src/oci/core/models/instance_agent_features.py
+++ b/src/oci/core/models/instance_agent_features.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class InstanceAgentFeatures(object):
     """
-    Instance agent features supported on the image
+    Oracle Cloud Agent features supported on the image.
     """
 
     def __init__(self, **kwargs):
@@ -44,7 +44,7 @@ class InstanceAgentFeatures(object):
     def is_monitoring_supported(self):
         """
         Gets the is_monitoring_supported of this InstanceAgentFeatures.
-        Whether the agent running on the instance can gather performance metrics and monitor the instance.
+        Whether Oracle Cloud Agent can gather performance metrics and monitor the instance.
 
 
         :return: The is_monitoring_supported of this InstanceAgentFeatures.
@@ -56,7 +56,7 @@ class InstanceAgentFeatures(object):
     def is_monitoring_supported(self, is_monitoring_supported):
         """
         Sets the is_monitoring_supported of this InstanceAgentFeatures.
-        Whether the agent running on the instance can gather performance metrics and monitor the instance.
+        Whether Oracle Cloud Agent can gather performance metrics and monitor the instance.
 
 
         :param is_monitoring_supported: The is_monitoring_supported of this InstanceAgentFeatures.
@@ -68,7 +68,7 @@ class InstanceAgentFeatures(object):
     def is_management_supported(self):
         """
         Gets the is_management_supported of this InstanceAgentFeatures.
-        Whether the agent running on the instance can run all the available management plugins
+        Whether Oracle Cloud Agent can run all the available management plugins.
 
 
         :return: The is_management_supported of this InstanceAgentFeatures.
@@ -80,7 +80,7 @@ class InstanceAgentFeatures(object):
     def is_management_supported(self, is_management_supported):
         """
         Sets the is_management_supported of this InstanceAgentFeatures.
-        Whether the agent running on the instance can run all the available management plugins
+        Whether Oracle Cloud Agent can run all the available management plugins.
 
 
         :param is_management_supported: The is_management_supported of this InstanceAgentFeatures.

--- a/src/oci/core/models/instance_configuration_instance_source_via_image_details.py
+++ b/src/oci/core/models/instance_configuration_instance_source_via_image_details.py
@@ -53,7 +53,8 @@ class InstanceConfigurationInstanceSourceViaImageDetails(InstanceConfigurationIn
     def boot_volume_size_in_gbs(self):
         """
         Gets the boot_volume_size_in_gbs of this InstanceConfigurationInstanceSourceViaImageDetails.
-        The size of the boot volume in GBs. The minimum value is 50 GB and the maximum value is 16384 GB (16TB).
+        The size of the boot volume in GBs. The minimum value is 50 GB and the maximum
+        value is 16384 GB (16TB).
 
 
         :return: The boot_volume_size_in_gbs of this InstanceConfigurationInstanceSourceViaImageDetails.
@@ -65,7 +66,8 @@ class InstanceConfigurationInstanceSourceViaImageDetails(InstanceConfigurationIn
     def boot_volume_size_in_gbs(self, boot_volume_size_in_gbs):
         """
         Sets the boot_volume_size_in_gbs of this InstanceConfigurationInstanceSourceViaImageDetails.
-        The size of the boot volume in GBs. The minimum value is 50 GB and the maximum value is 16384 GB (16TB).
+        The size of the boot volume in GBs. The minimum value is 50 GB and the maximum
+        value is 16384 GB (16TB).
 
 
         :param boot_volume_size_in_gbs: The boot_volume_size_in_gbs of this InstanceConfigurationInstanceSourceViaImageDetails.

--- a/src/oci/core/models/instance_configuration_launch_instance_agent_config_details.py
+++ b/src/oci/core/models/instance_configuration_launch_instance_agent_config_details.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class InstanceConfigurationLaunchInstanceAgentConfigDetails(object):
     """
-    Instance agent configuration options to choose for launching the instance
+    Configuration options for the Oracle Cloud Agent software running on the instance.
     """
 
     def __init__(self, **kwargs):
@@ -44,8 +44,8 @@ class InstanceConfigurationLaunchInstanceAgentConfigDetails(object):
     def is_monitoring_disabled(self):
         """
         Gets the is_monitoring_disabled of this InstanceConfigurationLaunchInstanceAgentConfigDetails.
-        Whether the agent running on the instance can gather performance metrics and monitor the instance.
-        Default value is false.
+        Whether Oracle Cloud Agent can gather performance metrics and monitor the instance using the
+        monitoring plugins. Default value is false (monitoring plugins are enabled).
 
 
         :return: The is_monitoring_disabled of this InstanceConfigurationLaunchInstanceAgentConfigDetails.
@@ -57,8 +57,8 @@ class InstanceConfigurationLaunchInstanceAgentConfigDetails(object):
     def is_monitoring_disabled(self, is_monitoring_disabled):
         """
         Sets the is_monitoring_disabled of this InstanceConfigurationLaunchInstanceAgentConfigDetails.
-        Whether the agent running on the instance can gather performance metrics and monitor the instance.
-        Default value is false.
+        Whether Oracle Cloud Agent can gather performance metrics and monitor the instance using the
+        monitoring plugins. Default value is false (monitoring plugins are enabled).
 
 
         :param is_monitoring_disabled: The is_monitoring_disabled of this InstanceConfigurationLaunchInstanceAgentConfigDetails.
@@ -70,8 +70,8 @@ class InstanceConfigurationLaunchInstanceAgentConfigDetails(object):
     def is_management_disabled(self):
         """
         Gets the is_management_disabled of this InstanceConfigurationLaunchInstanceAgentConfigDetails.
-        Whether the agent running on the instance can run all the available management plugins.
-        Default value is false.
+        Whether Oracle Cloud Agent can run all the available management plugins.
+        Default value is false (management plugins are enabled).
 
 
         :return: The is_management_disabled of this InstanceConfigurationLaunchInstanceAgentConfigDetails.
@@ -83,8 +83,8 @@ class InstanceConfigurationLaunchInstanceAgentConfigDetails(object):
     def is_management_disabled(self, is_management_disabled):
         """
         Sets the is_management_disabled of this InstanceConfigurationLaunchInstanceAgentConfigDetails.
-        Whether the agent running on the instance can run all the available management plugins.
-        Default value is false.
+        Whether Oracle Cloud Agent can run all the available management plugins.
+        Default value is false (management plugins are enabled).
 
 
         :param is_management_disabled: The is_management_disabled of this InstanceConfigurationLaunchInstanceAgentConfigDetails.

--- a/src/oci/core/models/instance_configuration_launch_options.py
+++ b/src/oci/core/models/instance_configuration_launch_options.py
@@ -145,7 +145,7 @@ class InstanceConfigurationLaunchOptions(object):
         * `ISCSI` - ISCSI attached block storage device.
         * `SCSI` - Emulated SCSI disk.
         * `IDE` - Emulated IDE disk.
-        * `VFIO` - Direct attached Virtual Function storage.  This is the default option for local data
+        * `VFIO` - Direct attached Virtual Function storage. This is the default option for local data
         volumes on Oracle provided images.
         * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
         storage volumes on Oracle-provided images.
@@ -167,7 +167,7 @@ class InstanceConfigurationLaunchOptions(object):
         * `ISCSI` - ISCSI attached block storage device.
         * `SCSI` - Emulated SCSI disk.
         * `IDE` - Emulated IDE disk.
-        * `VFIO` - Direct attached Virtual Function storage.  This is the default option for local data
+        * `VFIO` - Direct attached Virtual Function storage. This is the default option for local data
         volumes on Oracle provided images.
         * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
         storage volumes on Oracle-provided images.
@@ -185,10 +185,10 @@ class InstanceConfigurationLaunchOptions(object):
     def firmware(self):
         """
         Gets the firmware of this InstanceConfigurationLaunchOptions.
-        Firmware used to boot VM.  Select the option that matches your operating system.
-        * `BIOS` - Boot VM using BIOS style firmware.  This is compatible with both 32 bit and 64 bit operating
+        Firmware used to boot VM. Select the option that matches your operating system.
+        * `BIOS` - Boot VM using BIOS style firmware. This is compatible with both 32 bit and 64 bit operating
         systems that boot using MBR style bootloaders.
-        * `UEFI_64` - Boot VM using UEFI style firmware compatible with 64 bit operating systems.  This is the
+        * `UEFI_64` - Boot VM using UEFI style firmware compatible with 64 bit operating systems. This is the
         default for Oracle-provided images.
 
         Allowed values for this property are: "BIOS", "UEFI_64", 'UNKNOWN_ENUM_VALUE'.
@@ -204,10 +204,10 @@ class InstanceConfigurationLaunchOptions(object):
     def firmware(self, firmware):
         """
         Sets the firmware of this InstanceConfigurationLaunchOptions.
-        Firmware used to boot VM.  Select the option that matches your operating system.
-        * `BIOS` - Boot VM using BIOS style firmware.  This is compatible with both 32 bit and 64 bit operating
+        Firmware used to boot VM. Select the option that matches your operating system.
+        * `BIOS` - Boot VM using BIOS style firmware. This is compatible with both 32 bit and 64 bit operating
         systems that boot using MBR style bootloaders.
-        * `UEFI_64` - Boot VM using UEFI style firmware compatible with 64 bit operating systems.  This is the
+        * `UEFI_64` - Boot VM using UEFI style firmware compatible with 64 bit operating systems. This is the
         default for Oracle-provided images.
 
 
@@ -224,7 +224,7 @@ class InstanceConfigurationLaunchOptions(object):
         """
         Gets the network_type of this InstanceConfigurationLaunchOptions.
         Emulation type for the physical network interface card (NIC).
-        * `E1000` - Emulated Gigabit ethernet controller.  Compatible with Linux e1000 network driver.
+        * `E1000` - Emulated Gigabit ethernet controller. Compatible with Linux e1000 network driver.
         * `VFIO` - Direct attached Virtual Function network controller. This is the networking type
         when you launch an instance using hardware-assisted (SR-IOV) networking.
         * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
@@ -243,7 +243,7 @@ class InstanceConfigurationLaunchOptions(object):
         """
         Sets the network_type of this InstanceConfigurationLaunchOptions.
         Emulation type for the physical network interface card (NIC).
-        * `E1000` - Emulated Gigabit ethernet controller.  Compatible with Linux e1000 network driver.
+        * `E1000` - Emulated Gigabit ethernet controller. Compatible with Linux e1000 network driver.
         * `VFIO` - Direct attached Virtual Function network controller. This is the networking type
         when you launch an instance using hardware-assisted (SR-IOV) networking.
         * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
@@ -265,7 +265,7 @@ class InstanceConfigurationLaunchOptions(object):
         * `ISCSI` - ISCSI attached block storage device.
         * `SCSI` - Emulated SCSI disk.
         * `IDE` - Emulated IDE disk.
-        * `VFIO` - Direct attached Virtual Function storage.  This is the default option for local data
+        * `VFIO` - Direct attached Virtual Function storage. This is the default option for local data
         volumes on Oracle provided images.
         * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
         storage volumes on Oracle-provided images.
@@ -287,7 +287,7 @@ class InstanceConfigurationLaunchOptions(object):
         * `ISCSI` - ISCSI attached block storage device.
         * `SCSI` - Emulated SCSI disk.
         * `IDE` - Emulated IDE disk.
-        * `VFIO` - Direct attached Virtual Function storage.  This is the default option for local data
+        * `VFIO` - Direct attached Virtual Function storage. This is the default option for local data
         volumes on Oracle provided images.
         * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
         storage volumes on Oracle-provided images.

--- a/src/oci/core/models/instance_console_connection.py
+++ b/src/oci/core/models/instance_console_connection.py
@@ -13,8 +13,7 @@ class InstanceConsoleConnection(object):
     The `InstanceConsoleConnection` API provides you with console access to Compute instances,
     enabling you to troubleshoot malfunctioning instances remotely.
 
-    For more information about console access, see
-    `Accessing the Console`__.
+    For more information about instance console connections, see `Troubleshooting Instances Using Instance Console Connections`__.
 
     __ https://docs.cloud.oracle.com/Content/Compute/References/serialconsole.htm
     """

--- a/src/oci/core/models/instance_pool_load_balancer_attachment.py
+++ b/src/oci/core/models/instance_pool_load_balancer_attachment.py
@@ -229,7 +229,9 @@ class InstancePoolLoadBalancerAttachment(object):
     def vnic_selection(self):
         """
         **[Required]** Gets the vnic_selection of this InstancePoolLoadBalancerAttachment.
-        Indicates which VNIC on each instance in the instance pool should be used to associate with the load balancer. Possible values are \"PrimaryVnic\" or the displayName of one of the secondary VNICs on the instance configuration that is associated with the instance pool.
+        Indicates which VNIC on each instance in the instance pool should be used to associate with the load balancer.
+        Possible values are \"PrimaryVnic\" or the displayName of one of the secondary VNICs on the instance configuration
+        that is associated with the instance pool.
 
 
         :return: The vnic_selection of this InstancePoolLoadBalancerAttachment.
@@ -241,7 +243,9 @@ class InstancePoolLoadBalancerAttachment(object):
     def vnic_selection(self, vnic_selection):
         """
         Sets the vnic_selection of this InstancePoolLoadBalancerAttachment.
-        Indicates which VNIC on each instance in the instance pool should be used to associate with the load balancer. Possible values are \"PrimaryVnic\" or the displayName of one of the secondary VNICs on the instance configuration that is associated with the instance pool.
+        Indicates which VNIC on each instance in the instance pool should be used to associate with the load balancer.
+        Possible values are \"PrimaryVnic\" or the displayName of one of the secondary VNICs on the instance configuration
+        that is associated with the instance pool.
 
 
         :param vnic_selection: The vnic_selection of this InstancePoolLoadBalancerAttachment.

--- a/src/oci/core/models/instance_pool_summary.py
+++ b/src/oci/core/models/instance_pool_summary.py
@@ -182,7 +182,7 @@ class InstancePoolSummary(object):
     def display_name(self):
         """
         Gets the display_name of this InstancePoolSummary.
-        The user-friendly name.  Does not have to be unique.
+        The user-friendly name. Does not have to be unique.
 
 
         :return: The display_name of this InstancePoolSummary.
@@ -194,7 +194,7 @@ class InstancePoolSummary(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this InstancePoolSummary.
-        The user-friendly name.  Does not have to be unique.
+        The user-friendly name. Does not have to be unique.
 
 
         :param display_name: The display_name of this InstancePoolSummary.

--- a/src/oci/core/models/instance_summary.py
+++ b/src/oci/core/models/instance_summary.py
@@ -179,7 +179,7 @@ class InstanceSummary(object):
     def display_name(self):
         """
         Gets the display_name of this InstanceSummary.
-        The user-friendly name.  Does not have to be unique.
+        The user-friendly name. Does not have to be unique.
 
 
         :return: The display_name of this InstanceSummary.
@@ -191,7 +191,7 @@ class InstanceSummary(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this InstanceSummary.
-        The user-friendly name.  Does not have to be unique.
+        The user-friendly name. Does not have to be unique.
 
 
         :param display_name: The display_name of this InstanceSummary.

--- a/src/oci/core/models/internet_gateway.py
+++ b/src/oci/core/models/internet_gateway.py
@@ -18,9 +18,6 @@ class InternetGateway(object):
     talk to an administrator. If you're an administrator who needs to write policies to give users access, see
     `Getting Started with Policies`__.
 
-    **Warning:** Oracle recommends that you avoid using any confidential information when you
-    supply string values using the API.
-
     __ https://docs.cloud.oracle.com/Content/Network/Concepts/overview.htm#scenarios
     __ https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm
     """

--- a/src/oci/core/models/ip_sec_connection.py
+++ b/src/oci/core/models/ip_sec_connection.py
@@ -32,9 +32,6 @@ class IPSecConnection(object):
     talk to an administrator. If you're an administrator who needs to write policies to give users access, see
     `Getting Started with Policies`__.
 
-    **Warning:** Oracle recommends that you avoid using any confidential information when you
-    supply string values using the API.
-
     __ https://docs.cloud.oracle.com/Content/Network/Tasks/managingIPsec.htm
     __ https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm
     """

--- a/src/oci/core/models/ip_sec_connection_tunnel.py
+++ b/src/oci/core/models/ip_sec_connection_tunnel.py
@@ -27,6 +27,10 @@ class IPSecConnectionTunnel(object):
     #: This constant has a value of "DOWN_FOR_MAINTENANCE"
     STATUS_DOWN_FOR_MAINTENANCE = "DOWN_FOR_MAINTENANCE"
 
+    #: A constant which can be used with the status property of a IPSecConnectionTunnel.
+    #: This constant has a value of "PARTIAL_UP"
+    STATUS_PARTIAL_UP = "PARTIAL_UP"
+
     #: A constant which can be used with the ike_version property of a IPSecConnectionTunnel.
     #: This constant has a value of "V1"
     IKE_VERSION_V1 = "V1"
@@ -59,6 +63,10 @@ class IPSecConnectionTunnel(object):
     #: This constant has a value of "STATIC"
     ROUTING_STATIC = "STATIC"
 
+    #: A constant which can be used with the routing property of a IPSecConnectionTunnel.
+    #: This constant has a value of "POLICY"
+    ROUTING_POLICY = "POLICY"
+
     def __init__(self, **kwargs):
         """
         Initializes a new IPSecConnectionTunnel object with values from keyword arguments.
@@ -82,7 +90,7 @@ class IPSecConnectionTunnel(object):
 
         :param status:
             The value to assign to the status property of this IPSecConnectionTunnel.
-            Allowed values for this property are: "UP", "DOWN", "DOWN_FOR_MAINTENANCE", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "UP", "DOWN", "DOWN_FOR_MAINTENANCE", "PARTIAL_UP", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type status: str
 
@@ -106,9 +114,13 @@ class IPSecConnectionTunnel(object):
             The value to assign to the bgp_session_info property of this IPSecConnectionTunnel.
         :type bgp_session_info: oci.core.models.BgpSessionInfo
 
+        :param encryption_domain_config:
+            The value to assign to the encryption_domain_config property of this IPSecConnectionTunnel.
+        :type encryption_domain_config: oci.core.models.EncryptionDomainConfig
+
         :param routing:
             The value to assign to the routing property of this IPSecConnectionTunnel.
-            Allowed values for this property are: "BGP", "STATIC", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "BGP", "STATIC", "POLICY", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type routing: str
 
@@ -131,6 +143,7 @@ class IPSecConnectionTunnel(object):
             'lifecycle_state': 'str',
             'display_name': 'str',
             'bgp_session_info': 'BgpSessionInfo',
+            'encryption_domain_config': 'EncryptionDomainConfig',
             'routing': 'str',
             'time_created': 'datetime',
             'time_status_updated': 'datetime'
@@ -146,6 +159,7 @@ class IPSecConnectionTunnel(object):
             'lifecycle_state': 'lifecycleState',
             'display_name': 'displayName',
             'bgp_session_info': 'bgpSessionInfo',
+            'encryption_domain_config': 'encryptionDomainConfig',
             'routing': 'routing',
             'time_created': 'timeCreated',
             'time_status_updated': 'timeStatusUpdated'
@@ -160,6 +174,7 @@ class IPSecConnectionTunnel(object):
         self._lifecycle_state = None
         self._display_name = None
         self._bgp_session_info = None
+        self._encryption_domain_config = None
         self._routing = None
         self._time_created = None
         self._time_status_updated = None
@@ -282,7 +297,7 @@ class IPSecConnectionTunnel(object):
         Gets the status of this IPSecConnectionTunnel.
         The status of the tunnel based on IPSec protocol characteristics.
 
-        Allowed values for this property are: "UP", "DOWN", "DOWN_FOR_MAINTENANCE", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "UP", "DOWN", "DOWN_FOR_MAINTENANCE", "PARTIAL_UP", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -301,7 +316,7 @@ class IPSecConnectionTunnel(object):
         :param status: The status of this IPSecConnectionTunnel.
         :type: str
         """
-        allowed_values = ["UP", "DOWN", "DOWN_FOR_MAINTENANCE"]
+        allowed_values = ["UP", "DOWN", "DOWN_FOR_MAINTENANCE", "PARTIAL_UP"]
         if not value_allowed_none_or_none_sentinel(status, allowed_values):
             status = 'UNKNOWN_ENUM_VALUE'
         self._status = status
@@ -413,12 +428,32 @@ class IPSecConnectionTunnel(object):
         self._bgp_session_info = bgp_session_info
 
     @property
+    def encryption_domain_config(self):
+        """
+        Gets the encryption_domain_config of this IPSecConnectionTunnel.
+
+        :return: The encryption_domain_config of this IPSecConnectionTunnel.
+        :rtype: oci.core.models.EncryptionDomainConfig
+        """
+        return self._encryption_domain_config
+
+    @encryption_domain_config.setter
+    def encryption_domain_config(self, encryption_domain_config):
+        """
+        Sets the encryption_domain_config of this IPSecConnectionTunnel.
+
+        :param encryption_domain_config: The encryption_domain_config of this IPSecConnectionTunnel.
+        :type: oci.core.models.EncryptionDomainConfig
+        """
+        self._encryption_domain_config = encryption_domain_config
+
+    @property
     def routing(self):
         """
         Gets the routing of this IPSecConnectionTunnel.
         The type of routing used for this tunnel (either BGP dynamic routing or static routing).
 
-        Allowed values for this property are: "BGP", "STATIC", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "BGP", "STATIC", "POLICY", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -437,7 +472,7 @@ class IPSecConnectionTunnel(object):
         :param routing: The routing of this IPSecConnectionTunnel.
         :type: str
         """
-        allowed_values = ["BGP", "STATIC"]
+        allowed_values = ["BGP", "STATIC", "POLICY"]
         if not value_allowed_none_or_none_sentinel(routing, allowed_values):
             routing = 'UNKNOWN_ENUM_VALUE'
         self._routing = routing

--- a/src/oci/core/models/ipv6.py
+++ b/src/oci/core/models/ipv6.py
@@ -295,7 +295,7 @@ class Ipv6(object):
         **[Required]** Gets the ip_address of this Ipv6.
         The IPv6 address of the `IPv6` object. The address is within the private IPv6 CIDR block
         of the VNIC's subnet (see the `ipv6CidrBlock` attribute for the :class:`Subnet`
-        object).
+        object.
 
         Example: `2001:0db8:0123:1111:abcd:ef01:2345:6789`
 
@@ -311,7 +311,7 @@ class Ipv6(object):
         Sets the ip_address of this Ipv6.
         The IPv6 address of the `IPv6` object. The address is within the private IPv6 CIDR block
         of the VNIC's subnet (see the `ipv6CidrBlock` attribute for the :class:`Subnet`
-        object).
+        object.
 
         Example: `2001:0db8:0123:1111:abcd:ef01:2345:6789`
 
@@ -500,7 +500,7 @@ class Ipv6(object):
     @property
     def vnic_id(self):
         """
-        **[Required]** Gets the vnic_id of this Ipv6.
+        Gets the vnic_id of this Ipv6.
         The `OCID`__ of the VNIC the IPv6 is assigned to.
         The VNIC and IPv6 must be in the same subnet.
 

--- a/src/oci/core/models/launch_instance_agent_config_details.py
+++ b/src/oci/core/models/launch_instance_agent_config_details.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class LaunchInstanceAgentConfigDetails(object):
     """
-    Instance agent configuration options to choose for launching the instance
+    Configuration options for the Oracle Cloud Agent software running on the instance.
     """
 
     def __init__(self, **kwargs):
@@ -44,8 +44,8 @@ class LaunchInstanceAgentConfigDetails(object):
     def is_monitoring_disabled(self):
         """
         Gets the is_monitoring_disabled of this LaunchInstanceAgentConfigDetails.
-        Whether the agent running on the instance can gather performance metrics and monitor the instance.
-        Default value is false.
+        Whether Oracle Cloud Agent can gather performance metrics and monitor the instance using the
+        monitoring plugins. Default value is false (monitoring plugins are enabled).
 
 
         :return: The is_monitoring_disabled of this LaunchInstanceAgentConfigDetails.
@@ -57,8 +57,8 @@ class LaunchInstanceAgentConfigDetails(object):
     def is_monitoring_disabled(self, is_monitoring_disabled):
         """
         Sets the is_monitoring_disabled of this LaunchInstanceAgentConfigDetails.
-        Whether the agent running on the instance can gather performance metrics and monitor the instance.
-        Default value is false.
+        Whether Oracle Cloud Agent can gather performance metrics and monitor the instance using the
+        monitoring plugins. Default value is false (monitoring plugins are enabled).
 
 
         :param is_monitoring_disabled: The is_monitoring_disabled of this LaunchInstanceAgentConfigDetails.
@@ -70,8 +70,8 @@ class LaunchInstanceAgentConfigDetails(object):
     def is_management_disabled(self):
         """
         Gets the is_management_disabled of this LaunchInstanceAgentConfigDetails.
-        Whether the agent running on the instance can run all the available management plugins.
-        Default value is false.
+        Whether Oracle Cloud Agent can run all the available management plugins.
+        Default value is false (management plugins are enabled).
 
 
         :return: The is_management_disabled of this LaunchInstanceAgentConfigDetails.
@@ -83,8 +83,8 @@ class LaunchInstanceAgentConfigDetails(object):
     def is_management_disabled(self, is_management_disabled):
         """
         Sets the is_management_disabled of this LaunchInstanceAgentConfigDetails.
-        Whether the agent running on the instance can run all the available management plugins.
-        Default value is false.
+        Whether Oracle Cloud Agent can run all the available management plugins.
+        Default value is false (management plugins are enabled).
 
 
         :param is_management_disabled: The is_management_disabled of this LaunchInstanceAgentConfigDetails.

--- a/src/oci/core/models/launch_instance_details.py
+++ b/src/oci/core/models/launch_instance_details.py
@@ -897,7 +897,7 @@ class LaunchInstanceDetails(object):
     def is_pv_encryption_in_transit_enabled(self):
         """
         Gets the is_pv_encryption_in_transit_enabled of this LaunchInstanceDetails.
-        Whether to enable in-transit encryption for the data volume's paravirtualized attachment. The default value is false.
+        Whether to enable in-transit encryption for the data volume's paravirtualized attachment. This field applies to both block volumes and boot volumes. The default value is false.
 
 
         :return: The is_pv_encryption_in_transit_enabled of this LaunchInstanceDetails.
@@ -909,7 +909,7 @@ class LaunchInstanceDetails(object):
     def is_pv_encryption_in_transit_enabled(self, is_pv_encryption_in_transit_enabled):
         """
         Sets the is_pv_encryption_in_transit_enabled of this LaunchInstanceDetails.
-        Whether to enable in-transit encryption for the data volume's paravirtualized attachment. The default value is false.
+        Whether to enable in-transit encryption for the data volume's paravirtualized attachment. This field applies to both block volumes and boot volumes. The default value is false.
 
 
         :param is_pv_encryption_in_transit_enabled: The is_pv_encryption_in_transit_enabled of this LaunchInstanceDetails.

--- a/src/oci/core/models/launch_options.py
+++ b/src/oci/core/models/launch_options.py
@@ -145,7 +145,7 @@ class LaunchOptions(object):
         * `ISCSI` - ISCSI attached block storage device.
         * `SCSI` - Emulated SCSI disk.
         * `IDE` - Emulated IDE disk.
-        * `VFIO` - Direct attached Virtual Function storage.  This is the default option for local data
+        * `VFIO` - Direct attached Virtual Function storage. This is the default option for local data
         volumes on Oracle-provided images.
         * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
         storage volumes on Oracle-provided images.
@@ -167,7 +167,7 @@ class LaunchOptions(object):
         * `ISCSI` - ISCSI attached block storage device.
         * `SCSI` - Emulated SCSI disk.
         * `IDE` - Emulated IDE disk.
-        * `VFIO` - Direct attached Virtual Function storage.  This is the default option for local data
+        * `VFIO` - Direct attached Virtual Function storage. This is the default option for local data
         volumes on Oracle-provided images.
         * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
         storage volumes on Oracle-provided images.
@@ -185,10 +185,10 @@ class LaunchOptions(object):
     def firmware(self):
         """
         Gets the firmware of this LaunchOptions.
-        Firmware used to boot VM.  Select the option that matches your operating system.
-        * `BIOS` - Boot VM using BIOS style firmware.  This is compatible with both 32 bit and 64 bit operating
+        Firmware used to boot VM. Select the option that matches your operating system.
+        * `BIOS` - Boot VM using BIOS style firmware. This is compatible with both 32 bit and 64 bit operating
         systems that boot using MBR style bootloaders.
-        * `UEFI_64` - Boot VM using UEFI style firmware compatible with 64 bit operating systems.  This is the
+        * `UEFI_64` - Boot VM using UEFI style firmware compatible with 64 bit operating systems. This is the
         default for Oracle-provided images.
 
         Allowed values for this property are: "BIOS", "UEFI_64", 'UNKNOWN_ENUM_VALUE'.
@@ -204,10 +204,10 @@ class LaunchOptions(object):
     def firmware(self, firmware):
         """
         Sets the firmware of this LaunchOptions.
-        Firmware used to boot VM.  Select the option that matches your operating system.
-        * `BIOS` - Boot VM using BIOS style firmware.  This is compatible with both 32 bit and 64 bit operating
+        Firmware used to boot VM. Select the option that matches your operating system.
+        * `BIOS` - Boot VM using BIOS style firmware. This is compatible with both 32 bit and 64 bit operating
         systems that boot using MBR style bootloaders.
-        * `UEFI_64` - Boot VM using UEFI style firmware compatible with 64 bit operating systems.  This is the
+        * `UEFI_64` - Boot VM using UEFI style firmware compatible with 64 bit operating systems. This is the
         default for Oracle-provided images.
 
 
@@ -224,7 +224,7 @@ class LaunchOptions(object):
         """
         Gets the network_type of this LaunchOptions.
         Emulation type for the physical network interface card (NIC).
-        * `E1000` - Emulated Gigabit ethernet controller.  Compatible with Linux e1000 network driver.
+        * `E1000` - Emulated Gigabit ethernet controller. Compatible with Linux e1000 network driver.
         * `VFIO` - Direct attached Virtual Function network controller. This is the networking type
         when you launch an instance using hardware-assisted (SR-IOV) networking.
         * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
@@ -243,7 +243,7 @@ class LaunchOptions(object):
         """
         Sets the network_type of this LaunchOptions.
         Emulation type for the physical network interface card (NIC).
-        * `E1000` - Emulated Gigabit ethernet controller.  Compatible with Linux e1000 network driver.
+        * `E1000` - Emulated Gigabit ethernet controller. Compatible with Linux e1000 network driver.
         * `VFIO` - Direct attached Virtual Function network controller. This is the networking type
         when you launch an instance using hardware-assisted (SR-IOV) networking.
         * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
@@ -265,7 +265,7 @@ class LaunchOptions(object):
         * `ISCSI` - ISCSI attached block storage device.
         * `SCSI` - Emulated SCSI disk.
         * `IDE` - Emulated IDE disk.
-        * `VFIO` - Direct attached Virtual Function storage.  This is the default option for local data
+        * `VFIO` - Direct attached Virtual Function storage. This is the default option for local data
         volumes on Oracle-provided images.
         * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
         storage volumes on Oracle-provided images.
@@ -287,7 +287,7 @@ class LaunchOptions(object):
         * `ISCSI` - ISCSI attached block storage device.
         * `SCSI` - Emulated SCSI disk.
         * `IDE` - Emulated IDE disk.
-        * `VFIO` - Direct attached Virtual Function storage.  This is the default option for local data
+        * `VFIO` - Direct attached Virtual Function storage. This is the default option for local data
         volumes on Oracle-provided images.
         * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
         storage volumes on Oracle-provided images.

--- a/src/oci/core/models/local_peering_gateway.py
+++ b/src/oci/core/models/local_peering_gateway.py
@@ -20,9 +20,6 @@ class LocalPeeringGateway(object):
     talk to an administrator. If you're an administrator who needs to write policies to give users access, see
     `Getting Started with Policies`__.
 
-    **Warning:** Oracle recommends that you avoid using any confidential information when you
-    supply string values using the API.
-
     __ https://docs.cloud.oracle.com/Content/Network/Tasks/VCNpeering.htm
     __ https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm
     """

--- a/src/oci/core/models/nat_gateway.py
+++ b/src/oci/core/models/nat_gateway.py
@@ -21,9 +21,6 @@ class NatGateway(object):
     policies to give users access, see `Getting Started with
     Policies`__.
 
-    **Warning:** Oracle recommends that you avoid using any confidential information when you
-    supply string values using the API.
-
     __ https://docs.cloud.oracle.com/Content/Network/Tasks/NATgateway.htm
     __ https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm
     """
@@ -264,7 +261,8 @@ class NatGateway(object):
     def id(self):
         """
         **[Required]** Gets the id of this NatGateway.
-        The `OCID`__ of the NAT gateway.
+        The `OCID`__ of the
+        NAT gateway.
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
@@ -278,7 +276,8 @@ class NatGateway(object):
     def id(self, id):
         """
         Sets the id of this NatGateway.
-        The `OCID`__ of the NAT gateway.
+        The `OCID`__ of the
+        NAT gateway.
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 

--- a/src/oci/core/models/network_security_group.py
+++ b/src/oci/core/models/network_security_group.py
@@ -49,9 +49,6 @@ class NetworkSecurityGroup(object):
     talk to an administrator. If you're an administrator who needs to write policies to give users access, see
     `Getting Started with Policies`__.
 
-    **Warning:** Oracle recommends that you avoid using any confidential information when you
-    supply string values using the API.
-
     __ https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/networksecuritygroups.htm
     __ https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm
     """

--- a/src/oci/core/models/peer_region_for_remote_peering.py
+++ b/src/oci/core/models/peer_region_for_remote_peering.py
@@ -10,7 +10,8 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class PeerRegionForRemotePeering(object):
     """
-    Details about a region that supports remote VCN peering. For more information, see `VCN Peering`__.
+    Details about a region that supports remote VCN peering. For more
+    information, see `VCN Peering`__.
 
     __ https://docs.cloud.oracle.com/Content/Network/Tasks/VCNpeering.htm
     """

--- a/src/oci/core/models/private_ip.py
+++ b/src/oci/core/models/private_ip.py
@@ -45,9 +45,6 @@ class PrivateIp(object):
     talk to an administrator. If you're an administrator who needs to write policies to give users access, see
     `Getting Started with Policies`__.
 
-    **Warning:** Oracle recommends that you avoid using any confidential information when you
-    supply string values using the API.
-
     __ https://docs.cloud.oracle.com/Content/Network/Tasks/managingIPaddresses.htm
     __ https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm
     """
@@ -544,7 +541,6 @@ class PrivateIp(object):
         Gets the vnic_id of this PrivateIp.
         The OCID of the VNIC the private IP is assigned to. The VNIC and private IP
         must be in the same subnet.
-
         However, if the `PrivateIp` object is being used with a VLAN as part of
         the Oracle Cloud VMware Solution, the `vnicId` is null.
 
@@ -560,7 +556,6 @@ class PrivateIp(object):
         Sets the vnic_id of this PrivateIp.
         The OCID of the VNIC the private IP is assigned to. The VNIC and private IP
         must be in the same subnet.
-
         However, if the `PrivateIp` object is being used with a VLAN as part of
         the Oracle Cloud VMware Solution, the `vnicId` is null.
 

--- a/src/oci/core/models/public_ip.py
+++ b/src/oci/core/models/public_ip.py
@@ -20,9 +20,6 @@ class PublicIp(object):
     For more information and comparison of the two types,
     see `Public IP Addresses`__.
 
-    **Warning:** Oracle recommends that you avoid using any confidential information when you
-    supply string values using the API.
-
     __ https://docs.cloud.oracle.com/Content/Network/Tasks/managingpublicIPs.htm
     """
 

--- a/src/oci/core/models/remote_peering_connection.py
+++ b/src/oci/core/models/remote_peering_connection.py
@@ -20,9 +20,6 @@ class RemotePeeringConnection(object):
     talk to an administrator. If you're an administrator who needs to write policies to give users access, see
     `Getting Started with Policies`__.
 
-    **Warning:** Oracle recommends that you avoid using any confidential information when you
-    supply string values using the API.
-
     __ https://docs.cloud.oracle.com/Content/Network/Tasks/VCNpeering.htm
     __ https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm
     """

--- a/src/oci/core/models/route_table.py
+++ b/src/oci/core/models/route_table.py
@@ -18,9 +18,6 @@ class RouteTable(object):
     talk to an administrator. If you're an administrator who needs to write policies to give users access, see
     `Getting Started with Policies`__.
 
-    **Warning:** Oracle recommends that you avoid using any confidential information when you
-    supply string values using the API.
-
     __ https://docs.cloud.oracle.com/Content/Network/Concepts/overview.htm
     __ https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm
     """

--- a/src/oci/core/models/security_list.py
+++ b/src/oci/core/models/security_list.py
@@ -28,9 +28,6 @@ class SecurityList(object):
     talk to an administrator. If you're an administrator who needs to write policies to give users access, see
     `Getting Started with Policies`__.
 
-    **Warning:** Oracle recommends that you avoid using any confidential information when you
-    supply string values using the API.
-
     __ https://docs.cloud.oracle.com/Content/Network/Concepts/securitylists.htm
     __ https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm
     """

--- a/src/oci/core/models/security_rule.py
+++ b/src/oci/core/models/security_rule.py
@@ -302,7 +302,8 @@ class SecurityRule(object):
     def direction(self):
         """
         **[Required]** Gets the direction of this SecurityRule.
-        Direction of the security rule. Set to `EGRESS` for rules to allow outbound IP packets, or `INGRESS` for rules to allow inbound IP packets.
+        Direction of the security rule. Set to `EGRESS` for rules to allow outbound IP packets,
+        or `INGRESS` for rules to allow inbound IP packets.
 
         Allowed values for this property are: "EGRESS", "INGRESS", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -317,7 +318,8 @@ class SecurityRule(object):
     def direction(self, direction):
         """
         Sets the direction of this SecurityRule.
-        Direction of the security rule. Set to `EGRESS` for rules to allow outbound IP packets, or `INGRESS` for rules to allow inbound IP packets.
+        Direction of the security rule. Set to `EGRESS` for rules to allow outbound IP packets,
+        or `INGRESS` for rules to allow inbound IP packets.
 
 
         :param direction: The direction of this SecurityRule.

--- a/src/oci/core/models/service_gateway.py
+++ b/src/oci/core/models/service_gateway.py
@@ -22,9 +22,6 @@ class ServiceGateway(object):
     talk to an administrator. If you're an administrator who needs to write policies to give users access, see
     `Getting Started with Policies`__.
 
-    **Warning:** Oracle recommends that you avoid using any confidential information when you
-    supply string values using the API.
-
     __ https://docs.cloud.oracle.com/Content/Network/Tasks/servicegateway.htm
     __ https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm
     """

--- a/src/oci/core/models/subnet.py
+++ b/src/oci/core/models/subnet.py
@@ -20,9 +20,6 @@ class Subnet(object):
     talk to an administrator. If you're an administrator who needs to write policies to give users access, see
     `Getting Started with Policies`__.
 
-    **Warning:** Oracle recommends that you avoid using any confidential information when you
-    supply string values using the API.
-
     __ https://docs.cloud.oracle.com/Content/Network/Concepts/overview.htm
     __ https://docs.cloud.oracle.com/Content/Network/Tasks/managingVCNs.htm
     __ https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm

--- a/src/oci/core/models/tunnel_status.py
+++ b/src/oci/core/models/tunnel_status.py
@@ -25,6 +25,10 @@ class TunnelStatus(object):
     #: This constant has a value of "DOWN_FOR_MAINTENANCE"
     LIFECYCLE_STATE_DOWN_FOR_MAINTENANCE = "DOWN_FOR_MAINTENANCE"
 
+    #: A constant which can be used with the lifecycle_state property of a TunnelStatus.
+    #: This constant has a value of "PARTIAL_UP"
+    LIFECYCLE_STATE_PARTIAL_UP = "PARTIAL_UP"
+
     def __init__(self, **kwargs):
         """
         Initializes a new TunnelStatus object with values from keyword arguments.
@@ -36,7 +40,7 @@ class TunnelStatus(object):
 
         :param lifecycle_state:
             The value to assign to the lifecycle_state property of this TunnelStatus.
-            Allowed values for this property are: "UP", "DOWN", "DOWN_FOR_MAINTENANCE", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "UP", "DOWN", "DOWN_FOR_MAINTENANCE", "PARTIAL_UP", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type lifecycle_state: str
 
@@ -102,7 +106,7 @@ class TunnelStatus(object):
         Gets the lifecycle_state of this TunnelStatus.
         The tunnel's current state.
 
-        Allowed values for this property are: "UP", "DOWN", "DOWN_FOR_MAINTENANCE", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "UP", "DOWN", "DOWN_FOR_MAINTENANCE", "PARTIAL_UP", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -121,7 +125,7 @@ class TunnelStatus(object):
         :param lifecycle_state: The lifecycle_state of this TunnelStatus.
         :type: str
         """
-        allowed_values = ["UP", "DOWN", "DOWN_FOR_MAINTENANCE"]
+        allowed_values = ["UP", "DOWN", "DOWN_FOR_MAINTENANCE", "PARTIAL_UP"]
         if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
             lifecycle_state = 'UNKNOWN_ENUM_VALUE'
         self._lifecycle_state = lifecycle_state

--- a/src/oci/core/models/update_instance_agent_config_details.py
+++ b/src/oci/core/models/update_instance_agent_config_details.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class UpdateInstanceAgentConfigDetails(object):
     """
-    Instance agent configuration options to choose for updating the instance
+    Configuration options for the Oracle Cloud Agent software running on the instance.
     """
 
     def __init__(self, **kwargs):
@@ -44,7 +44,8 @@ class UpdateInstanceAgentConfigDetails(object):
     def is_monitoring_disabled(self):
         """
         Gets the is_monitoring_disabled of this UpdateInstanceAgentConfigDetails.
-        Whether the agent running on the instance can gather performance metrics and monitor the instance.
+        Whether Oracle Cloud Agent can gather performance metrics and monitor the instance using the
+        monitoring plugins.
 
 
         :return: The is_monitoring_disabled of this UpdateInstanceAgentConfigDetails.
@@ -56,7 +57,8 @@ class UpdateInstanceAgentConfigDetails(object):
     def is_monitoring_disabled(self, is_monitoring_disabled):
         """
         Sets the is_monitoring_disabled of this UpdateInstanceAgentConfigDetails.
-        Whether the agent running on the instance can gather performance metrics and monitor the instance.
+        Whether Oracle Cloud Agent can gather performance metrics and monitor the instance using the
+        monitoring plugins.
 
 
         :param is_monitoring_disabled: The is_monitoring_disabled of this UpdateInstanceAgentConfigDetails.
@@ -68,7 +70,7 @@ class UpdateInstanceAgentConfigDetails(object):
     def is_management_disabled(self):
         """
         Gets the is_management_disabled of this UpdateInstanceAgentConfigDetails.
-        Whether the agent running on the instance can run all the available management plugins
+        Whether Oracle Cloud Agent can run all the available management plugins.
 
 
         :return: The is_management_disabled of this UpdateInstanceAgentConfigDetails.
@@ -80,7 +82,7 @@ class UpdateInstanceAgentConfigDetails(object):
     def is_management_disabled(self, is_management_disabled):
         """
         Sets the is_management_disabled of this UpdateInstanceAgentConfigDetails.
-        Whether the agent running on the instance can run all the available management plugins
+        Whether Oracle Cloud Agent can run all the available management plugins.
 
 
         :param is_management_disabled: The is_management_disabled of this UpdateInstanceAgentConfigDetails.

--- a/src/oci/core/models/update_ip_sec_connection_tunnel_details.py
+++ b/src/oci/core/models/update_ip_sec_connection_tunnel_details.py
@@ -21,6 +21,10 @@ class UpdateIPSecConnectionTunnelDetails(object):
     #: This constant has a value of "STATIC"
     ROUTING_STATIC = "STATIC"
 
+    #: A constant which can be used with the routing property of a UpdateIPSecConnectionTunnelDetails.
+    #: This constant has a value of "POLICY"
+    ROUTING_POLICY = "POLICY"
+
     #: A constant which can be used with the ike_version property of a UpdateIPSecConnectionTunnelDetails.
     #: This constant has a value of "V1"
     IKE_VERSION_V1 = "V1"
@@ -40,7 +44,7 @@ class UpdateIPSecConnectionTunnelDetails(object):
 
         :param routing:
             The value to assign to the routing property of this UpdateIPSecConnectionTunnelDetails.
-            Allowed values for this property are: "BGP", "STATIC"
+            Allowed values for this property are: "BGP", "STATIC", "POLICY"
         :type routing: str
 
         :param ike_version:
@@ -52,25 +56,32 @@ class UpdateIPSecConnectionTunnelDetails(object):
             The value to assign to the bgp_session_config property of this UpdateIPSecConnectionTunnelDetails.
         :type bgp_session_config: oci.core.models.UpdateIPSecTunnelBgpSessionDetails
 
+        :param encryption_domain_config:
+            The value to assign to the encryption_domain_config property of this UpdateIPSecConnectionTunnelDetails.
+        :type encryption_domain_config: oci.core.models.UpdateIPSecTunnelEncryptionDomainDetails
+
         """
         self.swagger_types = {
             'display_name': 'str',
             'routing': 'str',
             'ike_version': 'str',
-            'bgp_session_config': 'UpdateIPSecTunnelBgpSessionDetails'
+            'bgp_session_config': 'UpdateIPSecTunnelBgpSessionDetails',
+            'encryption_domain_config': 'UpdateIPSecTunnelEncryptionDomainDetails'
         }
 
         self.attribute_map = {
             'display_name': 'displayName',
             'routing': 'routing',
             'ike_version': 'ikeVersion',
-            'bgp_session_config': 'bgpSessionConfig'
+            'bgp_session_config': 'bgpSessionConfig',
+            'encryption_domain_config': 'encryptionDomainConfig'
         }
 
         self._display_name = None
         self._routing = None
         self._ike_version = None
         self._bgp_session_config = None
+        self._encryption_domain_config = None
 
     @property
     def display_name(self):
@@ -104,7 +115,7 @@ class UpdateIPSecConnectionTunnelDetails(object):
         Gets the routing of this UpdateIPSecConnectionTunnelDetails.
         The type of routing to use for this tunnel (either BGP dynamic routing or static routing).
 
-        Allowed values for this property are: "BGP", "STATIC"
+        Allowed values for this property are: "BGP", "STATIC", "POLICY"
 
 
         :return: The routing of this UpdateIPSecConnectionTunnelDetails.
@@ -122,7 +133,7 @@ class UpdateIPSecConnectionTunnelDetails(object):
         :param routing: The routing of this UpdateIPSecConnectionTunnelDetails.
         :type: str
         """
-        allowed_values = ["BGP", "STATIC"]
+        allowed_values = ["BGP", "STATIC", "POLICY"]
         if not value_allowed_none_or_none_sentinel(routing, allowed_values):
             raise ValueError(
                 "Invalid value for `routing`, must be None or one of {0}"
@@ -181,6 +192,26 @@ class UpdateIPSecConnectionTunnelDetails(object):
         :type: oci.core.models.UpdateIPSecTunnelBgpSessionDetails
         """
         self._bgp_session_config = bgp_session_config
+
+    @property
+    def encryption_domain_config(self):
+        """
+        Gets the encryption_domain_config of this UpdateIPSecConnectionTunnelDetails.
+
+        :return: The encryption_domain_config of this UpdateIPSecConnectionTunnelDetails.
+        :rtype: oci.core.models.UpdateIPSecTunnelEncryptionDomainDetails
+        """
+        return self._encryption_domain_config
+
+    @encryption_domain_config.setter
+    def encryption_domain_config(self, encryption_domain_config):
+        """
+        Sets the encryption_domain_config of this UpdateIPSecConnectionTunnelDetails.
+
+        :param encryption_domain_config: The encryption_domain_config of this UpdateIPSecConnectionTunnelDetails.
+        :type: oci.core.models.UpdateIPSecTunnelEncryptionDomainDetails
+        """
+        self._encryption_domain_config = encryption_domain_config
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/core/models/update_ip_sec_tunnel_encryption_domain_details.py
+++ b/src/oci/core/models/update_ip_sec_tunnel_encryption_domain_details.py
@@ -1,0 +1,102 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateIPSecTunnelEncryptionDomainDetails(object):
+    """
+    Request to enable a multi-encryption domain policy on the VPNaaS tunnel.
+    The cross product of oracleTrafficSelector and cpeTrafficSelector can't be more than 50.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateIPSecTunnelEncryptionDomainDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param oracle_traffic_selector:
+            The value to assign to the oracle_traffic_selector property of this UpdateIPSecTunnelEncryptionDomainDetails.
+        :type oracle_traffic_selector: list[str]
+
+        :param cpe_traffic_selector:
+            The value to assign to the cpe_traffic_selector property of this UpdateIPSecTunnelEncryptionDomainDetails.
+        :type cpe_traffic_selector: list[str]
+
+        """
+        self.swagger_types = {
+            'oracle_traffic_selector': 'list[str]',
+            'cpe_traffic_selector': 'list[str]'
+        }
+
+        self.attribute_map = {
+            'oracle_traffic_selector': 'oracleTrafficSelector',
+            'cpe_traffic_selector': 'cpeTrafficSelector'
+        }
+
+        self._oracle_traffic_selector = None
+        self._cpe_traffic_selector = None
+
+    @property
+    def oracle_traffic_selector(self):
+        """
+        Gets the oracle_traffic_selector of this UpdateIPSecTunnelEncryptionDomainDetails.
+        Lists IPv4 or IPv6-enabled subnets in your Oracle tenancy.
+
+
+        :return: The oracle_traffic_selector of this UpdateIPSecTunnelEncryptionDomainDetails.
+        :rtype: list[str]
+        """
+        return self._oracle_traffic_selector
+
+    @oracle_traffic_selector.setter
+    def oracle_traffic_selector(self, oracle_traffic_selector):
+        """
+        Sets the oracle_traffic_selector of this UpdateIPSecTunnelEncryptionDomainDetails.
+        Lists IPv4 or IPv6-enabled subnets in your Oracle tenancy.
+
+
+        :param oracle_traffic_selector: The oracle_traffic_selector of this UpdateIPSecTunnelEncryptionDomainDetails.
+        :type: list[str]
+        """
+        self._oracle_traffic_selector = oracle_traffic_selector
+
+    @property
+    def cpe_traffic_selector(self):
+        """
+        Gets the cpe_traffic_selector of this UpdateIPSecTunnelEncryptionDomainDetails.
+        Lists IPv4 or IPv6-enabled subnets in your on-premises network.
+
+
+        :return: The cpe_traffic_selector of this UpdateIPSecTunnelEncryptionDomainDetails.
+        :rtype: list[str]
+        """
+        return self._cpe_traffic_selector
+
+    @cpe_traffic_selector.setter
+    def cpe_traffic_selector(self, cpe_traffic_selector):
+        """
+        Sets the cpe_traffic_selector of this UpdateIPSecTunnelEncryptionDomainDetails.
+        Lists IPv4 or IPv6-enabled subnets in your on-premises network.
+
+
+        :param cpe_traffic_selector: The cpe_traffic_selector of this UpdateIPSecTunnelEncryptionDomainDetails.
+        :type: list[str]
+        """
+        self._cpe_traffic_selector = cpe_traffic_selector
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/update_launch_options.py
+++ b/src/oci/core/models/update_launch_options.py
@@ -191,14 +191,15 @@ class UpdateLaunchOptions(object):
     def is_pv_encryption_in_transit_enabled(self):
         """
         Gets the is_pv_encryption_in_transit_enabled of this UpdateLaunchOptions.
-        Whether to enable in-transit encryption for the boot volume's paravirtualized attachment.
+        Whether to enable in-transit encryption for the volume's paravirtualized attachment.
+        To enable in-transit encryption for block volumes and boot volumes, this field must be set to `true`.
 
         Data in transit is transferred over an internal and highly secure network. If you have specific
         compliance requirements related to the encryption of the data while it is moving between the
-        instance and the boot volume, you can enable in-transit encryption. In-transit encryption is
-        not enabled by default.
+        instance and the boot volume or the block volume, you can enable in-transit encryption.
+        In-transit encryption is not enabled by default.
 
-        All boot volumes are encrypted at rest.
+        All boot volumes and block volumes are encrypted at rest.
 
         For more information, see `Block Volume Encryption`__.
 
@@ -214,14 +215,15 @@ class UpdateLaunchOptions(object):
     def is_pv_encryption_in_transit_enabled(self, is_pv_encryption_in_transit_enabled):
         """
         Sets the is_pv_encryption_in_transit_enabled of this UpdateLaunchOptions.
-        Whether to enable in-transit encryption for the boot volume's paravirtualized attachment.
+        Whether to enable in-transit encryption for the volume's paravirtualized attachment.
+        To enable in-transit encryption for block volumes and boot volumes, this field must be set to `true`.
 
         Data in transit is transferred over an internal and highly secure network. If you have specific
         compliance requirements related to the encryption of the data while it is moving between the
-        instance and the boot volume, you can enable in-transit encryption. In-transit encryption is
-        not enabled by default.
+        instance and the boot volume or the block volume, you can enable in-transit encryption.
+        In-transit encryption is not enabled by default.
 
-        All boot volumes are encrypted at rest.
+        All boot volumes and block volumes are encrypted at rest.
 
         For more information, see `Block Volume Encryption`__.
 

--- a/src/oci/core/models/update_virtual_circuit_details.py
+++ b/src/oci/core/models/update_virtual_circuit_details.py
@@ -381,7 +381,7 @@ class UpdateVirtualCircuitDetails(object):
         """
         Gets the provider_state of this UpdateVirtualCircuitDetails.
         The provider's state in relation to this virtual circuit. Relevant only
-        if the customer is using FastConnect via a provider.  ACTIVE
+        if the customer is using FastConnect via a provider. ACTIVE
         means the provider has provisioned the virtual circuit from their
         end. INACTIVE means the provider has not yet provisioned the virtual
         circuit, or has de-provisioned it.
@@ -401,7 +401,7 @@ class UpdateVirtualCircuitDetails(object):
         """
         Sets the provider_state of this UpdateVirtualCircuitDetails.
         The provider's state in relation to this virtual circuit. Relevant only
-        if the customer is using FastConnect via a provider.  ACTIVE
+        if the customer is using FastConnect via a provider. ACTIVE
         means the provider has provisioned the virtual circuit from their
         end. INACTIVE means the provider has not yet provisioned the virtual
         circuit, or has de-provisioned it.

--- a/src/oci/core/models/vcn.py
+++ b/src/oci/core/models/vcn.py
@@ -17,9 +17,6 @@ class Vcn(object):
     talk to an administrator. If you're an administrator who needs to write policies to give users access, see
     `Getting Started with Policies`__.
 
-    **Warning:** Oracle recommends that you avoid using any confidential information when you
-    supply string values using the API.
-
     __ https://docs.cloud.oracle.com/Content/Network/Concepts/overview.htm
     __ https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm
     """
@@ -499,7 +496,6 @@ class Vcn(object):
         value, Oracle provides a *different* CIDR for the `ipv6PublicCidrBlock`. Note that IPv6
         addressing is currently supported only in certain regions. See
         `IPv6 Addresses`__.
-
         Example: `2001:0db8:0123::/48`
 
         __ https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm
@@ -520,7 +516,6 @@ class Vcn(object):
         value, Oracle provides a *different* CIDR for the `ipv6PublicCidrBlock`. Note that IPv6
         addressing is currently supported only in certain regions. See
         `IPv6 Addresses`__.
-
         Example: `2001:0db8:0123::/48`
 
         __ https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm

--- a/src/oci/core/models/virtual_circuit.py
+++ b/src/oci/core/models/virtual_circuit.py
@@ -30,9 +30,6 @@ class VirtualCircuit(object):
     talk to an administrator. If you're an administrator who needs to write policies to give users access, see
     `Getting Started with Policies`__.
 
-    **Warning:** Oracle recommends that you avoid using any confidential information when you
-    supply string values using the API.
-
     __ https://docs.cloud.oracle.com/Content/Network/Concepts/fastconnect.htm
     __ https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm
     """
@@ -321,7 +318,7 @@ class VirtualCircuit(object):
     def bandwidth_shape_name(self):
         """
         Gets the bandwidth_shape_name of this VirtualCircuit.
-        The provisioned data rate of the connection.  To get a list of the
+        The provisioned data rate of the connection. To get a list of the
         available bandwidth levels (that is, shapes), see
         :func:`list_fast_connect_provider_virtual_circuit_bandwidth_shapes`.
 
@@ -337,7 +334,7 @@ class VirtualCircuit(object):
     def bandwidth_shape_name(self, bandwidth_shape_name):
         """
         Sets the bandwidth_shape_name of this VirtualCircuit.
-        The provisioned data rate of the connection.  To get a list of the
+        The provisioned data rate of the connection. To get a list of the
         available bandwidth levels (that is, shapes), see
         :func:`list_fast_connect_provider_virtual_circuit_bandwidth_shapes`.
 

--- a/src/oci/core/models/vnic.py
+++ b/src/oci/core/models/vnic.py
@@ -32,9 +32,6 @@ class Vnic(object):
     talk to an administrator. If you're an administrator who needs to write policies to give users access, see
     `Getting Started with Policies`__.
 
-    **Warning:** Oracle recommends that you avoid using any confidential information when you
-    supply string values using the API.
-
     __ https://docs.cloud.oracle.com/Content/Network/Tasks/managingVNICs.htm
     __ https://docs.cloud.oracle.com/Content/Network/Tasks/managingIPaddresses.htm
     __ https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm

--- a/src/oci/core/models/volume.py
+++ b/src/oci/core/models/volume.py
@@ -540,7 +540,8 @@ class Volume(object):
     def size_in_mbs(self):
         """
         **[Required]** Gets the size_in_mbs of this Volume.
-        The size of the volume in MBs. This field is deprecated. Use sizeInGBs instead.
+        The size of the volume in MBs. This field is deprecated. Use
+        sizeInGBs instead.
 
 
         :return: The size_in_mbs of this Volume.
@@ -552,7 +553,8 @@ class Volume(object):
     def size_in_mbs(self, size_in_mbs):
         """
         Sets the size_in_mbs of this Volume.
-        The size of the volume in MBs. This field is deprecated. Use sizeInGBs instead.
+        The size of the volume in MBs. This field is deprecated. Use
+        sizeInGBs instead.
 
 
         :param size_in_mbs: The size_in_mbs of this Volume.

--- a/src/oci/core/models/volume_attachment.py
+++ b/src/oci/core/models/volume_attachment.py
@@ -376,7 +376,10 @@ class VolumeAttachment(object):
     def is_shareable(self):
         """
         Gets the is_shareable of this VolumeAttachment.
-        Whether the attachment should be created in shareable mode. If an attachment is created in shareable mode, then other instances can attach the same volume, provided that they also create their attachments in shareable mode. Only certain volume types can be attached in shareable mode. Defaults to false if not specified.
+        Whether the attachment should be created in shareable mode. If an attachment
+        is created in shareable mode, then other instances can attach the same volume, provided
+        that they also create their attachments in shareable mode. Only certain volume types can
+        be attached in shareable mode. Defaults to false if not specified.
 
 
         :return: The is_shareable of this VolumeAttachment.
@@ -388,7 +391,10 @@ class VolumeAttachment(object):
     def is_shareable(self, is_shareable):
         """
         Sets the is_shareable of this VolumeAttachment.
-        Whether the attachment should be created in shareable mode. If an attachment is created in shareable mode, then other instances can attach the same volume, provided that they also create their attachments in shareable mode. Only certain volume types can be attached in shareable mode. Defaults to false if not specified.
+        Whether the attachment should be created in shareable mode. If an attachment
+        is created in shareable mode, then other instances can attach the same volume, provided
+        that they also create their attachments in shareable mode. Only certain volume types can
+        be attached in shareable mode. Defaults to false if not specified.
 
 
         :param is_shareable: The is_shareable of this VolumeAttachment.

--- a/src/oci/core/models/volume_backup_policy_assignment.py
+++ b/src/oci/core/models/volume_backup_policy_assignment.py
@@ -135,7 +135,8 @@ class VolumeBackupPolicyAssignment(object):
     def time_created(self):
         """
         **[Required]** Gets the time_created of this VolumeBackupPolicyAssignment.
-        The date and time the volume backup policy was assigned to the volume. The format is defined by `RFC3339`__.
+        The date and time the volume backup policy was assigned to the volume. The format is
+        defined by `RFC3339`__.
 
         __ https://tools.ietf.org/html/rfc3339
 
@@ -149,7 +150,8 @@ class VolumeBackupPolicyAssignment(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this VolumeBackupPolicyAssignment.
-        The date and time the volume backup policy was assigned to the volume. The format is defined by `RFC3339`__.
+        The date and time the volume backup policy was assigned to the volume. The format is
+        defined by `RFC3339`__.
 
         __ https://tools.ietf.org/html/rfc3339
 

--- a/src/oci/core/models/volume_backup_schedule.py
+++ b/src/oci/core/models/volume_backup_schedule.py
@@ -265,7 +265,9 @@ class VolumeBackupSchedule(object):
     def offset_seconds(self):
         """
         Gets the offset_seconds of this VolumeBackupSchedule.
-        The number of seconds that the volume backup start time should be shifted from the default interval boundaries specified by the period. The volume backup start time is the frequency start time plus the offset.
+        The number of seconds that the volume backup start
+        time should be shifted from the default interval boundaries specified by
+        the period. The volume backup start time is the frequency start time plus the offset.
 
 
         :return: The offset_seconds of this VolumeBackupSchedule.
@@ -277,7 +279,9 @@ class VolumeBackupSchedule(object):
     def offset_seconds(self, offset_seconds):
         """
         Sets the offset_seconds of this VolumeBackupSchedule.
-        The number of seconds that the volume backup start time should be shifted from the default interval boundaries specified by the period. The volume backup start time is the frequency start time plus the offset.
+        The number of seconds that the volume backup start
+        time should be shifted from the default interval boundaries specified by
+        the period. The volume backup start time is the frequency start time plus the offset.
 
 
         :param offset_seconds: The offset_seconds of this VolumeBackupSchedule.
@@ -319,11 +323,16 @@ class VolumeBackupSchedule(object):
     def offset_type(self):
         """
         Gets the offset_type of this VolumeBackupSchedule.
-        Indicates how the offset is defined. If value is `STRUCTURED`, then `hourOfDay`, `dayOfWeek`, `dayOfMonth`, and `month` fields are used and `offsetSeconds` will be ignored in requests and users should ignore its value from the responses.
+        Indicates how the offset is defined. If value is `STRUCTURED`,
+        then `hourOfDay`, `dayOfWeek`, `dayOfMonth`, and `month` fields are used
+        and `offsetSeconds` will be ignored in requests and users should ignore its
+        value from the responses.
 
-        `hourOfDay` is applicable for periods `ONE_DAY`, `ONE_WEEK`, `ONE_MONTH` and `ONE_YEAR`.
+        `hourOfDay` is applicable for periods `ONE_DAY`,
+        `ONE_WEEK`, `ONE_MONTH` and `ONE_YEAR`.
 
-        `dayOfWeek` is applicable for period `ONE_WEEK`.
+        `dayOfWeek` is applicable for period
+        `ONE_WEEK`.
 
         `dayOfMonth` is applicable for periods `ONE_MONTH` and `ONE_YEAR`.
 
@@ -331,9 +340,12 @@ class VolumeBackupSchedule(object):
 
         They will be ignored in the requests for inapplicable periods.
 
-        If value is `NUMERIC_SECONDS`, then `offsetSeconds` will be used for both requests and responses and the structured fields will be ignored in the requests and users should ignore their values from the responses.
+        If value is `NUMERIC_SECONDS`, then `offsetSeconds`
+        will be used for both requests and responses and the structured fields will be
+        ignored in the requests and users should ignore their values from the responses.
 
-        For clients using older versions of Apis and not sending `offsetType` in their requests, the behaviour is just like `NUMERIC_SECONDS`.
+        For clients using older versions of Apis and not sending `offsetType` in their
+        requests, the behaviour is just like `NUMERIC_SECONDS`.
 
         Allowed values for this property are: "STRUCTURED", "NUMERIC_SECONDS", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -348,11 +360,16 @@ class VolumeBackupSchedule(object):
     def offset_type(self, offset_type):
         """
         Sets the offset_type of this VolumeBackupSchedule.
-        Indicates how the offset is defined. If value is `STRUCTURED`, then `hourOfDay`, `dayOfWeek`, `dayOfMonth`, and `month` fields are used and `offsetSeconds` will be ignored in requests and users should ignore its value from the responses.
+        Indicates how the offset is defined. If value is `STRUCTURED`,
+        then `hourOfDay`, `dayOfWeek`, `dayOfMonth`, and `month` fields are used
+        and `offsetSeconds` will be ignored in requests and users should ignore its
+        value from the responses.
 
-        `hourOfDay` is applicable for periods `ONE_DAY`, `ONE_WEEK`, `ONE_MONTH` and `ONE_YEAR`.
+        `hourOfDay` is applicable for periods `ONE_DAY`,
+        `ONE_WEEK`, `ONE_MONTH` and `ONE_YEAR`.
 
-        `dayOfWeek` is applicable for period `ONE_WEEK`.
+        `dayOfWeek` is applicable for period
+        `ONE_WEEK`.
 
         `dayOfMonth` is applicable for periods `ONE_MONTH` and `ONE_YEAR`.
 
@@ -360,9 +377,12 @@ class VolumeBackupSchedule(object):
 
         They will be ignored in the requests for inapplicable periods.
 
-        If value is `NUMERIC_SECONDS`, then `offsetSeconds` will be used for both requests and responses and the structured fields will be ignored in the requests and users should ignore their values from the responses.
+        If value is `NUMERIC_SECONDS`, then `offsetSeconds`
+        will be used for both requests and responses and the structured fields will be
+        ignored in the requests and users should ignore their values from the responses.
 
-        For clients using older versions of Apis and not sending `offsetType` in their requests, the behaviour is just like `NUMERIC_SECONDS`.
+        For clients using older versions of Apis and not sending `offsetType` in their
+        requests, the behaviour is just like `NUMERIC_SECONDS`.
 
 
         :param offset_type: The offset_type of this VolumeBackupSchedule.

--- a/src/oci/core/models/volume_group.py
+++ b/src/oci/core/models/volume_group.py
@@ -231,7 +231,8 @@ class VolumeGroup(object):
     def display_name(self):
         """
         **[Required]** Gets the display_name of this VolumeGroup.
-        A user-friendly name for the volume group. Does not have to be unique, and it's changeable. Avoid entering confidential information.
+        A user-friendly name for the volume group. Does not have to be
+        unique, and it's changeable. Avoid entering confidential information.
 
 
         :return: The display_name of this VolumeGroup.
@@ -243,7 +244,8 @@ class VolumeGroup(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this VolumeGroup.
-        A user-friendly name for the volume group. Does not have to be unique, and it's changeable. Avoid entering confidential information.
+        A user-friendly name for the volume group. Does not have to be
+        unique, and it's changeable. Avoid entering confidential information.
 
 
         :param display_name: The display_name of this VolumeGroup.
@@ -463,7 +465,8 @@ class VolumeGroup(object):
     def is_hydrated(self):
         """
         Gets the is_hydrated of this VolumeGroup.
-        Specifies whether the newly created cloned volume group's data has finished copying from the source volume group or backup.
+        Specifies whether the newly created cloned volume group's data has finished copying
+        from the source volume group or backup.
 
 
         :return: The is_hydrated of this VolumeGroup.
@@ -475,7 +478,8 @@ class VolumeGroup(object):
     def is_hydrated(self, is_hydrated):
         """
         Sets the is_hydrated of this VolumeGroup.
-        Specifies whether the newly created cloned volume group's data has finished copying from the source volume group or backup.
+        Specifies whether the newly created cloned volume group's data has finished copying
+        from the source volume group or backup.
 
 
         :param is_hydrated: The is_hydrated of this VolumeGroup.

--- a/src/oci/core/models/volume_group_backup.py
+++ b/src/oci/core/models/volume_group_backup.py
@@ -275,7 +275,8 @@ class VolumeGroupBackup(object):
     def display_name(self):
         """
         **[Required]** Gets the display_name of this VolumeGroupBackup.
-        A user-friendly name for the volume group backup. Does not have to be unique and it's changeable. Avoid entering confidential information.
+        A user-friendly name for the volume group backup. Does not have
+        to be unique and it's changeable. Avoid entering confidential information.
 
 
         :return: The display_name of this VolumeGroupBackup.
@@ -287,7 +288,8 @@ class VolumeGroupBackup(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this VolumeGroupBackup.
-        A user-friendly name for the volume group backup. Does not have to be unique and it's changeable. Avoid entering confidential information.
+        A user-friendly name for the volume group backup. Does not have
+        to be unique and it's changeable. Avoid entering confidential information.
 
 
         :param display_name: The display_name of this VolumeGroupBackup.
@@ -471,7 +473,8 @@ class VolumeGroupBackup(object):
     def source_type(self):
         """
         Gets the source_type of this VolumeGroupBackup.
-        Specifies whether the volume group backup was created manually, or via scheduled backup policy.
+        Specifies whether the volume group backup was created manually, or via scheduled
+        backup policy.
 
         Allowed values for this property are: "MANUAL", "SCHEDULED", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -486,7 +489,8 @@ class VolumeGroupBackup(object):
     def source_type(self, source_type):
         """
         Sets the source_type of this VolumeGroupBackup.
-        Specifies whether the volume group backup was created manually, or via scheduled backup policy.
+        Specifies whether the volume group backup was created manually, or via scheduled
+        backup policy.
 
 
         :param source_type: The source_type of this VolumeGroupBackup.
@@ -590,8 +594,9 @@ class VolumeGroupBackup(object):
         """
         Gets the unique_size_in_mbs of this VolumeGroupBackup.
         The aggregate size used by the volume group backup, in MBs.
-        It is typically smaller than sizeInMBs, depending on the space
-        consumed on the volume group and whether the volume backup is full or incremental.
+
+        It is typically smaller than sizeInMBs, depending on the spaceconsumed
+        on the volume group and whether the volume backup is full or incremental.
 
 
         :return: The unique_size_in_mbs of this VolumeGroupBackup.
@@ -604,8 +609,9 @@ class VolumeGroupBackup(object):
         """
         Sets the unique_size_in_mbs of this VolumeGroupBackup.
         The aggregate size used by the volume group backup, in MBs.
-        It is typically smaller than sizeInMBs, depending on the space
-        consumed on the volume group and whether the volume backup is full or incremental.
+
+        It is typically smaller than sizeInMBs, depending on the spaceconsumed
+        on the volume group and whether the volume backup is full or incremental.
 
 
         :param unique_size_in_mbs: The unique_size_in_mbs of this VolumeGroupBackup.
@@ -618,8 +624,9 @@ class VolumeGroupBackup(object):
         """
         Gets the unique_size_in_gbs of this VolumeGroupBackup.
         The aggregate size used by the volume group backup, in GBs.
-        It is typically smaller than sizeInGBs, depending on the space
-        consumed on the volume group and whether the volume backup is full or incremental.
+
+        It is typically smaller than sizeInGBs, depending on the spaceconsumed
+        on the volume group and whether the volume backup is full or incremental.
 
 
         :return: The unique_size_in_gbs of this VolumeGroupBackup.
@@ -632,8 +639,9 @@ class VolumeGroupBackup(object):
         """
         Sets the unique_size_in_gbs of this VolumeGroupBackup.
         The aggregate size used by the volume group backup, in GBs.
-        It is typically smaller than sizeInGBs, depending on the space
-        consumed on the volume group and whether the volume backup is full or incremental.
+
+        It is typically smaller than sizeInGBs, depending on the spaceconsumed
+        on the volume group and whether the volume backup is full or incremental.
 
 
         :param unique_size_in_gbs: The unique_size_in_gbs of this VolumeGroupBackup.

--- a/src/oci/core/virtual_network_client.py
+++ b/src/oci/core/virtual_network_client.py
@@ -292,7 +292,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -466,7 +466,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -2592,7 +2592,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param str opc_request_id: (optional)
@@ -4918,7 +4918,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -4997,7 +4997,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -5073,7 +5073,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -5150,7 +5150,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -5229,7 +5229,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -5307,7 +5307,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -5384,7 +5384,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -5463,7 +5463,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -5545,7 +5545,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -5623,7 +5623,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param str opc_request_id: (optional)
@@ -5707,7 +5707,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -5788,7 +5788,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -5871,7 +5871,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -5958,7 +5958,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -6047,7 +6047,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -6132,7 +6132,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -6212,7 +6212,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -6291,7 +6291,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -6370,7 +6370,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -6448,7 +6448,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -6525,7 +6525,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -6604,7 +6604,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -6683,7 +6683,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -6760,7 +6760,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param str opc_request_id: (optional)
@@ -6857,7 +6857,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -10562,7 +10562,8 @@ class VirtualNetworkClient(object):
             Allowed values are: "ASC", "DESC"
 
         :param str lifecycle_state: (optional)
-            A filter to return only resources that match the specified lifecycle state. The value is case insensitive.
+            A filter to return only resources that match the specified lifecycle
+            state. The value is case insensitive.
 
             Allowed values are: "PROVISIONING", "PROVISIONED", "INACTIVE", "TERMINATING", "TERMINATED"
 
@@ -10794,7 +10795,8 @@ class VirtualNetworkClient(object):
             Allowed values are: "ASC", "DESC"
 
         :param str lifecycle_state: (optional)
-            A filter to return only resources that match the specified lifecycle state. The value is case insensitive.
+            A filter to return only resources that match the specified lifecycle
+            state. The value is case insensitive.
 
             Allowed values are: "PENDING_CUSTOMER", "PROVISIONING", "PROVISIONED", "INACTIVE", "TERMINATING", "TERMINATED"
 
@@ -11033,7 +11035,8 @@ class VirtualNetworkClient(object):
             Allowed values are: "ASC", "DESC"
 
         :param str lifecycle_state: (optional)
-            A filter to only return resources that match the given lifecycle state.  The state value is case-insensitive.
+            A filter to only return resources that match the given lifecycle
+            state. The state value is case-insensitive.
 
             Allowed values are: "PROVISIONING", "AVAILABLE", "TERMINATING", "TERMINATED"
 
@@ -11561,7 +11564,8 @@ class VirtualNetworkClient(object):
             Allowed values are: "ASC", "DESC"
 
         :param str lifecycle_state: (optional)
-            A filter to only return resources that match the given lifecycle state.  The state value is case-insensitive.
+            A filter to only return resources that match the given lifecycle
+            state. The state value is case-insensitive.
 
             Allowed values are: "PROVISIONING", "AVAILABLE", "TERMINATING", "TERMINATED"
 
@@ -12106,7 +12110,8 @@ class VirtualNetworkClient(object):
             Allowed values are: "ASC", "DESC"
 
         :param str lifecycle_state: (optional)
-            A filter to return only resources that match the specified lifecycle state. The value is case insensitive.
+            A filter to return only resources that match the specified lifecycle
+            state. The value is case insensitive.
 
             Allowed values are: "PROVISIONING", "AVAILABLE", "TERMINATING", "TERMINATED"
 
@@ -12521,7 +12526,8 @@ class VirtualNetworkClient(object):
             Allowed values are: "ASC", "DESC"
 
         :param str lifecycle_state: (optional)
-            A filter to return only resources that match the specified lifecycle state. The value is case insensitive.
+            A filter to return only resources that match the specified lifecycle
+            state. The value is case insensitive.
 
             Allowed values are: "PROVISIONING", "AVAILABLE", "TERMINATING", "TERMINATED"
 
@@ -13174,7 +13180,8 @@ class VirtualNetworkClient(object):
             Allowed values are: "ASC", "DESC"
 
         :param str lifecycle_state: (optional)
-            A filter to only return resources that match the given lifecycle state.  The state value is case-insensitive.
+            A filter to only return resources that match the given lifecycle
+            state. The state value is case-insensitive.
 
             Allowed values are: "PROVISIONING", "AVAILABLE", "TERMINATING", "TERMINATED"
 
@@ -13323,7 +13330,8 @@ class VirtualNetworkClient(object):
             Allowed values are: "ASC", "DESC"
 
         :param str lifecycle_state: (optional)
-            A filter to only return resources that match the given lifecycle state.  The state value is case-insensitive.
+            A filter to only return resources that match the given lifecycle
+            state. The state value is case-insensitive.
 
             Allowed values are: "PROVISIONING", "AVAILABLE", "TERMINATING", "TERMINATED"
 
@@ -13469,7 +13477,8 @@ class VirtualNetworkClient(object):
             Allowed values are: "ASC", "DESC"
 
         :param str lifecycle_state: (optional)
-            A filter to return only resources that match the given lifecycle state.  The state value is case-insensitive.
+            A filter to return only resources that match the given lifecycle
+            state. The state value is case-insensitive.
 
             Allowed values are: "PROVISIONING", "AVAILABLE", "TERMINATING", "TERMINATED"
 
@@ -13697,7 +13706,8 @@ class VirtualNetworkClient(object):
             Allowed values are: "ASC", "DESC"
 
         :param str lifecycle_state: (optional)
-            A filter to only return resources that match the given lifecycle state. The state value is case-insensitive.
+            A filter to only return resources that match the given lifecycle
+            state. The state value is case-insensitive.
 
             Allowed values are: "PROVISIONING", "AVAILABLE", "TERMINATING", "TERMINATED", "UPDATING"
 
@@ -13840,7 +13850,8 @@ class VirtualNetworkClient(object):
             Allowed values are: "ASC", "DESC"
 
         :param str lifecycle_state: (optional)
-            A filter to only return resources that match the given lifecycle state.  The state value is case-insensitive.
+            A filter to only return resources that match the given lifecycle
+            state. The state value is case-insensitive.
 
             Allowed values are: "PROVISIONING", "AVAILABLE", "TERMINATING", "TERMINATED", "UPDATING"
 
@@ -14029,7 +14040,9 @@ class VirtualNetworkClient(object):
             The OCID of the virtual circuit.
 
         :param str verification_state: (optional)
-            A filter to only return resources that match the given verification state.
+            A filter to only return resources that match the given verification
+            state.
+
             The state value is case-insensitive.
 
             Allowed values are: "IN_PROGRESS", "COMPLETED", "FAILED"
@@ -14158,7 +14171,8 @@ class VirtualNetworkClient(object):
             Allowed values are: "ASC", "DESC"
 
         :param str lifecycle_state: (optional)
-            A filter to return only resources that match the specified lifecycle state. The value is case insensitive.
+            A filter to return only resources that match the specified lifecycle
+            state. The value is case insensitive.
 
             Allowed values are: "PENDING_PROVIDER", "VERIFYING", "PROVISIONING", "PROVISIONED", "FAILED", "INACTIVE", "TERMINATING", "TERMINATED"
 
@@ -14308,7 +14322,8 @@ class VirtualNetworkClient(object):
             If you need to contact Oracle about a particular request, please provide the request ID.
 
         :param str lifecycle_state: (optional)
-            A filter to only return resources that match the given lifecycle state.  The state value is case-insensitive.
+            A filter to only return resources that match the given lifecycle
+            state. The state value is case-insensitive.
 
             Allowed values are: "PROVISIONING", "AVAILABLE", "TERMINATING", "TERMINATED", "UPDATING"
 
@@ -14439,7 +14454,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -14708,7 +14723,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -14800,7 +14815,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -14885,7 +14900,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -14967,7 +14982,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -15050,7 +15065,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -15135,7 +15150,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -15217,7 +15232,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -15300,7 +15315,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -15386,7 +15401,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -15471,7 +15486,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -15569,7 +15584,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param str opc_request_id: (optional)
@@ -15665,7 +15680,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -15756,7 +15771,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param str opc_request_id: (optional)
@@ -15844,7 +15859,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -15928,7 +15943,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -16026,7 +16041,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -16191,7 +16206,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -16313,7 +16328,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -16401,7 +16416,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -16485,7 +16500,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -16570,7 +16585,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -16656,7 +16671,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -16741,7 +16756,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -16823,7 +16838,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -16912,7 +16927,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param str opc_retry_token: (optional)
@@ -17014,7 +17029,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -17121,7 +17136,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)
@@ -17206,7 +17221,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param str opc_request_id: (optional)
@@ -17294,7 +17309,7 @@ class VirtualNetworkClient(object):
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
-            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            parameter to the value of the etag from a previous GET or POST response for that resource. The resource
             will be updated or deleted only if the etag you provide matches the resource's current etag value.
 
         :param obj retry_strategy: (optional)

--- a/src/oci/database/database_client.py
+++ b/src/oci/database/database_client.py
@@ -1295,6 +1295,316 @@ class DatabaseClient(object):
                 header_params=header_params,
                 body=change_exadata_infrastructure_compartment_details)
 
+    def change_external_container_database_compartment(self, change_compartment_details, external_container_database_id, **kwargs):
+        """
+        Move the :func:`create_external_container_database_details`
+        and its dependent resources to the specified compartment.
+        For more information about moving external container databases, see
+        `Moving Database Resources to a Different Compartment`__.
+
+        __ https://docs.cloud.oracle.com/Content/Database/Concepts/databaseoverview.htm#moveRes
+
+
+        :param oci.database.models.ChangeCompartmentDetails change_compartment_details: (required)
+            Request to move the external container database to a different compartment.
+
+        :param str external_container_database_id: (required)
+            The ExternalContainerDatabase `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/database/change_external_container_database_compartment.py.html>`__ to see an example of how to use change_external_container_database_compartment API.
+        """
+        resource_path = "/externalcontainerdatabases/{externalContainerDatabaseId}/actions/changeCompartment"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "opc_request_id",
+            "if_match"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "change_external_container_database_compartment got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "externalContainerDatabaseId": external_container_database_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_compartment_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_compartment_details)
+
+    def change_external_non_container_database_compartment(self, change_compartment_details, external_non_container_database_id, **kwargs):
+        """
+        Move the external non-container database and its dependent resources to the specified compartment.
+        For more information about moving external non-container databases, see
+        `Moving Database Resources to a Different Compartment`__.
+
+        __ https://docs.cloud.oracle.com/Content/Database/Concepts/databaseoverview.htm#moveRes
+
+
+        :param oci.database.models.ChangeCompartmentDetails change_compartment_details: (required)
+            Request to move the external non-container database to a different compartment.
+
+        :param str external_non_container_database_id: (required)
+            The external non-container database `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/database/change_external_non_container_database_compartment.py.html>`__ to see an example of how to use change_external_non_container_database_compartment API.
+        """
+        resource_path = "/externalnoncontainerdatabases/{externalNonContainerDatabaseId}/actions/changeCompartment"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "opc_request_id",
+            "if_match"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "change_external_non_container_database_compartment got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "externalNonContainerDatabaseId": external_non_container_database_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_compartment_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_compartment_details)
+
+    def change_external_pluggable_database_compartment(self, change_compartment_details, external_pluggable_database_id, **kwargs):
+        """
+        Move the :func:`create_external_pluggable_database_details` and
+        its dependent resources to the specified compartment.
+        For more information about moving external pluggable databases, see
+        `Moving Database Resources to a Different Compartment`__.
+
+        __ https://docs.cloud.oracle.com/Content/Database/Concepts/databaseoverview.htm#moveRes
+
+
+        :param oci.database.models.ChangeCompartmentDetails change_compartment_details: (required)
+            Request to move the
+            :func:`create_external_pluggable_database_details` resource
+            to a different compartment.
+
+        :param str external_pluggable_database_id: (required)
+            The ExternalPluggableDatabaseId `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/database/change_external_pluggable_database_compartment.py.html>`__ to see an example of how to use change_external_pluggable_database_compartment API.
+        """
+        resource_path = "/externalpluggabledatabases/{externalPluggableDatabaseId}/actions/changeCompartment"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "opc_request_id",
+            "if_match"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "change_external_pluggable_database_compartment got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "externalPluggableDatabaseId": external_pluggable_database_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_compartment_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_compartment_details)
+
     def change_key_store_compartment(self, change_key_store_compartment_details, key_store_id, **kwargs):
         """
         Move the key store resource to the specified compartment.
@@ -1495,6 +1805,101 @@ class DatabaseClient(object):
                 path_params=path_params,
                 header_params=header_params,
                 body=change_vm_cluster_compartment_details)
+
+    def check_external_database_connector_connection_status(self, external_database_connector_id, **kwargs):
+        """
+        Check the status of the external database connection specified in this connector.
+        This operation will refresh the connectionStatus and timeConnectionStatusLastUpdated fields.
+
+
+        :param str external_database_connector_id: (required)
+            The `OCID`__ of the
+            external database connector resource (`ExternalDatabaseConnectorId`).
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/database/check_external_database_connector_connection_status.py.html>`__ to see an example of how to use check_external_database_connector_connection_status API.
+        """
+        resource_path = "/externaldatabaseconnectors/{externalDatabaseConnectorId}/actions/checkConnectionStatus"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "opc_request_id",
+            "if_match"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "check_external_database_connector_connection_status got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "externalDatabaseConnectorId": external_database_connector_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
 
     def complete_external_backup_job(self, backup_id, complete_external_backup_job_details, **kwargs):
         """
@@ -2756,6 +3161,311 @@ class DatabaseClient(object):
                 header_params=header_params,
                 body=create_external_backup_job_details,
                 response_type="ExternalBackupJob")
+
+    def create_external_container_database(self, create_external_container_database_details, **kwargs):
+        """
+        Creates a new external container database resource.
+
+
+        :param oci.database.models.CreateExternalContainerDatabaseDetails create_external_container_database_details: (required)
+            Request to create a new external container database resource.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.ExternalContainerDatabase`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/database/create_external_container_database.py.html>`__ to see an example of how to use create_external_container_database API.
+        """
+        resource_path = "/externalcontainerdatabases"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "create_external_container_database got unknown kwargs: {!r}".format(extra_kwargs))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_external_container_database_details,
+                response_type="ExternalContainerDatabase")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_external_container_database_details,
+                response_type="ExternalContainerDatabase")
+
+    def create_external_database_connector(self, create_external_database_connector_details, **kwargs):
+        """
+        Creates a new external database connector.
+
+
+        :param oci.database.models.CreateExternalDatabaseConnectorDetails create_external_database_connector_details: (required)
+            Request to create a connector to an external database.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.ExternalDatabaseConnector`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/database/create_external_database_connector.py.html>`__ to see an example of how to use create_external_database_connector API.
+        """
+        resource_path = "/externaldatabaseconnectors"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "create_external_database_connector got unknown kwargs: {!r}".format(extra_kwargs))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_external_database_connector_details,
+                response_type="ExternalDatabaseConnector")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_external_database_connector_details,
+                response_type="ExternalDatabaseConnector")
+
+    def create_external_non_container_database(self, create_external_non_container_database_details, **kwargs):
+        """
+        Creates a new ExternalNonContainerDatabase resource
+
+
+        :param oci.database.models.CreateExternalNonContainerDatabaseDetails create_external_non_container_database_details: (required)
+            Request to create a new external non-container database.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.ExternalNonContainerDatabase`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/database/create_external_non_container_database.py.html>`__ to see an example of how to use create_external_non_container_database API.
+        """
+        resource_path = "/externalnoncontainerdatabases"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "create_external_non_container_database got unknown kwargs: {!r}".format(extra_kwargs))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_external_non_container_database_details,
+                response_type="ExternalNonContainerDatabase")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_external_non_container_database_details,
+                response_type="ExternalNonContainerDatabase")
+
+    def create_external_pluggable_database(self, create_external_pluggable_database_details, **kwargs):
+        """
+        Registers a new :func:`create_external_pluggable_database_details`
+        resource.
+
+
+        :param oci.database.models.CreateExternalPluggableDatabaseDetails create_external_pluggable_database_details: (required)
+            Request to create a new external pluggable database.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.ExternalPluggableDatabase`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/database/create_external_pluggable_database.py.html>`__ to see an example of how to use create_external_pluggable_database API.
+        """
+        resource_path = "/externalpluggabledatabases"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "create_external_pluggable_database got unknown kwargs: {!r}".format(extra_kwargs))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_external_pluggable_database_details,
+                response_type="ExternalPluggableDatabase")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_external_pluggable_database_details,
+                response_type="ExternalPluggableDatabase")
 
     def create_key_store(self, create_key_store_details, **kwargs):
         """
@@ -4049,6 +4759,340 @@ class DatabaseClient(object):
                 path_params=path_params,
                 header_params=header_params)
 
+    def delete_external_container_database(self, external_container_database_id, **kwargs):
+        """
+        Deletes the :func:`create_external_container_database_details`
+        resource. Any external pluggable databases registered under this container database must be deleted in
+        your Oracle Cloud Infrastructure tenancy prior to this operation.
+
+
+        :param str external_container_database_id: (required)
+            The ExternalContainerDatabase `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/database/delete_external_container_database.py.html>`__ to see an example of how to use delete_external_container_database API.
+        """
+        resource_path = "/externalcontainerdatabases/{externalContainerDatabaseId}"
+        method = "DELETE"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "if_match"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "delete_external_container_database got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "externalContainerDatabaseId": external_container_database_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
+    def delete_external_database_connector(self, external_database_connector_id, **kwargs):
+        """
+        Deletes an external database connector.
+        Any services enabled using the external database connector must be
+        deleted prior to this operation.
+
+
+        :param str external_database_connector_id: (required)
+            The `OCID`__ of the
+            external database connector resource (`ExternalDatabaseConnectorId`).
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/database/delete_external_database_connector.py.html>`__ to see an example of how to use delete_external_database_connector API.
+        """
+        resource_path = "/externaldatabaseconnectors/{externalDatabaseConnectorId}"
+        method = "DELETE"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "delete_external_database_connector got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "externalDatabaseConnectorId": external_database_connector_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
+    def delete_external_non_container_database(self, external_non_container_database_id, **kwargs):
+        """
+        Deletes the Oracle Cloud Infrastructure resource representing an external non-container database.
+
+
+        :param str external_non_container_database_id: (required)
+            The external non-container database `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/database/delete_external_non_container_database.py.html>`__ to see an example of how to use delete_external_non_container_database API.
+        """
+        resource_path = "/externalnoncontainerdatabases/{externalNonContainerDatabaseId}"
+        method = "DELETE"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "delete_external_non_container_database got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "externalNonContainerDatabaseId": external_non_container_database_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
+    def delete_external_pluggable_database(self, external_pluggable_database_id, **kwargs):
+        """
+        Deletes the :func:`create_external_pluggable_database_details`.
+        resource.
+
+
+        :param str external_pluggable_database_id: (required)
+            The ExternalPluggableDatabaseId `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/database/delete_external_pluggable_database.py.html>`__ to see an example of how to use delete_external_pluggable_database API.
+        """
+        resource_path = "/externalpluggabledatabases/{externalPluggableDatabaseId}"
+        method = "DELETE"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "if_match"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "delete_external_pluggable_database got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "externalPluggableDatabaseId": external_pluggable_database_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
     def delete_key_store(self, key_store_id, **kwargs):
         """
         Deletes a key store.
@@ -4458,6 +5502,293 @@ class DatabaseClient(object):
                 path_params=path_params,
                 header_params=header_params)
 
+    def disable_external_container_database_database_management(self, external_container_database_id, **kwargs):
+        """
+        Disable Database Management service for the external container database.
+
+
+        :param str external_container_database_id: (required)
+            The ExternalContainerDatabase `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/database/disable_external_container_database_database_management.py.html>`__ to see an example of how to use disable_external_container_database_database_management API.
+        """
+        resource_path = "/externalcontainerdatabases/{externalContainerDatabaseId}/actions/disableDatabaseManagement"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "opc_request_id",
+            "if_match"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "disable_external_container_database_database_management got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "externalContainerDatabaseId": external_container_database_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
+    def disable_external_non_container_database_database_management(self, external_non_container_database_id, **kwargs):
+        """
+        Disable Database Management Service for the external non-container database.
+        For more information about the Database Management Service, see
+        `Database Management Service`__.
+
+        __ https://docs.cloud.oracle.com/Content/ExternalDatabase/Concepts/databasemanagementservice.htm
+
+
+        :param str external_non_container_database_id: (required)
+            The external non-container database `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/database/disable_external_non_container_database_database_management.py.html>`__ to see an example of how to use disable_external_non_container_database_database_management API.
+        """
+        resource_path = "/externalnoncontainerdatabases/{externalNonContainerDatabaseId}/actions/disableDatabaseManagement"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "opc_request_id",
+            "if_match"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "disable_external_non_container_database_database_management got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "externalNonContainerDatabaseId": external_non_container_database_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
+    def disable_external_pluggable_database_database_management(self, external_pluggable_database_id, **kwargs):
+        """
+        Disable Database Management Service for the external pluggable database.
+        For more information about the Database Management Service, see
+        `Database Management Service`__.
+
+        __ https://docs.cloud.oracle.com/Content/ExternalDatabase/Concepts/databasemanagementservice.htm
+
+
+        :param str external_pluggable_database_id: (required)
+            The ExternalPluggableDatabaseId `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/database/disable_external_pluggable_database_database_management.py.html>`__ to see an example of how to use disable_external_pluggable_database_database_management API.
+        """
+        resource_path = "/externalpluggabledatabases/{externalPluggableDatabaseId}/actions/disableDatabaseManagement"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "opc_request_id",
+            "if_match"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "disable_external_pluggable_database_database_management got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "externalPluggableDatabaseId": external_pluggable_database_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
     def download_exadata_infrastructure_config_file(self, exadata_infrastructure_id, **kwargs):
         """
         Downloads the configuration file for the specified Exadata Cloud@Customer infrastructure.
@@ -4714,6 +6045,312 @@ class DatabaseClient(object):
                 method=method,
                 path_params=path_params,
                 header_params=header_params)
+
+    def enable_external_container_database_database_management(self, external_container_database_id, enable_external_container_database_database_management_details, **kwargs):
+        """
+        Enables Database Management Service for the external container database.
+        For more information about the Database Management Service, see
+        `Database Management Service`__.
+
+        __ https://docs.cloud.oracle.com/Content/ExternalDatabase/Concepts/databasemanagementservice.htm
+
+
+        :param str external_container_database_id: (required)
+            The ExternalContainerDatabase `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param oci.database.models.EnableExternalContainerDatabaseDatabaseManagementDetails enable_external_container_database_database_management_details: (required)
+            Request to enable the Database Management Service for an external container database.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/database/enable_external_container_database_database_management.py.html>`__ to see an example of how to use enable_external_container_database_database_management API.
+        """
+        resource_path = "/externalcontainerdatabases/{externalContainerDatabaseId}/actions/enableDatabaseManagement"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "opc_request_id",
+            "if_match"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "enable_external_container_database_database_management got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "externalContainerDatabaseId": external_container_database_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=enable_external_container_database_database_management_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=enable_external_container_database_database_management_details)
+
+    def enable_external_non_container_database_database_management(self, external_non_container_database_id, enable_external_non_container_database_database_management_details, **kwargs):
+        """
+        Enable Database Management Service for the external non-container database.
+        For more information about the Database Management Service, see
+        `Database Management Service`__.
+
+        __ https://docs.cloud.oracle.com/Content/ExternalDatabase/Concepts/databasemanagementservice.htm
+
+
+        :param str external_non_container_database_id: (required)
+            The external non-container database `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param oci.database.models.EnableExternalNonContainerDatabaseDatabaseManagementDetails enable_external_non_container_database_database_management_details: (required)
+            Request to enable the Database Management Service for an external non-container database.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/database/enable_external_non_container_database_database_management.py.html>`__ to see an example of how to use enable_external_non_container_database_database_management API.
+        """
+        resource_path = "/externalnoncontainerdatabases/{externalNonContainerDatabaseId}/actions/enableDatabaseManagement"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "opc_request_id",
+            "if_match"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "enable_external_non_container_database_database_management got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "externalNonContainerDatabaseId": external_non_container_database_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=enable_external_non_container_database_database_management_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=enable_external_non_container_database_database_management_details)
+
+    def enable_external_pluggable_database_database_management(self, external_pluggable_database_id, enable_external_pluggable_database_database_management_details, **kwargs):
+        """
+        Enable Database Management Service for the external pluggable database.
+        For more information about the Database Management Service, see
+        `Database Management Service`__.
+
+        __ https://docs.cloud.oracle.com/Content/ExternalDatabase/Concepts/databasemanagementservice.htm
+
+
+        :param str external_pluggable_database_id: (required)
+            The ExternalPluggableDatabaseId `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param oci.database.models.EnableExternalPluggableDatabaseDatabaseManagementDetails enable_external_pluggable_database_database_management_details: (required)
+            Request to enable the Database Management Service for an external database.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/database/enable_external_pluggable_database_database_management.py.html>`__ to see an example of how to use enable_external_pluggable_database_database_management API.
+        """
+        resource_path = "/externalpluggabledatabases/{externalPluggableDatabaseId}/actions/enableDatabaseManagement"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "opc_request_id",
+            "if_match"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "enable_external_pluggable_database_database_management got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "externalPluggableDatabaseId": external_pluggable_database_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=enable_external_pluggable_database_database_management_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=enable_external_pluggable_database_database_management_details)
 
     def fail_over_autonomous_database(self, autonomous_database_id, **kwargs):
         """
@@ -7636,6 +9273,316 @@ class DatabaseClient(object):
                 header_params=header_params,
                 response_type="ExternalBackupJob")
 
+    def get_external_container_database(self, external_container_database_id, **kwargs):
+        """
+        Gets information about the specified external container database.
+
+
+        :param str external_container_database_id: (required)
+            The ExternalContainerDatabase `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.ExternalContainerDatabase`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/database/get_external_container_database.py.html>`__ to see an example of how to use get_external_container_database API.
+        """
+        resource_path = "/externalcontainerdatabases/{externalContainerDatabaseId}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_external_container_database got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "externalContainerDatabaseId": external_container_database_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="ExternalContainerDatabase")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="ExternalContainerDatabase")
+
+    def get_external_database_connector(self, external_database_connector_id, **kwargs):
+        """
+        Gets information about the specified external database connector.
+
+
+        :param str external_database_connector_id: (required)
+            The `OCID`__ of the
+            external database connector resource (`ExternalDatabaseConnectorId`).
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.ExternalDatabaseConnector`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/database/get_external_database_connector.py.html>`__ to see an example of how to use get_external_database_connector API.
+        """
+        resource_path = "/externaldatabaseconnectors/{externalDatabaseConnectorId}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_external_database_connector got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "externalDatabaseConnectorId": external_database_connector_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="ExternalDatabaseConnector")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="ExternalDatabaseConnector")
+
+    def get_external_non_container_database(self, external_non_container_database_id, **kwargs):
+        """
+        Gets information about a specific external non-container database.
+
+
+        :param str external_non_container_database_id: (required)
+            The external non-container database `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.ExternalNonContainerDatabase`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/database/get_external_non_container_database.py.html>`__ to see an example of how to use get_external_non_container_database API.
+        """
+        resource_path = "/externalnoncontainerdatabases/{externalNonContainerDatabaseId}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_external_non_container_database got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "externalNonContainerDatabaseId": external_non_container_database_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="ExternalNonContainerDatabase")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="ExternalNonContainerDatabase")
+
+    def get_external_pluggable_database(self, external_pluggable_database_id, **kwargs):
+        """
+        Gets information about a specific
+        :func:`create_external_pluggable_database_details` resource.
+
+
+        :param str external_pluggable_database_id: (required)
+            The ExternalPluggableDatabaseId `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.ExternalPluggableDatabase`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/database/get_external_pluggable_database.py.html>`__ to see an example of how to use get_external_pluggable_database API.
+        """
+        resource_path = "/externalpluggabledatabases/{externalPluggableDatabaseId}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_external_pluggable_database got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "externalPluggableDatabaseId": external_pluggable_database_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="ExternalPluggableDatabase")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="ExternalPluggableDatabase")
+
     def get_key_store(self, key_store_id, **kwargs):
         """
         Gets information about the specified key store.
@@ -9965,7 +11912,7 @@ class DatabaseClient(object):
         :param str update_type: (optional)
             A filter to return only resources that match the given update type exactly.
 
-            Allowed values are: "GI_UPGRADE", "GI_PATCH"
+            Allowed values are: "GI_UPGRADE", "GI_PATCH", "OS_UPDATE"
 
         :param int limit: (optional)
             The maximum number of items to return per page.
@@ -10017,7 +11964,7 @@ class DatabaseClient(object):
                 raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
 
         if 'update_type' in kwargs:
-            update_type_allowed_values = ["GI_UPGRADE", "GI_PATCH"]
+            update_type_allowed_values = ["GI_UPGRADE", "GI_PATCH", "OS_UPDATE"]
             if kwargs['update_type'] not in update_type_allowed_values:
                 raise ValueError(
                     "Invalid value for `update_type`, must be one of {0}".format(update_type_allowed_values)
@@ -10072,7 +12019,7 @@ class DatabaseClient(object):
         :param str update_type: (optional)
             A filter to return only resources that match the given update type exactly.
 
-            Allowed values are: "GI_UPGRADE", "GI_PATCH"
+            Allowed values are: "GI_UPGRADE", "GI_PATCH", "OS_UPDATE"
 
         :param int limit: (optional)
             The maximum number of items to return per page.
@@ -10124,7 +12071,7 @@ class DatabaseClient(object):
                 raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
 
         if 'update_type' in kwargs:
-            update_type_allowed_values = ["GI_UPGRADE", "GI_PATCH"]
+            update_type_allowed_values = ["GI_UPGRADE", "GI_PATCH", "OS_UPDATE"]
             if kwargs['update_type'] not in update_type_allowed_values:
                 raise ValueError(
                     "Invalid value for `update_type`, must be one of {0}".format(update_type_allowed_values)
@@ -12082,6 +14029,548 @@ class DatabaseClient(object):
                 query_params=query_params,
                 header_params=header_params,
                 response_type="list[ExadataInfrastructureSummary]")
+
+    def list_external_container_databases(self, compartment_id, **kwargs):
+        """
+        Gets a list of the external container databases in the specified compartment.
+
+
+        :param str compartment_id: (required)
+            The compartment `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param int limit: (optional)
+            The maximum number of items to return per page.
+
+        :param str page: (optional)
+            The pagination token to continue listing from.
+
+        :param str sort_by: (optional)
+            The field to sort by. You can provide one sort order (`sortOrder`).
+            Default order for TIMECREATED is descending.
+            Default order for DISPLAYNAME is ascending.
+            The DISPLAYNAME sort order is case sensitive.
+
+            Allowed values are: "DISPLAYNAME", "TIMECREATED"
+
+        :param str sort_order: (optional)
+            The sort order to use, either ascending (`ASC`) or descending (`DESC`).
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str lifecycle_state: (optional)
+            A filter to return only resources that match the specified lifecycle state.
+
+            Allowed values are: "PROVISIONING", "NOT_CONNECTED", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED"
+
+        :param str display_name: (optional)
+            A filter to return only resources that match the entire display name given. The match is not case sensitive.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.database.models.ExternalContainerDatabaseSummary`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/database/list_external_container_databases.py.html>`__ to see an example of how to use list_external_container_databases API.
+        """
+        resource_path = "/externalcontainerdatabases"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "limit",
+            "page",
+            "sort_by",
+            "sort_order",
+            "lifecycle_state",
+            "display_name"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_external_container_databases got unknown kwargs: {!r}".format(extra_kwargs))
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["DISPLAYNAME", "TIMECREATED"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'lifecycle_state' in kwargs:
+            lifecycle_state_allowed_values = ["PROVISIONING", "NOT_CONNECTED", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED"]
+            if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
+                raise ValueError(
+                    "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
+                )
+
+        query_params = {
+            "compartmentId": compartment_id,
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortBy": kwargs.get("sort_by", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "lifecycleState": kwargs.get("lifecycle_state", missing),
+            "displayName": kwargs.get("display_name", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[ExternalContainerDatabaseSummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[ExternalContainerDatabaseSummary]")
+
+    def list_external_database_connectors(self, compartment_id, external_database_id, **kwargs):
+        """
+        Gets a list of the external database connectors in the specified compartment.
+
+
+        :param str compartment_id: (required)
+            The compartment `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str external_database_id: (required)
+            The `OCID`__ of the external database whose connectors will be listed.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param int limit: (optional)
+            The maximum number of items to return per page.
+
+        :param str page: (optional)
+            The pagination token to continue listing from.
+
+        :param str sort_by: (optional)
+            The field to sort by. You can provide one sort order (`sortOrder`).
+            Default order for TIMECREATED is descending.
+            Default order for DISPLAYNAME is ascending.
+            The DISPLAYNAME sort order is case sensitive.
+
+            Allowed values are: "DISPLAYNAME", "TIMECREATED"
+
+        :param str sort_order: (optional)
+            The sort order to use, either ascending (`ASC`) or descending (`DESC`).
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str lifecycle_state: (optional)
+            A filter to return only resources that match the specified lifecycle state.
+
+            Allowed values are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED"
+
+        :param str display_name: (optional)
+            A filter to return only resources that match the entire display name given. The match is not case sensitive.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.database.models.ExternalDatabaseConnectorSummary`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/database/list_external_database_connectors.py.html>`__ to see an example of how to use list_external_database_connectors API.
+        """
+        resource_path = "/externaldatabaseconnectors"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "limit",
+            "page",
+            "sort_by",
+            "sort_order",
+            "lifecycle_state",
+            "display_name"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_external_database_connectors got unknown kwargs: {!r}".format(extra_kwargs))
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["DISPLAYNAME", "TIMECREATED"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'lifecycle_state' in kwargs:
+            lifecycle_state_allowed_values = ["PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED"]
+            if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
+                raise ValueError(
+                    "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
+                )
+
+        query_params = {
+            "compartmentId": compartment_id,
+            "externalDatabaseId": external_database_id,
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortBy": kwargs.get("sort_by", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "lifecycleState": kwargs.get("lifecycle_state", missing),
+            "displayName": kwargs.get("display_name", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[ExternalDatabaseConnectorSummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[ExternalDatabaseConnectorSummary]")
+
+    def list_external_non_container_databases(self, compartment_id, **kwargs):
+        """
+        Gets a list of the ExternalNonContainerDatabases in the specified compartment.
+
+
+        :param str compartment_id: (required)
+            The compartment `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param int limit: (optional)
+            The maximum number of items to return per page.
+
+        :param str page: (optional)
+            The pagination token to continue listing from.
+
+        :param str sort_by: (optional)
+            The field to sort by. You can provide one sort order (`sortOrder`).
+            Default order for TIMECREATED is descending.
+            Default order for DISPLAYNAME is ascending.
+            The DISPLAYNAME sort order is case sensitive.
+
+            Allowed values are: "DISPLAYNAME", "TIMECREATED"
+
+        :param str sort_order: (optional)
+            The sort order to use, either ascending (`ASC`) or descending (`DESC`).
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str lifecycle_state: (optional)
+            A filter to return only resources that match the specified lifecycle state.
+
+            Allowed values are: "PROVISIONING", "NOT_CONNECTED", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED"
+
+        :param str display_name: (optional)
+            A filter to return only resources that match the entire display name given. The match is not case sensitive.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.database.models.ExternalNonContainerDatabaseSummary`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/database/list_external_non_container_databases.py.html>`__ to see an example of how to use list_external_non_container_databases API.
+        """
+        resource_path = "/externalnoncontainerdatabases"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "limit",
+            "page",
+            "sort_by",
+            "sort_order",
+            "lifecycle_state",
+            "display_name"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_external_non_container_databases got unknown kwargs: {!r}".format(extra_kwargs))
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["DISPLAYNAME", "TIMECREATED"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'lifecycle_state' in kwargs:
+            lifecycle_state_allowed_values = ["PROVISIONING", "NOT_CONNECTED", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED"]
+            if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
+                raise ValueError(
+                    "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
+                )
+
+        query_params = {
+            "compartmentId": compartment_id,
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortBy": kwargs.get("sort_by", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "lifecycleState": kwargs.get("lifecycle_state", missing),
+            "displayName": kwargs.get("display_name", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[ExternalNonContainerDatabaseSummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[ExternalNonContainerDatabaseSummary]")
+
+    def list_external_pluggable_databases(self, compartment_id, **kwargs):
+        """
+        Gets a list of the :func:`create_external_pluggable_database_details`
+        resources in the specified compartment.
+
+
+        :param str compartment_id: (required)
+            The compartment `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param str external_container_database_id: (optional)
+            The ExternalContainerDatabase `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param int limit: (optional)
+            The maximum number of items to return per page.
+
+        :param str page: (optional)
+            The pagination token to continue listing from.
+
+        :param str sort_by: (optional)
+            The field to sort by. You can provide one sort order (`sortOrder`).
+            Default order for TIMECREATED is descending.
+            Default order for DISPLAYNAME is ascending.
+            The DISPLAYNAME sort order is case sensitive.
+
+            Allowed values are: "DISPLAYNAME", "TIMECREATED"
+
+        :param str sort_order: (optional)
+            The sort order to use, either ascending (`ASC`) or descending (`DESC`).
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str lifecycle_state: (optional)
+            A filter to return only resources that match the specified lifecycle state.
+
+            Allowed values are: "PROVISIONING", "NOT_CONNECTED", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED"
+
+        :param str display_name: (optional)
+            A filter to return only resources that match the entire display name given. The match is not case sensitive.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.database.models.ExternalPluggableDatabaseSummary`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/database/list_external_pluggable_databases.py.html>`__ to see an example of how to use list_external_pluggable_databases API.
+        """
+        resource_path = "/externalpluggabledatabases"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "external_container_database_id",
+            "limit",
+            "page",
+            "sort_by",
+            "sort_order",
+            "lifecycle_state",
+            "display_name"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_external_pluggable_databases got unknown kwargs: {!r}".format(extra_kwargs))
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["DISPLAYNAME", "TIMECREATED"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'lifecycle_state' in kwargs:
+            lifecycle_state_allowed_values = ["PROVISIONING", "NOT_CONNECTED", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED"]
+            if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
+                raise ValueError(
+                    "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
+                )
+
+        query_params = {
+            "compartmentId": compartment_id,
+            "externalContainerDatabaseId": kwargs.get("external_container_database_id", missing),
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortBy": kwargs.get("sort_by", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "lifecycleState": kwargs.get("lifecycle_state", missing),
+            "displayName": kwargs.get("display_name", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[ExternalPluggableDatabaseSummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[ExternalPluggableDatabaseSummary]")
 
     def list_flex_components(self, compartment_id, **kwargs):
         """
@@ -14246,6 +16735,106 @@ class DatabaseClient(object):
                 header_params=header_params,
                 response_type="Database")
 
+    def scan_external_container_database_pluggable_databases(self, external_container_database_id, external_database_connector_id, **kwargs):
+        """
+        Scans for pluggable databases in the specified external container database.
+        This operation will return un-registered pluggable databases in the `GetWorkRequest` operation.
+
+
+        :param str external_container_database_id: (required)
+            The ExternalContainerDatabase `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str external_database_connector_id: (required)
+            The `OCID`__ of the
+            external database connector resource (`ExternalDatabaseConnectorId`).
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/database/scan_external_container_database_pluggable_databases.py.html>`__ to see an example of how to use scan_external_container_database_pluggable_databases API.
+        """
+        resource_path = "/externalcontainerdatabases/{externalContainerDatabaseId}/actions/scanPluggableDatabases"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "scan_external_container_database_pluggable_databases got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "externalContainerDatabaseId": external_container_database_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        query_params = {
+            "externalDatabaseConnectorId": external_database_connector_id
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params)
+
     def start_autonomous_database(self, autonomous_database_id, **kwargs):
         """
         Starts the specified Autonomous Database.
@@ -16301,6 +18890,368 @@ class DatabaseClient(object):
                 header_params=header_params,
                 body=exadata_iorm_config_update_details,
                 response_type="ExadataIormConfig")
+
+    def update_external_container_database(self, external_container_database_id, update_external_container_database_details, **kwargs):
+        """
+        Updates the properties of
+        an :func:`create_external_container_database_details` resource,
+        such as the display name.
+
+
+        :param str external_container_database_id: (required)
+            The ExternalContainerDatabase `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param oci.database.models.UpdateExternalContainerDatabaseDetails update_external_container_database_details: (required)
+            Request to update the properties of an
+            :func:`create_external_container_database_details` resource.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.ExternalContainerDatabase`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/database/update_external_container_database.py.html>`__ to see an example of how to use update_external_container_database API.
+        """
+        resource_path = "/externalcontainerdatabases/{externalContainerDatabaseId}"
+        method = "PUT"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "update_external_container_database got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "externalContainerDatabaseId": external_container_database_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_external_container_database_details,
+                response_type="ExternalContainerDatabase")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_external_container_database_details,
+                response_type="ExternalContainerDatabase")
+
+    def update_external_database_connector(self, external_database_connector_id, update_external_database_connector_details, **kwargs):
+        """
+        Updates the properties of an external database connector, such as the display name.
+
+
+        :param str external_database_connector_id: (required)
+            The `OCID`__ of the
+            external database connector resource (`ExternalDatabaseConnectorId`).
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param oci.database.models.UpdateExternalDatabaseConnectorDetails update_external_database_connector_details: (required)
+            Request to update the properties of an external database connector.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.ExternalDatabaseConnector`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/database/update_external_database_connector.py.html>`__ to see an example of how to use update_external_database_connector API.
+        """
+        resource_path = "/externaldatabaseconnectors/{externalDatabaseConnectorId}"
+        method = "PUT"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "update_external_database_connector got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "externalDatabaseConnectorId": external_database_connector_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_external_database_connector_details,
+                response_type="ExternalDatabaseConnector")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_external_database_connector_details,
+                response_type="ExternalDatabaseConnector")
+
+    def update_external_non_container_database(self, external_non_container_database_id, update_external_non_container_database_details, **kwargs):
+        """
+        Updates the properties of an external non-container database, such as the display name.
+
+
+        :param str external_non_container_database_id: (required)
+            The external non-container database `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param oci.database.models.UpdateExternalNonContainerDatabaseDetails update_external_non_container_database_details: (required)
+            Request to update the properties of an external non-container database.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.ExternalNonContainerDatabase`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/database/update_external_non_container_database.py.html>`__ to see an example of how to use update_external_non_container_database API.
+        """
+        resource_path = "/externalnoncontainerdatabases/{externalNonContainerDatabaseId}"
+        method = "PUT"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "update_external_non_container_database got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "externalNonContainerDatabaseId": external_non_container_database_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_external_non_container_database_details,
+                response_type="ExternalNonContainerDatabase")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_external_non_container_database_details,
+                response_type="ExternalNonContainerDatabase")
+
+    def update_external_pluggable_database(self, external_pluggable_database_id, update_external_pluggable_database_details, **kwargs):
+        """
+        Updates the properties of an
+        :func:`create_external_pluggable_database_details` resource,
+        such as the display name.
+
+
+        :param str external_pluggable_database_id: (required)
+            The ExternalPluggableDatabaseId `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param oci.database.models.UpdateExternalPluggableDatabaseDetails update_external_pluggable_database_details: (required)
+            Request to update the properties of an external pluggable database resource.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.database.models.ExternalPluggableDatabase`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/database/update_external_pluggable_database.py.html>`__ to see an example of how to use update_external_pluggable_database API.
+        """
+        resource_path = "/externalpluggabledatabases/{externalPluggableDatabaseId}"
+        method = "PUT"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "update_external_pluggable_database got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "externalPluggableDatabaseId": external_pluggable_database_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_external_pluggable_database_details,
+                response_type="ExternalPluggableDatabase")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_external_pluggable_database_details,
+                response_type="ExternalPluggableDatabase")
 
     def update_key_store(self, key_store_id, update_key_store_details, **kwargs):
         """

--- a/src/oci/database/database_client_composite_operations.py
+++ b/src/oci/database/database_client_composite_operations.py
@@ -600,6 +600,128 @@ class DatabaseClientCompositeOperations(object):
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
+    def change_external_container_database_compartment_and_wait_for_work_request(self, change_compartment_details, external_container_database_id, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.change_external_container_database_compartment` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param oci.database.models.ChangeCompartmentDetails change_compartment_details: (required)
+            Request to move the external container database to a different compartment.
+
+        :param str external_container_database_id: (required)
+            The ExternalContainerDatabase `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.change_external_container_database_compartment`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.change_external_container_database_compartment(change_compartment_details, external_container_database_id, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def change_external_non_container_database_compartment_and_wait_for_work_request(self, change_compartment_details, external_non_container_database_id, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.change_external_non_container_database_compartment` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param oci.database.models.ChangeCompartmentDetails change_compartment_details: (required)
+            Request to move the external non-container database to a different compartment.
+
+        :param str external_non_container_database_id: (required)
+            The external non-container database `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.change_external_non_container_database_compartment`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.change_external_non_container_database_compartment(change_compartment_details, external_non_container_database_id, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def change_external_pluggable_database_compartment_and_wait_for_work_request(self, change_compartment_details, external_pluggable_database_id, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.change_external_pluggable_database_compartment` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param oci.database.models.ChangeCompartmentDetails change_compartment_details: (required)
+            Request to move the
+            :func:`create_external_pluggable_database_details` resource
+            to a different compartment.
+
+        :param str external_pluggable_database_id: (required)
+            The ExternalPluggableDatabaseId `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.change_external_pluggable_database_compartment`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.change_external_pluggable_database_compartment(change_compartment_details, external_pluggable_database_id, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def change_key_store_compartment_and_wait_for_work_request(self, change_key_store_compartment_details, key_store_id, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.database.DatabaseClient.change_key_store_compartment` and waits for the oci.work_requests.models.WorkRequest
@@ -665,6 +787,44 @@ class DatabaseClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         operation_result = self.client.change_vm_cluster_compartment(change_vm_cluster_compartment_details, vm_cluster_id, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def check_external_database_connector_connection_status_and_wait_for_work_request(self, external_database_connector_id, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.check_external_database_connector_connection_status` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str external_database_connector_id: (required)
+            The `OCID`__ of the
+            external database connector resource (`ExternalDatabaseConnectorId`).
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.check_external_database_connector_connection_status`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.check_external_database_connector_connection_status(external_database_connector_id, **operation_kwargs)
         work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
         lowered_work_request_states = [w.lower() for w in work_request_states]
         work_request_id = operation_result.headers['opc-work-request-id']
@@ -1730,6 +1890,298 @@ class DatabaseClientCompositeOperations(object):
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
+    def create_external_container_database_and_wait_for_work_request(self, create_external_container_database_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.create_external_container_database` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param oci.database.models.CreateExternalContainerDatabaseDetails create_external_container_database_details: (required)
+            Request to create a new external container database resource.
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.create_external_container_database`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.create_external_container_database(create_external_container_database_details, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def create_external_container_database_and_wait_for_state(self, create_external_container_database_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.create_external_container_database` and waits for the :py:class:`~oci.database.models.ExternalContainerDatabase` acted upon
+        to enter the given state(s).
+
+        :param oci.database.models.CreateExternalContainerDatabaseDetails create_external_container_database_details: (required)
+            Request to create a new external container database resource.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.database.models.ExternalContainerDatabase.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.create_external_container_database`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.create_external_container_database(create_external_container_database_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_external_container_database(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def create_external_database_connector_and_wait_for_work_request(self, create_external_database_connector_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.create_external_database_connector` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param oci.database.models.CreateExternalDatabaseConnectorDetails create_external_database_connector_details: (required)
+            Request to create a connector to an external database.
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.create_external_database_connector`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.create_external_database_connector(create_external_database_connector_details, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def create_external_database_connector_and_wait_for_state(self, create_external_database_connector_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.create_external_database_connector` and waits for the :py:class:`~oci.database.models.ExternalDatabaseConnector` acted upon
+        to enter the given state(s).
+
+        :param oci.database.models.CreateExternalDatabaseConnectorDetails create_external_database_connector_details: (required)
+            Request to create a connector to an external database.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.database.models.ExternalDatabaseConnector.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.create_external_database_connector`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.create_external_database_connector(create_external_database_connector_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_external_database_connector(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def create_external_non_container_database_and_wait_for_work_request(self, create_external_non_container_database_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.create_external_non_container_database` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param oci.database.models.CreateExternalNonContainerDatabaseDetails create_external_non_container_database_details: (required)
+            Request to create a new external non-container database.
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.create_external_non_container_database`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.create_external_non_container_database(create_external_non_container_database_details, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def create_external_non_container_database_and_wait_for_state(self, create_external_non_container_database_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.create_external_non_container_database` and waits for the :py:class:`~oci.database.models.ExternalNonContainerDatabase` acted upon
+        to enter the given state(s).
+
+        :param oci.database.models.CreateExternalNonContainerDatabaseDetails create_external_non_container_database_details: (required)
+            Request to create a new external non-container database.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.database.models.ExternalNonContainerDatabase.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.create_external_non_container_database`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.create_external_non_container_database(create_external_non_container_database_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_external_non_container_database(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def create_external_pluggable_database_and_wait_for_work_request(self, create_external_pluggable_database_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.create_external_pluggable_database` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param oci.database.models.CreateExternalPluggableDatabaseDetails create_external_pluggable_database_details: (required)
+            Request to create a new external pluggable database.
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.create_external_pluggable_database`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.create_external_pluggable_database(create_external_pluggable_database_details, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def create_external_pluggable_database_and_wait_for_state(self, create_external_pluggable_database_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.create_external_pluggable_database` and waits for the :py:class:`~oci.database.models.ExternalPluggableDatabase` acted upon
+        to enter the given state(s).
+
+        :param oci.database.models.CreateExternalPluggableDatabaseDetails create_external_pluggable_database_details: (required)
+            Request to create a new external pluggable database.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.database.models.ExternalPluggableDatabase.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.create_external_pluggable_database`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.create_external_pluggable_database(create_external_pluggable_database_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_external_pluggable_database(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def create_key_store_and_wait_for_state(self, create_key_store_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.database.DatabaseClient.create_key_store` and waits for the :py:class:`~oci.database.models.KeyStore` acted upon
@@ -2395,6 +2847,155 @@ class DatabaseClientCompositeOperations(object):
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
+    def delete_external_container_database_and_wait_for_work_request(self, external_container_database_id, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.delete_external_container_database` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str external_container_database_id: (required)
+            The ExternalContainerDatabase `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.delete_external_container_database`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.delete_external_container_database(external_container_database_id, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def delete_external_database_connector_and_wait_for_work_request(self, external_database_connector_id, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.delete_external_database_connector` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str external_database_connector_id: (required)
+            The `OCID`__ of the
+            external database connector resource (`ExternalDatabaseConnectorId`).
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.delete_external_database_connector`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.delete_external_database_connector(external_database_connector_id, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def delete_external_non_container_database_and_wait_for_work_request(self, external_non_container_database_id, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.delete_external_non_container_database` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str external_non_container_database_id: (required)
+            The external non-container database `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.delete_external_non_container_database`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.delete_external_non_container_database(external_non_container_database_id, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def delete_external_pluggable_database_and_wait_for_work_request(self, external_pluggable_database_id, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.delete_external_pluggable_database` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str external_pluggable_database_id: (required)
+            The ExternalPluggableDatabaseId `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.delete_external_pluggable_database`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.delete_external_pluggable_database(external_pluggable_database_id, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def delete_key_store_and_wait_for_state(self, key_store_id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.database.DatabaseClient.delete_key_store` and waits for the :py:class:`~oci.database.models.KeyStore` acted upon
@@ -2597,6 +3198,117 @@ class DatabaseClientCompositeOperations(object):
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
+    def disable_external_container_database_database_management_and_wait_for_work_request(self, external_container_database_id, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.disable_external_container_database_database_management` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str external_container_database_id: (required)
+            The ExternalContainerDatabase `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.disable_external_container_database_database_management`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.disable_external_container_database_database_management(external_container_database_id, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def disable_external_non_container_database_database_management_and_wait_for_work_request(self, external_non_container_database_id, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.disable_external_non_container_database_database_management` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str external_non_container_database_id: (required)
+            The external non-container database `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.disable_external_non_container_database_database_management`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.disable_external_non_container_database_database_management(external_non_container_database_id, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def disable_external_pluggable_database_database_management_and_wait_for_work_request(self, external_pluggable_database_id, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.disable_external_pluggable_database_database_management` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str external_pluggable_database_id: (required)
+            The ExternalPluggableDatabaseId `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.disable_external_pluggable_database_database_management`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.disable_external_pluggable_database_database_management(external_pluggable_database_id, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def enable_autonomous_database_operations_insights_and_wait_for_work_request(self, autonomous_database_id, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.database.DatabaseClient.enable_autonomous_database_operations_insights` and waits for the oci.work_requests.models.WorkRequest
@@ -2619,6 +3331,126 @@ class DatabaseClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         operation_result = self.client.enable_autonomous_database_operations_insights(autonomous_database_id, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def enable_external_container_database_database_management_and_wait_for_work_request(self, external_container_database_id, enable_external_container_database_database_management_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.enable_external_container_database_database_management` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str external_container_database_id: (required)
+            The ExternalContainerDatabase `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param oci.database.models.EnableExternalContainerDatabaseDatabaseManagementDetails enable_external_container_database_database_management_details: (required)
+            Request to enable the Database Management Service for an external container database.
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.enable_external_container_database_database_management`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.enable_external_container_database_database_management(external_container_database_id, enable_external_container_database_database_management_details, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def enable_external_non_container_database_database_management_and_wait_for_work_request(self, external_non_container_database_id, enable_external_non_container_database_database_management_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.enable_external_non_container_database_database_management` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str external_non_container_database_id: (required)
+            The external non-container database `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param oci.database.models.EnableExternalNonContainerDatabaseDatabaseManagementDetails enable_external_non_container_database_database_management_details: (required)
+            Request to enable the Database Management Service for an external non-container database.
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.enable_external_non_container_database_database_management`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.enable_external_non_container_database_database_management(external_non_container_database_id, enable_external_non_container_database_database_management_details, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def enable_external_pluggable_database_database_management_and_wait_for_work_request(self, external_pluggable_database_id, enable_external_pluggable_database_database_management_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.enable_external_pluggable_database_database_management` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str external_pluggable_database_id: (required)
+            The ExternalPluggableDatabaseId `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param oci.database.models.EnableExternalPluggableDatabaseDatabaseManagementDetails enable_external_pluggable_database_database_management_details: (required)
+            Request to enable the Database Management Service for an external database.
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.enable_external_pluggable_database_database_management`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.enable_external_pluggable_database_database_management(external_pluggable_database_id, enable_external_pluggable_database_database_management_details, **operation_kwargs)
         work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
         lowered_work_request_states = [w.lower() for w in work_request_states]
         work_request_id = operation_result.headers['opc-work-request-id']
@@ -4010,6 +4842,49 @@ class DatabaseClientCompositeOperations(object):
             result_to_return = waiter_result
 
             return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def scan_external_container_database_pluggable_databases_and_wait_for_work_request(self, external_container_database_id, external_database_connector_id, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.scan_external_container_database_pluggable_databases` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str external_container_database_id: (required)
+            The ExternalContainerDatabase `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str external_database_connector_id: (required)
+            The `OCID`__ of the
+            external database connector resource (`ExternalDatabaseConnectorId`).
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.scan_external_container_database_pluggable_databases`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.scan_external_container_database_pluggable_databases(external_container_database_id, external_database_connector_id, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
@@ -5641,6 +6516,342 @@ class DatabaseClientCompositeOperations(object):
             waiter_result = oci.wait_until(
                 self.client,
                 self.client.get_exadata_iorm_config(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def update_external_container_database_and_wait_for_work_request(self, external_container_database_id, update_external_container_database_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.update_external_container_database` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str external_container_database_id: (required)
+            The ExternalContainerDatabase `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param oci.database.models.UpdateExternalContainerDatabaseDetails update_external_container_database_details: (required)
+            Request to update the properties of an
+            :func:`create_external_container_database_details` resource.
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.update_external_container_database`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_external_container_database(external_container_database_id, update_external_container_database_details, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def update_external_container_database_and_wait_for_state(self, external_container_database_id, update_external_container_database_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.update_external_container_database` and waits for the :py:class:`~oci.database.models.ExternalContainerDatabase` acted upon
+        to enter the given state(s).
+
+        :param str external_container_database_id: (required)
+            The ExternalContainerDatabase `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param oci.database.models.UpdateExternalContainerDatabaseDetails update_external_container_database_details: (required)
+            Request to update the properties of an
+            :func:`create_external_container_database_details` resource.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.database.models.ExternalContainerDatabase.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.update_external_container_database`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_external_container_database(external_container_database_id, update_external_container_database_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_external_container_database(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def update_external_database_connector_and_wait_for_work_request(self, external_database_connector_id, update_external_database_connector_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.update_external_database_connector` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str external_database_connector_id: (required)
+            The `OCID`__ of the
+            external database connector resource (`ExternalDatabaseConnectorId`).
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param oci.database.models.UpdateExternalDatabaseConnectorDetails update_external_database_connector_details: (required)
+            Request to update the properties of an external database connector.
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.update_external_database_connector`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_external_database_connector(external_database_connector_id, update_external_database_connector_details, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def update_external_database_connector_and_wait_for_state(self, external_database_connector_id, update_external_database_connector_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.update_external_database_connector` and waits for the :py:class:`~oci.database.models.ExternalDatabaseConnector` acted upon
+        to enter the given state(s).
+
+        :param str external_database_connector_id: (required)
+            The `OCID`__ of the
+            external database connector resource (`ExternalDatabaseConnectorId`).
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param oci.database.models.UpdateExternalDatabaseConnectorDetails update_external_database_connector_details: (required)
+            Request to update the properties of an external database connector.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.database.models.ExternalDatabaseConnector.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.update_external_database_connector`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_external_database_connector(external_database_connector_id, update_external_database_connector_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_external_database_connector(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def update_external_non_container_database_and_wait_for_work_request(self, external_non_container_database_id, update_external_non_container_database_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.update_external_non_container_database` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str external_non_container_database_id: (required)
+            The external non-container database `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param oci.database.models.UpdateExternalNonContainerDatabaseDetails update_external_non_container_database_details: (required)
+            Request to update the properties of an external non-container database.
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.update_external_non_container_database`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_external_non_container_database(external_non_container_database_id, update_external_non_container_database_details, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def update_external_non_container_database_and_wait_for_state(self, external_non_container_database_id, update_external_non_container_database_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.update_external_non_container_database` and waits for the :py:class:`~oci.database.models.ExternalNonContainerDatabase` acted upon
+        to enter the given state(s).
+
+        :param str external_non_container_database_id: (required)
+            The external non-container database `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param oci.database.models.UpdateExternalNonContainerDatabaseDetails update_external_non_container_database_details: (required)
+            Request to update the properties of an external non-container database.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.database.models.ExternalNonContainerDatabase.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.update_external_non_container_database`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_external_non_container_database(external_non_container_database_id, update_external_non_container_database_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_external_non_container_database(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def update_external_pluggable_database_and_wait_for_work_request(self, external_pluggable_database_id, update_external_pluggable_database_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.update_external_pluggable_database` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str external_pluggable_database_id: (required)
+            The ExternalPluggableDatabaseId `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param oci.database.models.UpdateExternalPluggableDatabaseDetails update_external_pluggable_database_details: (required)
+            Request to update the properties of an external pluggable database resource.
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.update_external_pluggable_database`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_external_pluggable_database(external_pluggable_database_id, update_external_pluggable_database_details, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def update_external_pluggable_database_and_wait_for_state(self, external_pluggable_database_id, update_external_pluggable_database_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.update_external_pluggable_database` and waits for the :py:class:`~oci.database.models.ExternalPluggableDatabase` acted upon
+        to enter the given state(s).
+
+        :param str external_pluggable_database_id: (required)
+            The ExternalPluggableDatabaseId `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param oci.database.models.UpdateExternalPluggableDatabaseDetails update_external_pluggable_database_details: (required)
+            Request to update the properties of an external pluggable database resource.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.database.models.ExternalPluggableDatabase.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.update_external_pluggable_database`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_external_pluggable_database(external_pluggable_database_id, update_external_pluggable_database_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_external_pluggable_database(wait_for_resource_id),
                 evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
                 **waiter_kwargs
             )

--- a/src/oci/database/models/__init__.py
+++ b/src/oci/database/models/__init__.py
@@ -91,6 +91,12 @@ from .create_db_home_with_vm_cluster_id_details import CreateDbHomeWithVmCluster
 from .create_db_home_with_vm_cluster_id_from_backup_details import CreateDbHomeWithVmClusterIdFromBackupDetails
 from .create_exadata_infrastructure_details import CreateExadataInfrastructureDetails
 from .create_external_backup_job_details import CreateExternalBackupJobDetails
+from .create_external_container_database_details import CreateExternalContainerDatabaseDetails
+from .create_external_database_connector_details import CreateExternalDatabaseConnectorDetails
+from .create_external_database_details_base import CreateExternalDatabaseDetailsBase
+from .create_external_macs_connector_details import CreateExternalMacsConnectorDetails
+from .create_external_non_container_database_details import CreateExternalNonContainerDatabaseDetails
+from .create_external_pluggable_database_details import CreateExternalPluggableDatabaseDetails
 from .create_key_store_details import CreateKeyStoreDetails
 from .create_nfs_backup_destination_details import CreateNFSBackupDestinationDetails
 from .create_new_database_details import CreateNewDatabaseDetails
@@ -100,7 +106,12 @@ from .create_vm_cluster_details import CreateVmClusterDetails
 from .data_guard_association import DataGuardAssociation
 from .data_guard_association_summary import DataGuardAssociationSummary
 from .database import Database
+from .database_connection_credentails_by_name import DatabaseConnectionCredentailsByName
+from .database_connection_credentials import DatabaseConnectionCredentials
+from .database_connection_credentials_by_details import DatabaseConnectionCredentialsByDetails
+from .database_connection_string import DatabaseConnectionString
 from .database_connection_strings import DatabaseConnectionStrings
+from .database_management_config import DatabaseManagementConfig
 from .database_software_image import DatabaseSoftwareImage
 from .database_software_image_summary import DatabaseSoftwareImageSummary
 from .database_summary import DatabaseSummary
@@ -124,6 +135,10 @@ from .db_system_shape_summary import DbSystemShapeSummary
 from .db_system_summary import DbSystemSummary
 from .db_version_summary import DbVersionSummary
 from .deregister_autonomous_database_data_safe_details import DeregisterAutonomousDatabaseDataSafeDetails
+from .enable_external_container_database_database_management_details import EnableExternalContainerDatabaseDatabaseManagementDetails
+from .enable_external_database_management_details_base import EnableExternalDatabaseManagementDetailsBase
+from .enable_external_non_container_database_database_management_details import EnableExternalNonContainerDatabaseDatabaseManagementDetails
+from .enable_external_pluggable_database_database_management_details import EnableExternalPluggableDatabaseDatabaseManagementDetails
 from .exadata_db_system_migration import ExadataDbSystemMigration
 from .exadata_db_system_migration_summary import ExadataDbSystemMigrationSummary
 from .exadata_infrastructure import ExadataInfrastructure
@@ -132,6 +147,17 @@ from .exadata_infrastructure_summary import ExadataInfrastructureSummary
 from .exadata_iorm_config import ExadataIormConfig
 from .exadata_iorm_config_update_details import ExadataIormConfigUpdateDetails
 from .external_backup_job import ExternalBackupJob
+from .external_container_database import ExternalContainerDatabase
+from .external_container_database_summary import ExternalContainerDatabaseSummary
+from .external_database_base import ExternalDatabaseBase
+from .external_database_connector import ExternalDatabaseConnector
+from .external_database_connector_summary import ExternalDatabaseConnectorSummary
+from .external_macs_connector import ExternalMacsConnector
+from .external_macs_connector_summary import ExternalMacsConnectorSummary
+from .external_non_container_database import ExternalNonContainerDatabase
+from .external_non_container_database_summary import ExternalNonContainerDatabaseSummary
+from .external_pluggable_database import ExternalPluggableDatabase
+from .external_pluggable_database_summary import ExternalPluggableDatabaseSummary
 from .failover_data_guard_association_details import FailoverDataGuardAssociationDetails
 from .flex_component_collection import FlexComponentCollection
 from .flex_component_summary import FlexComponentSummary
@@ -186,6 +212,12 @@ from .update_db_home_details import UpdateDbHomeDetails
 from .update_db_system_details import UpdateDbSystemDetails
 from .update_details import UpdateDetails
 from .update_exadata_infrastructure_details import UpdateExadataInfrastructureDetails
+from .update_external_container_database_details import UpdateExternalContainerDatabaseDetails
+from .update_external_database_connector_details import UpdateExternalDatabaseConnectorDetails
+from .update_external_database_details_base import UpdateExternalDatabaseDetailsBase
+from .update_external_macs_connector_details import UpdateExternalMacsConnectorDetails
+from .update_external_non_container_database_details import UpdateExternalNonContainerDatabaseDetails
+from .update_external_pluggable_database_details import UpdateExternalPluggableDatabaseDetails
 from .update_history_entry import UpdateHistoryEntry
 from .update_history_entry_summary import UpdateHistoryEntrySummary
 from .update_key_store_details import UpdateKeyStoreDetails
@@ -291,6 +323,12 @@ database_type_mapping = {
     "CreateDbHomeWithVmClusterIdFromBackupDetails": CreateDbHomeWithVmClusterIdFromBackupDetails,
     "CreateExadataInfrastructureDetails": CreateExadataInfrastructureDetails,
     "CreateExternalBackupJobDetails": CreateExternalBackupJobDetails,
+    "CreateExternalContainerDatabaseDetails": CreateExternalContainerDatabaseDetails,
+    "CreateExternalDatabaseConnectorDetails": CreateExternalDatabaseConnectorDetails,
+    "CreateExternalDatabaseDetailsBase": CreateExternalDatabaseDetailsBase,
+    "CreateExternalMacsConnectorDetails": CreateExternalMacsConnectorDetails,
+    "CreateExternalNonContainerDatabaseDetails": CreateExternalNonContainerDatabaseDetails,
+    "CreateExternalPluggableDatabaseDetails": CreateExternalPluggableDatabaseDetails,
     "CreateKeyStoreDetails": CreateKeyStoreDetails,
     "CreateNFSBackupDestinationDetails": CreateNFSBackupDestinationDetails,
     "CreateNewDatabaseDetails": CreateNewDatabaseDetails,
@@ -300,7 +338,12 @@ database_type_mapping = {
     "DataGuardAssociation": DataGuardAssociation,
     "DataGuardAssociationSummary": DataGuardAssociationSummary,
     "Database": Database,
+    "DatabaseConnectionCredentailsByName": DatabaseConnectionCredentailsByName,
+    "DatabaseConnectionCredentials": DatabaseConnectionCredentials,
+    "DatabaseConnectionCredentialsByDetails": DatabaseConnectionCredentialsByDetails,
+    "DatabaseConnectionString": DatabaseConnectionString,
     "DatabaseConnectionStrings": DatabaseConnectionStrings,
+    "DatabaseManagementConfig": DatabaseManagementConfig,
     "DatabaseSoftwareImage": DatabaseSoftwareImage,
     "DatabaseSoftwareImageSummary": DatabaseSoftwareImageSummary,
     "DatabaseSummary": DatabaseSummary,
@@ -324,6 +367,10 @@ database_type_mapping = {
     "DbSystemSummary": DbSystemSummary,
     "DbVersionSummary": DbVersionSummary,
     "DeregisterAutonomousDatabaseDataSafeDetails": DeregisterAutonomousDatabaseDataSafeDetails,
+    "EnableExternalContainerDatabaseDatabaseManagementDetails": EnableExternalContainerDatabaseDatabaseManagementDetails,
+    "EnableExternalDatabaseManagementDetailsBase": EnableExternalDatabaseManagementDetailsBase,
+    "EnableExternalNonContainerDatabaseDatabaseManagementDetails": EnableExternalNonContainerDatabaseDatabaseManagementDetails,
+    "EnableExternalPluggableDatabaseDatabaseManagementDetails": EnableExternalPluggableDatabaseDatabaseManagementDetails,
     "ExadataDbSystemMigration": ExadataDbSystemMigration,
     "ExadataDbSystemMigrationSummary": ExadataDbSystemMigrationSummary,
     "ExadataInfrastructure": ExadataInfrastructure,
@@ -332,6 +379,17 @@ database_type_mapping = {
     "ExadataIormConfig": ExadataIormConfig,
     "ExadataIormConfigUpdateDetails": ExadataIormConfigUpdateDetails,
     "ExternalBackupJob": ExternalBackupJob,
+    "ExternalContainerDatabase": ExternalContainerDatabase,
+    "ExternalContainerDatabaseSummary": ExternalContainerDatabaseSummary,
+    "ExternalDatabaseBase": ExternalDatabaseBase,
+    "ExternalDatabaseConnector": ExternalDatabaseConnector,
+    "ExternalDatabaseConnectorSummary": ExternalDatabaseConnectorSummary,
+    "ExternalMacsConnector": ExternalMacsConnector,
+    "ExternalMacsConnectorSummary": ExternalMacsConnectorSummary,
+    "ExternalNonContainerDatabase": ExternalNonContainerDatabase,
+    "ExternalNonContainerDatabaseSummary": ExternalNonContainerDatabaseSummary,
+    "ExternalPluggableDatabase": ExternalPluggableDatabase,
+    "ExternalPluggableDatabaseSummary": ExternalPluggableDatabaseSummary,
     "FailoverDataGuardAssociationDetails": FailoverDataGuardAssociationDetails,
     "FlexComponentCollection": FlexComponentCollection,
     "FlexComponentSummary": FlexComponentSummary,
@@ -386,6 +444,12 @@ database_type_mapping = {
     "UpdateDbSystemDetails": UpdateDbSystemDetails,
     "UpdateDetails": UpdateDetails,
     "UpdateExadataInfrastructureDetails": UpdateExadataInfrastructureDetails,
+    "UpdateExternalContainerDatabaseDetails": UpdateExternalContainerDatabaseDetails,
+    "UpdateExternalDatabaseConnectorDetails": UpdateExternalDatabaseConnectorDetails,
+    "UpdateExternalDatabaseDetailsBase": UpdateExternalDatabaseDetailsBase,
+    "UpdateExternalMacsConnectorDetails": UpdateExternalMacsConnectorDetails,
+    "UpdateExternalNonContainerDatabaseDetails": UpdateExternalNonContainerDatabaseDetails,
+    "UpdateExternalPluggableDatabaseDetails": UpdateExternalPluggableDatabaseDetails,
     "UpdateHistoryEntry": UpdateHistoryEntry,
     "UpdateHistoryEntrySummary": UpdateHistoryEntrySummary,
     "UpdateKeyStoreDetails": UpdateKeyStoreDetails,

--- a/src/oci/database/models/create_database_software_image_details.py
+++ b/src/oci/database/models/create_database_software_image_details.py
@@ -228,7 +228,7 @@ class CreateDatabaseSoftwareImageDetails(object):
     def image_type(self):
         """
         Gets the image_type of this CreateDatabaseSoftwareImageDetails.
-        List of the Fault Domains in which this DB system is provisioned.
+        The type of software image. Can be grid or database.
 
         Allowed values for this property are: "GRID_IMAGE", "DATABASE_IMAGE"
 
@@ -242,7 +242,7 @@ class CreateDatabaseSoftwareImageDetails(object):
     def image_type(self, image_type):
         """
         Sets the image_type of this CreateDatabaseSoftwareImageDetails.
-        List of the Fault Domains in which this DB system is provisioned.
+        The type of software image. Can be grid or database.
 
 
         :param image_type: The image_type of this CreateDatabaseSoftwareImageDetails.

--- a/src/oci/database/models/create_external_container_database_details.py
+++ b/src/oci/database/models/create_external_container_database_details.py
@@ -1,0 +1,183 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateExternalContainerDatabaseDetails(object):
+    """
+    Details for creating an external container database resource.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateExternalContainerDatabaseDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this CreateExternalContainerDatabaseDetails.
+        :type compartment_id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this CreateExternalContainerDatabaseDetails.
+        :type display_name: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this CreateExternalContainerDatabaseDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this CreateExternalContainerDatabaseDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str',
+            'display_name': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId',
+            'display_name': 'displayName',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._compartment_id = None
+        self._display_name = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this CreateExternalContainerDatabaseDetails.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this CreateExternalContainerDatabaseDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this CreateExternalContainerDatabaseDetails.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this CreateExternalContainerDatabaseDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this CreateExternalContainerDatabaseDetails.
+        The user-friendly name for the external database. The name does not have to be unique.
+
+
+        :return: The display_name of this CreateExternalContainerDatabaseDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this CreateExternalContainerDatabaseDetails.
+        The user-friendly name for the external database. The name does not have to be unique.
+
+
+        :param display_name: The display_name of this CreateExternalContainerDatabaseDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this CreateExternalContainerDatabaseDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this CreateExternalContainerDatabaseDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this CreateExternalContainerDatabaseDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this CreateExternalContainerDatabaseDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this CreateExternalContainerDatabaseDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this CreateExternalContainerDatabaseDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this CreateExternalContainerDatabaseDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this CreateExternalContainerDatabaseDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/create_external_database_connector_details.py
+++ b/src/oci/database/models/create_external_database_connector_details.py
@@ -1,0 +1,248 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateExternalDatabaseConnectorDetails(object):
+    """
+    Details for creating an external database connector resource.
+    """
+
+    #: A constant which can be used with the connector_type property of a CreateExternalDatabaseConnectorDetails.
+    #: This constant has a value of "MACS"
+    CONNECTOR_TYPE_MACS = "MACS"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateExternalDatabaseConnectorDetails object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
+        to a service operations then you should favor using a subclass over the base class:
+
+        * :class:`~oci.database.models.CreateExternalMacsConnectorDetails`
+
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this CreateExternalDatabaseConnectorDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this CreateExternalDatabaseConnectorDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param display_name:
+            The value to assign to the display_name property of this CreateExternalDatabaseConnectorDetails.
+        :type display_name: str
+
+        :param connector_type:
+            The value to assign to the connector_type property of this CreateExternalDatabaseConnectorDetails.
+            Allowed values for this property are: "MACS"
+        :type connector_type: str
+
+        :param external_database_id:
+            The value to assign to the external_database_id property of this CreateExternalDatabaseConnectorDetails.
+        :type external_database_id: str
+
+        """
+        self.swagger_types = {
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'display_name': 'str',
+            'connector_type': 'str',
+            'external_database_id': 'str'
+        }
+
+        self.attribute_map = {
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags',
+            'display_name': 'displayName',
+            'connector_type': 'connectorType',
+            'external_database_id': 'externalDatabaseId'
+        }
+
+        self._freeform_tags = None
+        self._defined_tags = None
+        self._display_name = None
+        self._connector_type = None
+        self._external_database_id = None
+
+    @staticmethod
+    def get_subtype(object_dictionary):
+        """
+        Given the hash representation of a subtype of this class,
+        use the info in the hash to return the class of the subtype.
+        """
+        type = object_dictionary['connectorType']
+
+        if type == 'MACS':
+            return 'CreateExternalMacsConnectorDetails'
+        else:
+            return 'CreateExternalDatabaseConnectorDetails'
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this CreateExternalDatabaseConnectorDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this CreateExternalDatabaseConnectorDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this CreateExternalDatabaseConnectorDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this CreateExternalDatabaseConnectorDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this CreateExternalDatabaseConnectorDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this CreateExternalDatabaseConnectorDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this CreateExternalDatabaseConnectorDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this CreateExternalDatabaseConnectorDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this CreateExternalDatabaseConnectorDetails.
+        The user-friendly name for the
+        :func:`create_external_database_connector_details`.
+        The name does not have to be unique.
+
+
+        :return: The display_name of this CreateExternalDatabaseConnectorDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this CreateExternalDatabaseConnectorDetails.
+        The user-friendly name for the
+        :func:`create_external_database_connector_details`.
+        The name does not have to be unique.
+
+
+        :param display_name: The display_name of this CreateExternalDatabaseConnectorDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def connector_type(self):
+        """
+        Gets the connector_type of this CreateExternalDatabaseConnectorDetails.
+        The type of connector used by the external database resource.
+
+        Allowed values for this property are: "MACS"
+
+
+        :return: The connector_type of this CreateExternalDatabaseConnectorDetails.
+        :rtype: str
+        """
+        return self._connector_type
+
+    @connector_type.setter
+    def connector_type(self, connector_type):
+        """
+        Sets the connector_type of this CreateExternalDatabaseConnectorDetails.
+        The type of connector used by the external database resource.
+
+
+        :param connector_type: The connector_type of this CreateExternalDatabaseConnectorDetails.
+        :type: str
+        """
+        allowed_values = ["MACS"]
+        if not value_allowed_none_or_none_sentinel(connector_type, allowed_values):
+            raise ValueError(
+                "Invalid value for `connector_type`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._connector_type = connector_type
+
+    @property
+    def external_database_id(self):
+        """
+        **[Required]** Gets the external_database_id of this CreateExternalDatabaseConnectorDetails.
+        The `OCID`__ of the external database resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The external_database_id of this CreateExternalDatabaseConnectorDetails.
+        :rtype: str
+        """
+        return self._external_database_id
+
+    @external_database_id.setter
+    def external_database_id(self, external_database_id):
+        """
+        Sets the external_database_id of this CreateExternalDatabaseConnectorDetails.
+        The `OCID`__ of the external database resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param external_database_id: The external_database_id of this CreateExternalDatabaseConnectorDetails.
+        :type: str
+        """
+        self._external_database_id = external_database_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/create_external_database_details_base.py
+++ b/src/oci/database/models/create_external_database_details_base.py
@@ -1,0 +1,183 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateExternalDatabaseDetailsBase(object):
+    """
+    Details for creating an external database.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateExternalDatabaseDetailsBase object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this CreateExternalDatabaseDetailsBase.
+        :type compartment_id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this CreateExternalDatabaseDetailsBase.
+        :type display_name: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this CreateExternalDatabaseDetailsBase.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this CreateExternalDatabaseDetailsBase.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str',
+            'display_name': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId',
+            'display_name': 'displayName',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._compartment_id = None
+        self._display_name = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this CreateExternalDatabaseDetailsBase.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this CreateExternalDatabaseDetailsBase.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this CreateExternalDatabaseDetailsBase.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this CreateExternalDatabaseDetailsBase.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this CreateExternalDatabaseDetailsBase.
+        The user-friendly name for the external database. The name does not have to be unique.
+
+
+        :return: The display_name of this CreateExternalDatabaseDetailsBase.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this CreateExternalDatabaseDetailsBase.
+        The user-friendly name for the external database. The name does not have to be unique.
+
+
+        :param display_name: The display_name of this CreateExternalDatabaseDetailsBase.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this CreateExternalDatabaseDetailsBase.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this CreateExternalDatabaseDetailsBase.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this CreateExternalDatabaseDetailsBase.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this CreateExternalDatabaseDetailsBase.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this CreateExternalDatabaseDetailsBase.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this CreateExternalDatabaseDetailsBase.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this CreateExternalDatabaseDetailsBase.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this CreateExternalDatabaseDetailsBase.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/create_external_macs_connector_details.py
+++ b/src/oci/database/models/create_external_macs_connector_details.py
@@ -1,0 +1,167 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .create_external_database_connector_details import CreateExternalDatabaseConnectorDetails
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateExternalMacsConnectorDetails(CreateExternalDatabaseConnectorDetails):
+    """
+    Details for creating a resource used to connect to an external Oracle Database using
+    the `Management Agent cloud service (MACS)`__.
+
+    __ https://docs.cloud.oracle.com/iaas/management-agents/index.html
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateExternalMacsConnectorDetails object with values from keyword arguments. The default value of the :py:attr:`~oci.database.models.CreateExternalMacsConnectorDetails.connector_type` attribute
+        of this class is ``MACS`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this CreateExternalMacsConnectorDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this CreateExternalMacsConnectorDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param display_name:
+            The value to assign to the display_name property of this CreateExternalMacsConnectorDetails.
+        :type display_name: str
+
+        :param connector_type:
+            The value to assign to the connector_type property of this CreateExternalMacsConnectorDetails.
+            Allowed values for this property are: "MACS"
+        :type connector_type: str
+
+        :param external_database_id:
+            The value to assign to the external_database_id property of this CreateExternalMacsConnectorDetails.
+        :type external_database_id: str
+
+        :param connection_string:
+            The value to assign to the connection_string property of this CreateExternalMacsConnectorDetails.
+        :type connection_string: oci.database.models.DatabaseConnectionString
+
+        :param connection_credentials:
+            The value to assign to the connection_credentials property of this CreateExternalMacsConnectorDetails.
+        :type connection_credentials: oci.database.models.DatabaseConnectionCredentials
+
+        :param connector_agent_id:
+            The value to assign to the connector_agent_id property of this CreateExternalMacsConnectorDetails.
+        :type connector_agent_id: str
+
+        """
+        self.swagger_types = {
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'display_name': 'str',
+            'connector_type': 'str',
+            'external_database_id': 'str',
+            'connection_string': 'DatabaseConnectionString',
+            'connection_credentials': 'DatabaseConnectionCredentials',
+            'connector_agent_id': 'str'
+        }
+
+        self.attribute_map = {
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags',
+            'display_name': 'displayName',
+            'connector_type': 'connectorType',
+            'external_database_id': 'externalDatabaseId',
+            'connection_string': 'connectionString',
+            'connection_credentials': 'connectionCredentials',
+            'connector_agent_id': 'connectorAgentId'
+        }
+
+        self._freeform_tags = None
+        self._defined_tags = None
+        self._display_name = None
+        self._connector_type = None
+        self._external_database_id = None
+        self._connection_string = None
+        self._connection_credentials = None
+        self._connector_agent_id = None
+        self._connector_type = 'MACS'
+
+    @property
+    def connection_string(self):
+        """
+        **[Required]** Gets the connection_string of this CreateExternalMacsConnectorDetails.
+
+        :return: The connection_string of this CreateExternalMacsConnectorDetails.
+        :rtype: oci.database.models.DatabaseConnectionString
+        """
+        return self._connection_string
+
+    @connection_string.setter
+    def connection_string(self, connection_string):
+        """
+        Sets the connection_string of this CreateExternalMacsConnectorDetails.
+
+        :param connection_string: The connection_string of this CreateExternalMacsConnectorDetails.
+        :type: oci.database.models.DatabaseConnectionString
+        """
+        self._connection_string = connection_string
+
+    @property
+    def connection_credentials(self):
+        """
+        **[Required]** Gets the connection_credentials of this CreateExternalMacsConnectorDetails.
+
+        :return: The connection_credentials of this CreateExternalMacsConnectorDetails.
+        :rtype: oci.database.models.DatabaseConnectionCredentials
+        """
+        return self._connection_credentials
+
+    @connection_credentials.setter
+    def connection_credentials(self, connection_credentials):
+        """
+        Sets the connection_credentials of this CreateExternalMacsConnectorDetails.
+
+        :param connection_credentials: The connection_credentials of this CreateExternalMacsConnectorDetails.
+        :type: oci.database.models.DatabaseConnectionCredentials
+        """
+        self._connection_credentials = connection_credentials
+
+    @property
+    def connector_agent_id(self):
+        """
+        **[Required]** Gets the connector_agent_id of this CreateExternalMacsConnectorDetails.
+        The ID of the agent used for the
+        :func:`create_external_database_connector_details`.
+
+
+        :return: The connector_agent_id of this CreateExternalMacsConnectorDetails.
+        :rtype: str
+        """
+        return self._connector_agent_id
+
+    @connector_agent_id.setter
+    def connector_agent_id(self, connector_agent_id):
+        """
+        Sets the connector_agent_id of this CreateExternalMacsConnectorDetails.
+        The ID of the agent used for the
+        :func:`create_external_database_connector_details`.
+
+
+        :param connector_agent_id: The connector_agent_id of this CreateExternalMacsConnectorDetails.
+        :type: str
+        """
+        self._connector_agent_id = connector_agent_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/create_external_non_container_database_details.py
+++ b/src/oci/database/models/create_external_non_container_database_details.py
@@ -1,0 +1,183 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateExternalNonContainerDatabaseDetails(object):
+    """
+    Details for creating an external non-container database resource.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateExternalNonContainerDatabaseDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this CreateExternalNonContainerDatabaseDetails.
+        :type compartment_id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this CreateExternalNonContainerDatabaseDetails.
+        :type display_name: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this CreateExternalNonContainerDatabaseDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this CreateExternalNonContainerDatabaseDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str',
+            'display_name': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId',
+            'display_name': 'displayName',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._compartment_id = None
+        self._display_name = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this CreateExternalNonContainerDatabaseDetails.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this CreateExternalNonContainerDatabaseDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this CreateExternalNonContainerDatabaseDetails.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this CreateExternalNonContainerDatabaseDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this CreateExternalNonContainerDatabaseDetails.
+        The user-friendly name for the external database. The name does not have to be unique.
+
+
+        :return: The display_name of this CreateExternalNonContainerDatabaseDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this CreateExternalNonContainerDatabaseDetails.
+        The user-friendly name for the external database. The name does not have to be unique.
+
+
+        :param display_name: The display_name of this CreateExternalNonContainerDatabaseDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this CreateExternalNonContainerDatabaseDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this CreateExternalNonContainerDatabaseDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this CreateExternalNonContainerDatabaseDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this CreateExternalNonContainerDatabaseDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this CreateExternalNonContainerDatabaseDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this CreateExternalNonContainerDatabaseDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this CreateExternalNonContainerDatabaseDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this CreateExternalNonContainerDatabaseDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/create_external_pluggable_database_details.py
+++ b/src/oci/database/models/create_external_pluggable_database_details.py
@@ -1,0 +1,259 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateExternalPluggableDatabaseDetails(object):
+    """
+    Details for creating an external pluggable database resource.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateExternalPluggableDatabaseDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param source_id:
+            The value to assign to the source_id property of this CreateExternalPluggableDatabaseDetails.
+        :type source_id: str
+
+        :param external_container_database_id:
+            The value to assign to the external_container_database_id property of this CreateExternalPluggableDatabaseDetails.
+        :type external_container_database_id: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this CreateExternalPluggableDatabaseDetails.
+        :type compartment_id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this CreateExternalPluggableDatabaseDetails.
+        :type display_name: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this CreateExternalPluggableDatabaseDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this CreateExternalPluggableDatabaseDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'source_id': 'str',
+            'external_container_database_id': 'str',
+            'compartment_id': 'str',
+            'display_name': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'source_id': 'sourceId',
+            'external_container_database_id': 'externalContainerDatabaseId',
+            'compartment_id': 'compartmentId',
+            'display_name': 'displayName',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._source_id = None
+        self._external_container_database_id = None
+        self._compartment_id = None
+        self._display_name = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def source_id(self):
+        """
+        Gets the source_id of this CreateExternalPluggableDatabaseDetails.
+        The `OCID`__ of the the non-container database that was converted
+        to a pluggable database to create this resource.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :return: The source_id of this CreateExternalPluggableDatabaseDetails.
+        :rtype: str
+        """
+        return self._source_id
+
+    @source_id.setter
+    def source_id(self, source_id):
+        """
+        Sets the source_id of this CreateExternalPluggableDatabaseDetails.
+        The `OCID`__ of the the non-container database that was converted
+        to a pluggable database to create this resource.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :param source_id: The source_id of this CreateExternalPluggableDatabaseDetails.
+        :type: str
+        """
+        self._source_id = source_id
+
+    @property
+    def external_container_database_id(self):
+        """
+        **[Required]** Gets the external_container_database_id of this CreateExternalPluggableDatabaseDetails.
+        The `OCID`__ of the
+        :func:`create_external_container_database_details` that contains
+        the specified :func:`create_external_pluggable_database_details` resource.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :return: The external_container_database_id of this CreateExternalPluggableDatabaseDetails.
+        :rtype: str
+        """
+        return self._external_container_database_id
+
+    @external_container_database_id.setter
+    def external_container_database_id(self, external_container_database_id):
+        """
+        Sets the external_container_database_id of this CreateExternalPluggableDatabaseDetails.
+        The `OCID`__ of the
+        :func:`create_external_container_database_details` that contains
+        the specified :func:`create_external_pluggable_database_details` resource.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :param external_container_database_id: The external_container_database_id of this CreateExternalPluggableDatabaseDetails.
+        :type: str
+        """
+        self._external_container_database_id = external_container_database_id
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this CreateExternalPluggableDatabaseDetails.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this CreateExternalPluggableDatabaseDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this CreateExternalPluggableDatabaseDetails.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this CreateExternalPluggableDatabaseDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this CreateExternalPluggableDatabaseDetails.
+        The user-friendly name for the external database. The name does not have to be unique.
+
+
+        :return: The display_name of this CreateExternalPluggableDatabaseDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this CreateExternalPluggableDatabaseDetails.
+        The user-friendly name for the external database. The name does not have to be unique.
+
+
+        :param display_name: The display_name of this CreateExternalPluggableDatabaseDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this CreateExternalPluggableDatabaseDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this CreateExternalPluggableDatabaseDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this CreateExternalPluggableDatabaseDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this CreateExternalPluggableDatabaseDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this CreateExternalPluggableDatabaseDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this CreateExternalPluggableDatabaseDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this CreateExternalPluggableDatabaseDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this CreateExternalPluggableDatabaseDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/database_connection_credentails_by_name.py
+++ b/src/oci/database/models/database_connection_credentails_by_name.py
@@ -1,0 +1,80 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .database_connection_credentials import DatabaseConnectionCredentials
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class DatabaseConnectionCredentailsByName(DatabaseConnectionCredentials):
+    """
+    Existing named credential used to connect to the database.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new DatabaseConnectionCredentailsByName object with values from keyword arguments. The default value of the :py:attr:`~oci.database.models.DatabaseConnectionCredentailsByName.credential_type` attribute
+        of this class is ``NAME_REFERENCE`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param credential_type:
+            The value to assign to the credential_type property of this DatabaseConnectionCredentailsByName.
+            Allowed values for this property are: "NAME_REFERENCE", "DETAILS"
+        :type credential_type: str
+
+        :param credential_name:
+            The value to assign to the credential_name property of this DatabaseConnectionCredentailsByName.
+        :type credential_name: str
+
+        """
+        self.swagger_types = {
+            'credential_type': 'str',
+            'credential_name': 'str'
+        }
+
+        self.attribute_map = {
+            'credential_type': 'credentialType',
+            'credential_name': 'credentialName'
+        }
+
+        self._credential_type = None
+        self._credential_name = None
+        self._credential_type = 'NAME_REFERENCE'
+
+    @property
+    def credential_name(self):
+        """
+        **[Required]** Gets the credential_name of this DatabaseConnectionCredentailsByName.
+        The name of the credential information that used to connect to the database.
+
+
+        :return: The credential_name of this DatabaseConnectionCredentailsByName.
+        :rtype: str
+        """
+        return self._credential_name
+
+    @credential_name.setter
+    def credential_name(self, credential_name):
+        """
+        Sets the credential_name of this DatabaseConnectionCredentailsByName.
+        The name of the credential information that used to connect to the database.
+
+
+        :param credential_name: The credential_name of this DatabaseConnectionCredentailsByName.
+        :type: str
+        """
+        self._credential_name = credential_name
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/database_connection_credentials.py
+++ b/src/oci/database/models/database_connection_credentials.py
@@ -1,0 +1,107 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class DatabaseConnectionCredentials(object):
+    """
+    Credentials used to connect to the database.
+    """
+
+    #: A constant which can be used with the credential_type property of a DatabaseConnectionCredentials.
+    #: This constant has a value of "NAME_REFERENCE"
+    CREDENTIAL_TYPE_NAME_REFERENCE = "NAME_REFERENCE"
+
+    #: A constant which can be used with the credential_type property of a DatabaseConnectionCredentials.
+    #: This constant has a value of "DETAILS"
+    CREDENTIAL_TYPE_DETAILS = "DETAILS"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new DatabaseConnectionCredentials object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
+        to a service operations then you should favor using a subclass over the base class:
+
+        * :class:`~oci.database.models.DatabaseConnectionCredentailsByName`
+        * :class:`~oci.database.models.DatabaseConnectionCredentialsByDetails`
+
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param credential_type:
+            The value to assign to the credential_type property of this DatabaseConnectionCredentials.
+            Allowed values for this property are: "NAME_REFERENCE", "DETAILS", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type credential_type: str
+
+        """
+        self.swagger_types = {
+            'credential_type': 'str'
+        }
+
+        self.attribute_map = {
+            'credential_type': 'credentialType'
+        }
+
+        self._credential_type = None
+
+    @staticmethod
+    def get_subtype(object_dictionary):
+        """
+        Given the hash representation of a subtype of this class,
+        use the info in the hash to return the class of the subtype.
+        """
+        type = object_dictionary['credentialType']
+
+        if type == 'NAME_REFERENCE':
+            return 'DatabaseConnectionCredentailsByName'
+
+        if type == 'DETAILS':
+            return 'DatabaseConnectionCredentialsByDetails'
+        else:
+            return 'DatabaseConnectionCredentials'
+
+    @property
+    def credential_type(self):
+        """
+        Gets the credential_type of this DatabaseConnectionCredentials.
+        The type of credential used to connect to the database.
+
+        Allowed values for this property are: "NAME_REFERENCE", "DETAILS", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The credential_type of this DatabaseConnectionCredentials.
+        :rtype: str
+        """
+        return self._credential_type
+
+    @credential_type.setter
+    def credential_type(self, credential_type):
+        """
+        Sets the credential_type of this DatabaseConnectionCredentials.
+        The type of credential used to connect to the database.
+
+
+        :param credential_type: The credential_type of this DatabaseConnectionCredentials.
+        :type: str
+        """
+        allowed_values = ["NAME_REFERENCE", "DETAILS"]
+        if not value_allowed_none_or_none_sentinel(credential_type, allowed_values):
+            credential_type = 'UNKNOWN_ENUM_VALUE'
+        self._credential_type = credential_type
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/database_connection_credentials_by_details.py
+++ b/src/oci/database/models/database_connection_credentials_by_details.py
@@ -1,0 +1,190 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .database_connection_credentials import DatabaseConnectionCredentials
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class DatabaseConnectionCredentialsByDetails(DatabaseConnectionCredentials):
+    """
+    User information to connect to the database.
+    """
+
+    #: A constant which can be used with the role property of a DatabaseConnectionCredentialsByDetails.
+    #: This constant has a value of "SYSDBA"
+    ROLE_SYSDBA = "SYSDBA"
+
+    #: A constant which can be used with the role property of a DatabaseConnectionCredentialsByDetails.
+    #: This constant has a value of "NORMAL"
+    ROLE_NORMAL = "NORMAL"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new DatabaseConnectionCredentialsByDetails object with values from keyword arguments. The default value of the :py:attr:`~oci.database.models.DatabaseConnectionCredentialsByDetails.credential_type` attribute
+        of this class is ``DETAILS`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param credential_type:
+            The value to assign to the credential_type property of this DatabaseConnectionCredentialsByDetails.
+            Allowed values for this property are: "NAME_REFERENCE", "DETAILS", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type credential_type: str
+
+        :param credential_name:
+            The value to assign to the credential_name property of this DatabaseConnectionCredentialsByDetails.
+        :type credential_name: str
+
+        :param username:
+            The value to assign to the username property of this DatabaseConnectionCredentialsByDetails.
+        :type username: str
+
+        :param password:
+            The value to assign to the password property of this DatabaseConnectionCredentialsByDetails.
+        :type password: str
+
+        :param role:
+            The value to assign to the role property of this DatabaseConnectionCredentialsByDetails.
+            Allowed values for this property are: "SYSDBA", "NORMAL", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type role: str
+
+        """
+        self.swagger_types = {
+            'credential_type': 'str',
+            'credential_name': 'str',
+            'username': 'str',
+            'password': 'str',
+            'role': 'str'
+        }
+
+        self.attribute_map = {
+            'credential_type': 'credentialType',
+            'credential_name': 'credentialName',
+            'username': 'username',
+            'password': 'password',
+            'role': 'role'
+        }
+
+        self._credential_type = None
+        self._credential_name = None
+        self._username = None
+        self._password = None
+        self._role = None
+        self._credential_type = 'DETAILS'
+
+    @property
+    def credential_name(self):
+        """
+        Gets the credential_name of this DatabaseConnectionCredentialsByDetails.
+        The name of the credential information that used to connect to the database.
+
+
+        :return: The credential_name of this DatabaseConnectionCredentialsByDetails.
+        :rtype: str
+        """
+        return self._credential_name
+
+    @credential_name.setter
+    def credential_name(self, credential_name):
+        """
+        Sets the credential_name of this DatabaseConnectionCredentialsByDetails.
+        The name of the credential information that used to connect to the database.
+
+
+        :param credential_name: The credential_name of this DatabaseConnectionCredentialsByDetails.
+        :type: str
+        """
+        self._credential_name = credential_name
+
+    @property
+    def username(self):
+        """
+        **[Required]** Gets the username of this DatabaseConnectionCredentialsByDetails.
+        The username that will be used to connect to the database.
+
+
+        :return: The username of this DatabaseConnectionCredentialsByDetails.
+        :rtype: str
+        """
+        return self._username
+
+    @username.setter
+    def username(self, username):
+        """
+        Sets the username of this DatabaseConnectionCredentialsByDetails.
+        The username that will be used to connect to the database.
+
+
+        :param username: The username of this DatabaseConnectionCredentialsByDetails.
+        :type: str
+        """
+        self._username = username
+
+    @property
+    def password(self):
+        """
+        **[Required]** Gets the password of this DatabaseConnectionCredentialsByDetails.
+        The password that will be used to connect to the database.
+
+
+        :return: The password of this DatabaseConnectionCredentialsByDetails.
+        :rtype: str
+        """
+        return self._password
+
+    @password.setter
+    def password(self, password):
+        """
+        Sets the password of this DatabaseConnectionCredentialsByDetails.
+        The password that will be used to connect to the database.
+
+
+        :param password: The password of this DatabaseConnectionCredentialsByDetails.
+        :type: str
+        """
+        self._password = password
+
+    @property
+    def role(self):
+        """
+        **[Required]** Gets the role of this DatabaseConnectionCredentialsByDetails.
+        The role of the user that will be connecting to the database.
+
+        Allowed values for this property are: "SYSDBA", "NORMAL", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The role of this DatabaseConnectionCredentialsByDetails.
+        :rtype: str
+        """
+        return self._role
+
+    @role.setter
+    def role(self, role):
+        """
+        Sets the role of this DatabaseConnectionCredentialsByDetails.
+        The role of the user that will be connecting to the database.
+
+
+        :param role: The role of this DatabaseConnectionCredentialsByDetails.
+        :type: str
+        """
+        allowed_values = ["SYSDBA", "NORMAL"]
+        if not value_allowed_none_or_none_sentinel(role, allowed_values):
+            role = 'UNKNOWN_ENUM_VALUE'
+        self._role = role
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/database_connection_string.py
+++ b/src/oci/database/models/database_connection_string.py
@@ -1,0 +1,175 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class DatabaseConnectionString(object):
+    """
+    The Oracle Database connection string.
+    """
+
+    #: A constant which can be used with the protocol property of a DatabaseConnectionString.
+    #: This constant has a value of "TCP"
+    PROTOCOL_TCP = "TCP"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new DatabaseConnectionString object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param hostname:
+            The value to assign to the hostname property of this DatabaseConnectionString.
+        :type hostname: str
+
+        :param port:
+            The value to assign to the port property of this DatabaseConnectionString.
+        :type port: int
+
+        :param service:
+            The value to assign to the service property of this DatabaseConnectionString.
+        :type service: str
+
+        :param protocol:
+            The value to assign to the protocol property of this DatabaseConnectionString.
+            Allowed values for this property are: "TCP", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type protocol: str
+
+        """
+        self.swagger_types = {
+            'hostname': 'str',
+            'port': 'int',
+            'service': 'str',
+            'protocol': 'str'
+        }
+
+        self.attribute_map = {
+            'hostname': 'hostname',
+            'port': 'port',
+            'service': 'service',
+            'protocol': 'protocol'
+        }
+
+        self._hostname = None
+        self._port = None
+        self._service = None
+        self._protocol = None
+
+    @property
+    def hostname(self):
+        """
+        **[Required]** Gets the hostname of this DatabaseConnectionString.
+        The host name of the database.
+
+
+        :return: The hostname of this DatabaseConnectionString.
+        :rtype: str
+        """
+        return self._hostname
+
+    @hostname.setter
+    def hostname(self, hostname):
+        """
+        Sets the hostname of this DatabaseConnectionString.
+        The host name of the database.
+
+
+        :param hostname: The hostname of this DatabaseConnectionString.
+        :type: str
+        """
+        self._hostname = hostname
+
+    @property
+    def port(self):
+        """
+        **[Required]** Gets the port of this DatabaseConnectionString.
+        The port used to connect to the database.
+
+
+        :return: The port of this DatabaseConnectionString.
+        :rtype: int
+        """
+        return self._port
+
+    @port.setter
+    def port(self, port):
+        """
+        Sets the port of this DatabaseConnectionString.
+        The port used to connect to the database.
+
+
+        :param port: The port of this DatabaseConnectionString.
+        :type: int
+        """
+        self._port = port
+
+    @property
+    def service(self):
+        """
+        **[Required]** Gets the service of this DatabaseConnectionString.
+        The name of the service alias used to connect to the database.
+
+
+        :return: The service of this DatabaseConnectionString.
+        :rtype: str
+        """
+        return self._service
+
+    @service.setter
+    def service(self, service):
+        """
+        Sets the service of this DatabaseConnectionString.
+        The name of the service alias used to connect to the database.
+
+
+        :param service: The service of this DatabaseConnectionString.
+        :type: str
+        """
+        self._service = service
+
+    @property
+    def protocol(self):
+        """
+        **[Required]** Gets the protocol of this DatabaseConnectionString.
+        The protocol used to connect to the database.
+
+        Allowed values for this property are: "TCP", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The protocol of this DatabaseConnectionString.
+        :rtype: str
+        """
+        return self._protocol
+
+    @protocol.setter
+    def protocol(self, protocol):
+        """
+        Sets the protocol of this DatabaseConnectionString.
+        The protocol used to connect to the database.
+
+
+        :param protocol: The protocol of this DatabaseConnectionString.
+        :type: str
+        """
+        allowed_values = ["TCP"]
+        if not value_allowed_none_or_none_sentinel(protocol, allowed_values):
+            protocol = 'UNKNOWN_ENUM_VALUE'
+        self._protocol = protocol
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/database_management_config.py
+++ b/src/oci/database/models/database_management_config.py
@@ -1,0 +1,186 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class DatabaseManagementConfig(object):
+    """
+    The configuration of the Database Management service.
+    """
+
+    #: A constant which can be used with the database_management_status property of a DatabaseManagementConfig.
+    #: This constant has a value of "ENABLING"
+    DATABASE_MANAGEMENT_STATUS_ENABLING = "ENABLING"
+
+    #: A constant which can be used with the database_management_status property of a DatabaseManagementConfig.
+    #: This constant has a value of "ENABLED"
+    DATABASE_MANAGEMENT_STATUS_ENABLED = "ENABLED"
+
+    #: A constant which can be used with the database_management_status property of a DatabaseManagementConfig.
+    #: This constant has a value of "DISABLING"
+    DATABASE_MANAGEMENT_STATUS_DISABLING = "DISABLING"
+
+    #: A constant which can be used with the database_management_status property of a DatabaseManagementConfig.
+    #: This constant has a value of "NOT_ENABLED"
+    DATABASE_MANAGEMENT_STATUS_NOT_ENABLED = "NOT_ENABLED"
+
+    #: A constant which can be used with the database_management_status property of a DatabaseManagementConfig.
+    #: This constant has a value of "FAILED_ENABLING"
+    DATABASE_MANAGEMENT_STATUS_FAILED_ENABLING = "FAILED_ENABLING"
+
+    #: A constant which can be used with the database_management_status property of a DatabaseManagementConfig.
+    #: This constant has a value of "FAILED_DISABLING"
+    DATABASE_MANAGEMENT_STATUS_FAILED_DISABLING = "FAILED_DISABLING"
+
+    #: A constant which can be used with the license_model property of a DatabaseManagementConfig.
+    #: This constant has a value of "LICENSE_INCLUDED"
+    LICENSE_MODEL_LICENSE_INCLUDED = "LICENSE_INCLUDED"
+
+    #: A constant which can be used with the license_model property of a DatabaseManagementConfig.
+    #: This constant has a value of "BRING_YOUR_OWN_LICENSE"
+    LICENSE_MODEL_BRING_YOUR_OWN_LICENSE = "BRING_YOUR_OWN_LICENSE"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new DatabaseManagementConfig object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param database_management_status:
+            The value to assign to the database_management_status property of this DatabaseManagementConfig.
+            Allowed values for this property are: "ENABLING", "ENABLED", "DISABLING", "NOT_ENABLED", "FAILED_ENABLING", "FAILED_DISABLING", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type database_management_status: str
+
+        :param database_management_connection_id:
+            The value to assign to the database_management_connection_id property of this DatabaseManagementConfig.
+        :type database_management_connection_id: str
+
+        :param license_model:
+            The value to assign to the license_model property of this DatabaseManagementConfig.
+            Allowed values for this property are: "LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type license_model: str
+
+        """
+        self.swagger_types = {
+            'database_management_status': 'str',
+            'database_management_connection_id': 'str',
+            'license_model': 'str'
+        }
+
+        self.attribute_map = {
+            'database_management_status': 'databaseManagementStatus',
+            'database_management_connection_id': 'databaseManagementConnectionId',
+            'license_model': 'licenseModel'
+        }
+
+        self._database_management_status = None
+        self._database_management_connection_id = None
+        self._license_model = None
+
+    @property
+    def database_management_status(self):
+        """
+        **[Required]** Gets the database_management_status of this DatabaseManagementConfig.
+        The status of the Database Management service.
+
+        Allowed values for this property are: "ENABLING", "ENABLED", "DISABLING", "NOT_ENABLED", "FAILED_ENABLING", "FAILED_DISABLING", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The database_management_status of this DatabaseManagementConfig.
+        :rtype: str
+        """
+        return self._database_management_status
+
+    @database_management_status.setter
+    def database_management_status(self, database_management_status):
+        """
+        Sets the database_management_status of this DatabaseManagementConfig.
+        The status of the Database Management service.
+
+
+        :param database_management_status: The database_management_status of this DatabaseManagementConfig.
+        :type: str
+        """
+        allowed_values = ["ENABLING", "ENABLED", "DISABLING", "NOT_ENABLED", "FAILED_ENABLING", "FAILED_DISABLING"]
+        if not value_allowed_none_or_none_sentinel(database_management_status, allowed_values):
+            database_management_status = 'UNKNOWN_ENUM_VALUE'
+        self._database_management_status = database_management_status
+
+    @property
+    def database_management_connection_id(self):
+        """
+        Gets the database_management_connection_id of this DatabaseManagementConfig.
+        The `OCID`__ of the
+        :func:`create_external_database_connector_details`.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The database_management_connection_id of this DatabaseManagementConfig.
+        :rtype: str
+        """
+        return self._database_management_connection_id
+
+    @database_management_connection_id.setter
+    def database_management_connection_id(self, database_management_connection_id):
+        """
+        Sets the database_management_connection_id of this DatabaseManagementConfig.
+        The `OCID`__ of the
+        :func:`create_external_database_connector_details`.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param database_management_connection_id: The database_management_connection_id of this DatabaseManagementConfig.
+        :type: str
+        """
+        self._database_management_connection_id = database_management_connection_id
+
+    @property
+    def license_model(self):
+        """
+        Gets the license_model of this DatabaseManagementConfig.
+        The Oracle license model that applies to the external database.
+
+        Allowed values for this property are: "LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The license_model of this DatabaseManagementConfig.
+        :rtype: str
+        """
+        return self._license_model
+
+    @license_model.setter
+    def license_model(self, license_model):
+        """
+        Sets the license_model of this DatabaseManagementConfig.
+        The Oracle license model that applies to the external database.
+
+
+        :param license_model: The license_model of this DatabaseManagementConfig.
+        :type: str
+        """
+        allowed_values = ["LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE"]
+        if not value_allowed_none_or_none_sentinel(license_model, allowed_values):
+            license_model = 'UNKNOWN_ENUM_VALUE'
+        self._license_model = license_model
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/enable_external_container_database_database_management_details.py
+++ b/src/oci/database/models/enable_external_container_database_database_management_details.py
@@ -1,0 +1,124 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class EnableExternalContainerDatabaseDatabaseManagementDetails(object):
+    """
+    Details to enable Database Management on an external container database.
+    """
+
+    #: A constant which can be used with the license_model property of a EnableExternalContainerDatabaseDatabaseManagementDetails.
+    #: This constant has a value of "LICENSE_INCLUDED"
+    LICENSE_MODEL_LICENSE_INCLUDED = "LICENSE_INCLUDED"
+
+    #: A constant which can be used with the license_model property of a EnableExternalContainerDatabaseDatabaseManagementDetails.
+    #: This constant has a value of "BRING_YOUR_OWN_LICENSE"
+    LICENSE_MODEL_BRING_YOUR_OWN_LICENSE = "BRING_YOUR_OWN_LICENSE"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new EnableExternalContainerDatabaseDatabaseManagementDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param license_model:
+            The value to assign to the license_model property of this EnableExternalContainerDatabaseDatabaseManagementDetails.
+            Allowed values for this property are: "LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE"
+        :type license_model: str
+
+        :param external_database_connector_id:
+            The value to assign to the external_database_connector_id property of this EnableExternalContainerDatabaseDatabaseManagementDetails.
+        :type external_database_connector_id: str
+
+        """
+        self.swagger_types = {
+            'license_model': 'str',
+            'external_database_connector_id': 'str'
+        }
+
+        self.attribute_map = {
+            'license_model': 'licenseModel',
+            'external_database_connector_id': 'externalDatabaseConnectorId'
+        }
+
+        self._license_model = None
+        self._external_database_connector_id = None
+
+    @property
+    def license_model(self):
+        """
+        **[Required]** Gets the license_model of this EnableExternalContainerDatabaseDatabaseManagementDetails.
+        The Oracle license model that applies to the external database.
+
+        Allowed values for this property are: "LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE"
+
+
+        :return: The license_model of this EnableExternalContainerDatabaseDatabaseManagementDetails.
+        :rtype: str
+        """
+        return self._license_model
+
+    @license_model.setter
+    def license_model(self, license_model):
+        """
+        Sets the license_model of this EnableExternalContainerDatabaseDatabaseManagementDetails.
+        The Oracle license model that applies to the external database.
+
+
+        :param license_model: The license_model of this EnableExternalContainerDatabaseDatabaseManagementDetails.
+        :type: str
+        """
+        allowed_values = ["LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE"]
+        if not value_allowed_none_or_none_sentinel(license_model, allowed_values):
+            raise ValueError(
+                "Invalid value for `license_model`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._license_model = license_model
+
+    @property
+    def external_database_connector_id(self):
+        """
+        **[Required]** Gets the external_database_connector_id of this EnableExternalContainerDatabaseDatabaseManagementDetails.
+        The `OCID`__ of the
+        :func:`create_external_database_connector_details`.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The external_database_connector_id of this EnableExternalContainerDatabaseDatabaseManagementDetails.
+        :rtype: str
+        """
+        return self._external_database_connector_id
+
+    @external_database_connector_id.setter
+    def external_database_connector_id(self, external_database_connector_id):
+        """
+        Sets the external_database_connector_id of this EnableExternalContainerDatabaseDatabaseManagementDetails.
+        The `OCID`__ of the
+        :func:`create_external_database_connector_details`.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param external_database_connector_id: The external_database_connector_id of this EnableExternalContainerDatabaseDatabaseManagementDetails.
+        :type: str
+        """
+        self._external_database_connector_id = external_database_connector_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/enable_external_database_management_details_base.py
+++ b/src/oci/database/models/enable_external_database_management_details_base.py
@@ -1,0 +1,76 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class EnableExternalDatabaseManagementDetailsBase(object):
+    """
+    Details to enable Database Management on an external database.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new EnableExternalDatabaseManagementDetailsBase object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param external_database_connector_id:
+            The value to assign to the external_database_connector_id property of this EnableExternalDatabaseManagementDetailsBase.
+        :type external_database_connector_id: str
+
+        """
+        self.swagger_types = {
+            'external_database_connector_id': 'str'
+        }
+
+        self.attribute_map = {
+            'external_database_connector_id': 'externalDatabaseConnectorId'
+        }
+
+        self._external_database_connector_id = None
+
+    @property
+    def external_database_connector_id(self):
+        """
+        **[Required]** Gets the external_database_connector_id of this EnableExternalDatabaseManagementDetailsBase.
+        The `OCID`__ of the
+        :func:`create_external_database_connector_details`.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The external_database_connector_id of this EnableExternalDatabaseManagementDetailsBase.
+        :rtype: str
+        """
+        return self._external_database_connector_id
+
+    @external_database_connector_id.setter
+    def external_database_connector_id(self, external_database_connector_id):
+        """
+        Sets the external_database_connector_id of this EnableExternalDatabaseManagementDetailsBase.
+        The `OCID`__ of the
+        :func:`create_external_database_connector_details`.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param external_database_connector_id: The external_database_connector_id of this EnableExternalDatabaseManagementDetailsBase.
+        :type: str
+        """
+        self._external_database_connector_id = external_database_connector_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/enable_external_non_container_database_database_management_details.py
+++ b/src/oci/database/models/enable_external_non_container_database_database_management_details.py
@@ -1,0 +1,124 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class EnableExternalNonContainerDatabaseDatabaseManagementDetails(object):
+    """
+    Details to enable Database Management on an external non-container database.
+    """
+
+    #: A constant which can be used with the license_model property of a EnableExternalNonContainerDatabaseDatabaseManagementDetails.
+    #: This constant has a value of "LICENSE_INCLUDED"
+    LICENSE_MODEL_LICENSE_INCLUDED = "LICENSE_INCLUDED"
+
+    #: A constant which can be used with the license_model property of a EnableExternalNonContainerDatabaseDatabaseManagementDetails.
+    #: This constant has a value of "BRING_YOUR_OWN_LICENSE"
+    LICENSE_MODEL_BRING_YOUR_OWN_LICENSE = "BRING_YOUR_OWN_LICENSE"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new EnableExternalNonContainerDatabaseDatabaseManagementDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param license_model:
+            The value to assign to the license_model property of this EnableExternalNonContainerDatabaseDatabaseManagementDetails.
+            Allowed values for this property are: "LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE"
+        :type license_model: str
+
+        :param external_database_connector_id:
+            The value to assign to the external_database_connector_id property of this EnableExternalNonContainerDatabaseDatabaseManagementDetails.
+        :type external_database_connector_id: str
+
+        """
+        self.swagger_types = {
+            'license_model': 'str',
+            'external_database_connector_id': 'str'
+        }
+
+        self.attribute_map = {
+            'license_model': 'licenseModel',
+            'external_database_connector_id': 'externalDatabaseConnectorId'
+        }
+
+        self._license_model = None
+        self._external_database_connector_id = None
+
+    @property
+    def license_model(self):
+        """
+        **[Required]** Gets the license_model of this EnableExternalNonContainerDatabaseDatabaseManagementDetails.
+        The Oracle license model that applies to the external database.
+
+        Allowed values for this property are: "LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE"
+
+
+        :return: The license_model of this EnableExternalNonContainerDatabaseDatabaseManagementDetails.
+        :rtype: str
+        """
+        return self._license_model
+
+    @license_model.setter
+    def license_model(self, license_model):
+        """
+        Sets the license_model of this EnableExternalNonContainerDatabaseDatabaseManagementDetails.
+        The Oracle license model that applies to the external database.
+
+
+        :param license_model: The license_model of this EnableExternalNonContainerDatabaseDatabaseManagementDetails.
+        :type: str
+        """
+        allowed_values = ["LICENSE_INCLUDED", "BRING_YOUR_OWN_LICENSE"]
+        if not value_allowed_none_or_none_sentinel(license_model, allowed_values):
+            raise ValueError(
+                "Invalid value for `license_model`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._license_model = license_model
+
+    @property
+    def external_database_connector_id(self):
+        """
+        **[Required]** Gets the external_database_connector_id of this EnableExternalNonContainerDatabaseDatabaseManagementDetails.
+        The `OCID`__ of the
+        :func:`create_external_database_connector_details`.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The external_database_connector_id of this EnableExternalNonContainerDatabaseDatabaseManagementDetails.
+        :rtype: str
+        """
+        return self._external_database_connector_id
+
+    @external_database_connector_id.setter
+    def external_database_connector_id(self, external_database_connector_id):
+        """
+        Sets the external_database_connector_id of this EnableExternalNonContainerDatabaseDatabaseManagementDetails.
+        The `OCID`__ of the
+        :func:`create_external_database_connector_details`.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param external_database_connector_id: The external_database_connector_id of this EnableExternalNonContainerDatabaseDatabaseManagementDetails.
+        :type: str
+        """
+        self._external_database_connector_id = external_database_connector_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/enable_external_pluggable_database_database_management_details.py
+++ b/src/oci/database/models/enable_external_pluggable_database_database_management_details.py
@@ -1,0 +1,76 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class EnableExternalPluggableDatabaseDatabaseManagementDetails(object):
+    """
+    Details to enable Database Management on an external pluggable database.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new EnableExternalPluggableDatabaseDatabaseManagementDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param external_database_connector_id:
+            The value to assign to the external_database_connector_id property of this EnableExternalPluggableDatabaseDatabaseManagementDetails.
+        :type external_database_connector_id: str
+
+        """
+        self.swagger_types = {
+            'external_database_connector_id': 'str'
+        }
+
+        self.attribute_map = {
+            'external_database_connector_id': 'externalDatabaseConnectorId'
+        }
+
+        self._external_database_connector_id = None
+
+    @property
+    def external_database_connector_id(self):
+        """
+        **[Required]** Gets the external_database_connector_id of this EnableExternalPluggableDatabaseDatabaseManagementDetails.
+        The `OCID`__ of the
+        :func:`create_external_database_connector_details`.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The external_database_connector_id of this EnableExternalPluggableDatabaseDatabaseManagementDetails.
+        :rtype: str
+        """
+        return self._external_database_connector_id
+
+    @external_database_connector_id.setter
+    def external_database_connector_id(self, external_database_connector_id):
+        """
+        Sets the external_database_connector_id of this EnableExternalPluggableDatabaseDatabaseManagementDetails.
+        The `OCID`__ of the
+        :func:`create_external_database_connector_details`.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param external_database_connector_id: The external_database_connector_id of this EnableExternalPluggableDatabaseDatabaseManagementDetails.
+        :type: str
+        """
+        self._external_database_connector_id = external_database_connector_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/exadata_infrastructure.py
+++ b/src/oci/database/models/exadata_infrastructure.py
@@ -57,6 +57,14 @@ class ExadataInfrastructure(object):
     #: This constant has a value of "MAINTENANCE_IN_PROGRESS"
     LIFECYCLE_STATE_MAINTENANCE_IN_PROGRESS = "MAINTENANCE_IN_PROGRESS"
 
+    #: A constant which can be used with the maintenance_slo_status property of a ExadataInfrastructure.
+    #: This constant has a value of "OK"
+    MAINTENANCE_SLO_STATUS_OK = "OK"
+
+    #: A constant which can be used with the maintenance_slo_status property of a ExadataInfrastructure.
+    #: This constant has a value of "DEGRADED"
+    MAINTENANCE_SLO_STATUS_DEGRADED = "DEGRADED"
+
     def __init__(self, **kwargs):
         """
         Initializes a new ExadataInfrastructure object with values from keyword arguments.
@@ -172,6 +180,12 @@ class ExadataInfrastructure(object):
             The value to assign to the contacts property of this ExadataInfrastructure.
         :type contacts: list[oci.database.models.ExadataInfrastructureContact]
 
+        :param maintenance_slo_status:
+            The value to assign to the maintenance_slo_status property of this ExadataInfrastructure.
+            Allowed values for this property are: "OK", "DEGRADED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type maintenance_slo_status: str
+
         :param maintenance_window:
             The value to assign to the maintenance_window property of this ExadataInfrastructure.
         :type maintenance_window: oci.database.models.MaintenanceWindow
@@ -213,6 +227,7 @@ class ExadataInfrastructure(object):
             'lifecycle_details': 'str',
             'csi_number': 'str',
             'contacts': 'list[ExadataInfrastructureContact]',
+            'maintenance_slo_status': 'str',
             'maintenance_window': 'MaintenanceWindow',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))'
@@ -246,6 +261,7 @@ class ExadataInfrastructure(object):
             'lifecycle_details': 'lifecycleDetails',
             'csi_number': 'csiNumber',
             'contacts': 'contacts',
+            'maintenance_slo_status': 'maintenanceSLOStatus',
             'maintenance_window': 'maintenanceWindow',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags'
@@ -278,6 +294,7 @@ class ExadataInfrastructure(object):
         self._lifecycle_details = None
         self._csi_number = None
         self._contacts = None
+        self._maintenance_slo_status = None
         self._maintenance_window = None
         self._freeform_tags = None
         self._defined_tags = None
@@ -947,6 +964,36 @@ class ExadataInfrastructure(object):
         :type: list[oci.database.models.ExadataInfrastructureContact]
         """
         self._contacts = contacts
+
+    @property
+    def maintenance_slo_status(self):
+        """
+        Gets the maintenance_slo_status of this ExadataInfrastructure.
+        A field to capture \u2018Maintenance SLO Status\u2019 for the Exadata infrastructure with values \u2018OK\u2019, \u2018DEGRADED\u2019. Default is \u2018OK\u2019 when the infrastructure is provisioned.
+
+        Allowed values for this property are: "OK", "DEGRADED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The maintenance_slo_status of this ExadataInfrastructure.
+        :rtype: str
+        """
+        return self._maintenance_slo_status
+
+    @maintenance_slo_status.setter
+    def maintenance_slo_status(self, maintenance_slo_status):
+        """
+        Sets the maintenance_slo_status of this ExadataInfrastructure.
+        A field to capture \u2018Maintenance SLO Status\u2019 for the Exadata infrastructure with values \u2018OK\u2019, \u2018DEGRADED\u2019. Default is \u2018OK\u2019 when the infrastructure is provisioned.
+
+
+        :param maintenance_slo_status: The maintenance_slo_status of this ExadataInfrastructure.
+        :type: str
+        """
+        allowed_values = ["OK", "DEGRADED"]
+        if not value_allowed_none_or_none_sentinel(maintenance_slo_status, allowed_values):
+            maintenance_slo_status = 'UNKNOWN_ENUM_VALUE'
+        self._maintenance_slo_status = maintenance_slo_status
 
     @property
     def maintenance_window(self):

--- a/src/oci/database/models/exadata_infrastructure_contact.py
+++ b/src/oci/database/models/exadata_infrastructure_contact.py
@@ -34,25 +34,32 @@ class ExadataInfrastructureContact(object):
             The value to assign to the is_primary property of this ExadataInfrastructureContact.
         :type is_primary: bool
 
+        :param is_contact_mos_validated:
+            The value to assign to the is_contact_mos_validated property of this ExadataInfrastructureContact.
+        :type is_contact_mos_validated: bool
+
         """
         self.swagger_types = {
             'name': 'str',
             'phone_number': 'str',
             'email': 'str',
-            'is_primary': 'bool'
+            'is_primary': 'bool',
+            'is_contact_mos_validated': 'bool'
         }
 
         self.attribute_map = {
             'name': 'name',
             'phone_number': 'phoneNumber',
             'email': 'email',
-            'is_primary': 'isPrimary'
+            'is_primary': 'isPrimary',
+            'is_contact_mos_validated': 'isContactMosValidated'
         }
 
         self._name = None
         self._phone_number = None
         self._email = None
         self._is_primary = None
+        self._is_contact_mos_validated = None
 
     @property
     def name(self):
@@ -130,7 +137,7 @@ class ExadataInfrastructureContact(object):
     def is_primary(self):
         """
         **[Required]** Gets the is_primary of this ExadataInfrastructureContact.
-        True, if this Exadata Infrastructure contact is a primary contact. False, if this Exadata Infrastructure is a secondary contact.
+        If `true`, this Exadata Infrastructure contact is a primary contact. If `false`, this Exadata Infrastructure is a secondary contact.
 
 
         :return: The is_primary of this ExadataInfrastructureContact.
@@ -142,13 +149,37 @@ class ExadataInfrastructureContact(object):
     def is_primary(self, is_primary):
         """
         Sets the is_primary of this ExadataInfrastructureContact.
-        True, if this Exadata Infrastructure contact is a primary contact. False, if this Exadata Infrastructure is a secondary contact.
+        If `true`, this Exadata Infrastructure contact is a primary contact. If `false`, this Exadata Infrastructure is a secondary contact.
 
 
         :param is_primary: The is_primary of this ExadataInfrastructureContact.
         :type: bool
         """
         self._is_primary = is_primary
+
+    @property
+    def is_contact_mos_validated(self):
+        """
+        Gets the is_contact_mos_validated of this ExadataInfrastructureContact.
+        If `true`, this Exadata Infrastructure contact is a valid My Oracle Support (MOS) contact. If `false`, this Exadata Infrastructure contact is not a valid MOS contact.
+
+
+        :return: The is_contact_mos_validated of this ExadataInfrastructureContact.
+        :rtype: bool
+        """
+        return self._is_contact_mos_validated
+
+    @is_contact_mos_validated.setter
+    def is_contact_mos_validated(self, is_contact_mos_validated):
+        """
+        Sets the is_contact_mos_validated of this ExadataInfrastructureContact.
+        If `true`, this Exadata Infrastructure contact is a valid My Oracle Support (MOS) contact. If `false`, this Exadata Infrastructure contact is not a valid MOS contact.
+
+
+        :param is_contact_mos_validated: The is_contact_mos_validated of this ExadataInfrastructureContact.
+        :type: bool
+        """
+        self._is_contact_mos_validated = is_contact_mos_validated
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/database/models/exadata_infrastructure_summary.py
+++ b/src/oci/database/models/exadata_infrastructure_summary.py
@@ -58,6 +58,14 @@ class ExadataInfrastructureSummary(object):
     #: This constant has a value of "MAINTENANCE_IN_PROGRESS"
     LIFECYCLE_STATE_MAINTENANCE_IN_PROGRESS = "MAINTENANCE_IN_PROGRESS"
 
+    #: A constant which can be used with the maintenance_slo_status property of a ExadataInfrastructureSummary.
+    #: This constant has a value of "OK"
+    MAINTENANCE_SLO_STATUS_OK = "OK"
+
+    #: A constant which can be used with the maintenance_slo_status property of a ExadataInfrastructureSummary.
+    #: This constant has a value of "DEGRADED"
+    MAINTENANCE_SLO_STATUS_DEGRADED = "DEGRADED"
+
     def __init__(self, **kwargs):
         """
         Initializes a new ExadataInfrastructureSummary object with values from keyword arguments.
@@ -173,6 +181,12 @@ class ExadataInfrastructureSummary(object):
             The value to assign to the contacts property of this ExadataInfrastructureSummary.
         :type contacts: list[oci.database.models.ExadataInfrastructureContact]
 
+        :param maintenance_slo_status:
+            The value to assign to the maintenance_slo_status property of this ExadataInfrastructureSummary.
+            Allowed values for this property are: "OK", "DEGRADED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type maintenance_slo_status: str
+
         :param maintenance_window:
             The value to assign to the maintenance_window property of this ExadataInfrastructureSummary.
         :type maintenance_window: oci.database.models.MaintenanceWindow
@@ -214,6 +228,7 @@ class ExadataInfrastructureSummary(object):
             'lifecycle_details': 'str',
             'csi_number': 'str',
             'contacts': 'list[ExadataInfrastructureContact]',
+            'maintenance_slo_status': 'str',
             'maintenance_window': 'MaintenanceWindow',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))'
@@ -247,6 +262,7 @@ class ExadataInfrastructureSummary(object):
             'lifecycle_details': 'lifecycleDetails',
             'csi_number': 'csiNumber',
             'contacts': 'contacts',
+            'maintenance_slo_status': 'maintenanceSLOStatus',
             'maintenance_window': 'maintenanceWindow',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags'
@@ -279,6 +295,7 @@ class ExadataInfrastructureSummary(object):
         self._lifecycle_details = None
         self._csi_number = None
         self._contacts = None
+        self._maintenance_slo_status = None
         self._maintenance_window = None
         self._freeform_tags = None
         self._defined_tags = None
@@ -948,6 +965,36 @@ class ExadataInfrastructureSummary(object):
         :type: list[oci.database.models.ExadataInfrastructureContact]
         """
         self._contacts = contacts
+
+    @property
+    def maintenance_slo_status(self):
+        """
+        Gets the maintenance_slo_status of this ExadataInfrastructureSummary.
+        A field to capture \u2018Maintenance SLO Status\u2019 for the Exadata infrastructure with values \u2018OK\u2019, \u2018DEGRADED\u2019. Default is \u2018OK\u2019 when the infrastructure is provisioned.
+
+        Allowed values for this property are: "OK", "DEGRADED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The maintenance_slo_status of this ExadataInfrastructureSummary.
+        :rtype: str
+        """
+        return self._maintenance_slo_status
+
+    @maintenance_slo_status.setter
+    def maintenance_slo_status(self, maintenance_slo_status):
+        """
+        Sets the maintenance_slo_status of this ExadataInfrastructureSummary.
+        A field to capture \u2018Maintenance SLO Status\u2019 for the Exadata infrastructure with values \u2018OK\u2019, \u2018DEGRADED\u2019. Default is \u2018OK\u2019 when the infrastructure is provisioned.
+
+
+        :param maintenance_slo_status: The maintenance_slo_status of this ExadataInfrastructureSummary.
+        :type: str
+        """
+        allowed_values = ["OK", "DEGRADED"]
+        if not value_allowed_none_or_none_sentinel(maintenance_slo_status, allowed_values):
+            maintenance_slo_status = 'UNKNOWN_ENUM_VALUE'
+        self._maintenance_slo_status = maintenance_slo_status
 
     @property
     def maintenance_window(self):

--- a/src/oci/database/models/external_container_database.py
+++ b/src/oci/database/models/external_container_database.py
@@ -1,0 +1,650 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ExternalContainerDatabase(object):
+    """
+    An Oracle Cloud Infrastructure resource that allows you to manage an external container database.
+    """
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalContainerDatabase.
+    #: This constant has a value of "PROVISIONING"
+    LIFECYCLE_STATE_PROVISIONING = "PROVISIONING"
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalContainerDatabase.
+    #: This constant has a value of "NOT_CONNECTED"
+    LIFECYCLE_STATE_NOT_CONNECTED = "NOT_CONNECTED"
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalContainerDatabase.
+    #: This constant has a value of "AVAILABLE"
+    LIFECYCLE_STATE_AVAILABLE = "AVAILABLE"
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalContainerDatabase.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalContainerDatabase.
+    #: This constant has a value of "TERMINATING"
+    LIFECYCLE_STATE_TERMINATING = "TERMINATING"
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalContainerDatabase.
+    #: This constant has a value of "TERMINATED"
+    LIFECYCLE_STATE_TERMINATED = "TERMINATED"
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalContainerDatabase.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    #: A constant which can be used with the database_edition property of a ExternalContainerDatabase.
+    #: This constant has a value of "STANDARD_EDITION"
+    DATABASE_EDITION_STANDARD_EDITION = "STANDARD_EDITION"
+
+    #: A constant which can be used with the database_edition property of a ExternalContainerDatabase.
+    #: This constant has a value of "ENTERPRISE_EDITION"
+    DATABASE_EDITION_ENTERPRISE_EDITION = "ENTERPRISE_EDITION"
+
+    #: A constant which can be used with the database_edition property of a ExternalContainerDatabase.
+    #: This constant has a value of "ENTERPRISE_EDITION_HIGH_PERFORMANCE"
+    DATABASE_EDITION_ENTERPRISE_EDITION_HIGH_PERFORMANCE = "ENTERPRISE_EDITION_HIGH_PERFORMANCE"
+
+    #: A constant which can be used with the database_edition property of a ExternalContainerDatabase.
+    #: This constant has a value of "ENTERPRISE_EDITION_EXTREME_PERFORMANCE"
+    DATABASE_EDITION_ENTERPRISE_EDITION_EXTREME_PERFORMANCE = "ENTERPRISE_EDITION_EXTREME_PERFORMANCE"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ExternalContainerDatabase object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ExternalContainerDatabase.
+        :type compartment_id: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this ExternalContainerDatabase.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this ExternalContainerDatabase.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param display_name:
+            The value to assign to the display_name property of this ExternalContainerDatabase.
+        :type display_name: str
+
+        :param id:
+            The value to assign to the id property of this ExternalContainerDatabase.
+        :type id: str
+
+        :param lifecycle_details:
+            The value to assign to the lifecycle_details property of this ExternalContainerDatabase.
+        :type lifecycle_details: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this ExternalContainerDatabase.
+            Allowed values for this property are: "PROVISIONING", "NOT_CONNECTED", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param time_created:
+            The value to assign to the time_created property of this ExternalContainerDatabase.
+        :type time_created: datetime
+
+        :param db_unique_name:
+            The value to assign to the db_unique_name property of this ExternalContainerDatabase.
+        :type db_unique_name: str
+
+        :param db_id:
+            The value to assign to the db_id property of this ExternalContainerDatabase.
+        :type db_id: str
+
+        :param database_version:
+            The value to assign to the database_version property of this ExternalContainerDatabase.
+        :type database_version: str
+
+        :param database_edition:
+            The value to assign to the database_edition property of this ExternalContainerDatabase.
+            Allowed values for this property are: "STANDARD_EDITION", "ENTERPRISE_EDITION", "ENTERPRISE_EDITION_HIGH_PERFORMANCE", "ENTERPRISE_EDITION_EXTREME_PERFORMANCE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type database_edition: str
+
+        :param time_zone:
+            The value to assign to the time_zone property of this ExternalContainerDatabase.
+        :type time_zone: str
+
+        :param character_set:
+            The value to assign to the character_set property of this ExternalContainerDatabase.
+        :type character_set: str
+
+        :param ncharacter_set:
+            The value to assign to the ncharacter_set property of this ExternalContainerDatabase.
+        :type ncharacter_set: str
+
+        :param db_packs:
+            The value to assign to the db_packs property of this ExternalContainerDatabase.
+        :type db_packs: str
+
+        :param database_management_config:
+            The value to assign to the database_management_config property of this ExternalContainerDatabase.
+        :type database_management_config: oci.database.models.DatabaseManagementConfig
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'display_name': 'str',
+            'id': 'str',
+            'lifecycle_details': 'str',
+            'lifecycle_state': 'str',
+            'time_created': 'datetime',
+            'db_unique_name': 'str',
+            'db_id': 'str',
+            'database_version': 'str',
+            'database_edition': 'str',
+            'time_zone': 'str',
+            'character_set': 'str',
+            'ncharacter_set': 'str',
+            'db_packs': 'str',
+            'database_management_config': 'DatabaseManagementConfig'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags',
+            'display_name': 'displayName',
+            'id': 'id',
+            'lifecycle_details': 'lifecycleDetails',
+            'lifecycle_state': 'lifecycleState',
+            'time_created': 'timeCreated',
+            'db_unique_name': 'dbUniqueName',
+            'db_id': 'dbId',
+            'database_version': 'databaseVersion',
+            'database_edition': 'databaseEdition',
+            'time_zone': 'timeZone',
+            'character_set': 'characterSet',
+            'ncharacter_set': 'ncharacterSet',
+            'db_packs': 'dbPacks',
+            'database_management_config': 'databaseManagementConfig'
+        }
+
+        self._compartment_id = None
+        self._freeform_tags = None
+        self._defined_tags = None
+        self._display_name = None
+        self._id = None
+        self._lifecycle_details = None
+        self._lifecycle_state = None
+        self._time_created = None
+        self._db_unique_name = None
+        self._db_id = None
+        self._database_version = None
+        self._database_edition = None
+        self._time_zone = None
+        self._character_set = None
+        self._ncharacter_set = None
+        self._db_packs = None
+        self._database_management_config = None
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this ExternalContainerDatabase.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this ExternalContainerDatabase.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this ExternalContainerDatabase.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this ExternalContainerDatabase.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this ExternalContainerDatabase.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this ExternalContainerDatabase.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this ExternalContainerDatabase.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this ExternalContainerDatabase.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this ExternalContainerDatabase.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this ExternalContainerDatabase.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this ExternalContainerDatabase.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this ExternalContainerDatabase.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this ExternalContainerDatabase.
+        The user-friendly name for the external database. The name does not have to be unique.
+
+
+        :return: The display_name of this ExternalContainerDatabase.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this ExternalContainerDatabase.
+        The user-friendly name for the external database. The name does not have to be unique.
+
+
+        :param display_name: The display_name of this ExternalContainerDatabase.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this ExternalContainerDatabase.
+        The `OCID`__ of the Oracle Cloud Infrastructure external database resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The id of this ExternalContainerDatabase.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this ExternalContainerDatabase.
+        The `OCID`__ of the Oracle Cloud Infrastructure external database resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param id: The id of this ExternalContainerDatabase.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def lifecycle_details(self):
+        """
+        Gets the lifecycle_details of this ExternalContainerDatabase.
+        Additional information about the current lifecycle state.
+
+
+        :return: The lifecycle_details of this ExternalContainerDatabase.
+        :rtype: str
+        """
+        return self._lifecycle_details
+
+    @lifecycle_details.setter
+    def lifecycle_details(self, lifecycle_details):
+        """
+        Sets the lifecycle_details of this ExternalContainerDatabase.
+        Additional information about the current lifecycle state.
+
+
+        :param lifecycle_details: The lifecycle_details of this ExternalContainerDatabase.
+        :type: str
+        """
+        self._lifecycle_details = lifecycle_details
+
+    @property
+    def lifecycle_state(self):
+        """
+        **[Required]** Gets the lifecycle_state of this ExternalContainerDatabase.
+        The current state of the Oracle Cloud Infrastructure external database resource.
+
+        Allowed values for this property are: "PROVISIONING", "NOT_CONNECTED", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this ExternalContainerDatabase.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this ExternalContainerDatabase.
+        The current state of the Oracle Cloud Infrastructure external database resource.
+
+
+        :param lifecycle_state: The lifecycle_state of this ExternalContainerDatabase.
+        :type: str
+        """
+        allowed_values = ["PROVISIONING", "NOT_CONNECTED", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def time_created(self):
+        """
+        **[Required]** Gets the time_created of this ExternalContainerDatabase.
+        The date and time the database was created.
+
+
+        :return: The time_created of this ExternalContainerDatabase.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this ExternalContainerDatabase.
+        The date and time the database was created.
+
+
+        :param time_created: The time_created of this ExternalContainerDatabase.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def db_unique_name(self):
+        """
+        Gets the db_unique_name of this ExternalContainerDatabase.
+        The `DB_UNIQUE_NAME` of the external database.
+
+
+        :return: The db_unique_name of this ExternalContainerDatabase.
+        :rtype: str
+        """
+        return self._db_unique_name
+
+    @db_unique_name.setter
+    def db_unique_name(self, db_unique_name):
+        """
+        Sets the db_unique_name of this ExternalContainerDatabase.
+        The `DB_UNIQUE_NAME` of the external database.
+
+
+        :param db_unique_name: The db_unique_name of this ExternalContainerDatabase.
+        :type: str
+        """
+        self._db_unique_name = db_unique_name
+
+    @property
+    def db_id(self):
+        """
+        Gets the db_id of this ExternalContainerDatabase.
+        The Oracle Database ID, which identifies an Oracle Database located outside of Oracle Cloud.
+
+
+        :return: The db_id of this ExternalContainerDatabase.
+        :rtype: str
+        """
+        return self._db_id
+
+    @db_id.setter
+    def db_id(self, db_id):
+        """
+        Sets the db_id of this ExternalContainerDatabase.
+        The Oracle Database ID, which identifies an Oracle Database located outside of Oracle Cloud.
+
+
+        :param db_id: The db_id of this ExternalContainerDatabase.
+        :type: str
+        """
+        self._db_id = db_id
+
+    @property
+    def database_version(self):
+        """
+        Gets the database_version of this ExternalContainerDatabase.
+        The Oracle Database version.
+
+
+        :return: The database_version of this ExternalContainerDatabase.
+        :rtype: str
+        """
+        return self._database_version
+
+    @database_version.setter
+    def database_version(self, database_version):
+        """
+        Sets the database_version of this ExternalContainerDatabase.
+        The Oracle Database version.
+
+
+        :param database_version: The database_version of this ExternalContainerDatabase.
+        :type: str
+        """
+        self._database_version = database_version
+
+    @property
+    def database_edition(self):
+        """
+        Gets the database_edition of this ExternalContainerDatabase.
+        The Oracle Database edition.
+
+        Allowed values for this property are: "STANDARD_EDITION", "ENTERPRISE_EDITION", "ENTERPRISE_EDITION_HIGH_PERFORMANCE", "ENTERPRISE_EDITION_EXTREME_PERFORMANCE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The database_edition of this ExternalContainerDatabase.
+        :rtype: str
+        """
+        return self._database_edition
+
+    @database_edition.setter
+    def database_edition(self, database_edition):
+        """
+        Sets the database_edition of this ExternalContainerDatabase.
+        The Oracle Database edition.
+
+
+        :param database_edition: The database_edition of this ExternalContainerDatabase.
+        :type: str
+        """
+        allowed_values = ["STANDARD_EDITION", "ENTERPRISE_EDITION", "ENTERPRISE_EDITION_HIGH_PERFORMANCE", "ENTERPRISE_EDITION_EXTREME_PERFORMANCE"]
+        if not value_allowed_none_or_none_sentinel(database_edition, allowed_values):
+            database_edition = 'UNKNOWN_ENUM_VALUE'
+        self._database_edition = database_edition
+
+    @property
+    def time_zone(self):
+        """
+        Gets the time_zone of this ExternalContainerDatabase.
+        The time zone of the external database.
+        It is a time zone offset (a character type in the format '[+|-]TZH:TZM') or a time zone region name,
+        depending on how the time zone value was specified when the database was created / last altered.
+
+
+        :return: The time_zone of this ExternalContainerDatabase.
+        :rtype: str
+        """
+        return self._time_zone
+
+    @time_zone.setter
+    def time_zone(self, time_zone):
+        """
+        Sets the time_zone of this ExternalContainerDatabase.
+        The time zone of the external database.
+        It is a time zone offset (a character type in the format '[+|-]TZH:TZM') or a time zone region name,
+        depending on how the time zone value was specified when the database was created / last altered.
+
+
+        :param time_zone: The time_zone of this ExternalContainerDatabase.
+        :type: str
+        """
+        self._time_zone = time_zone
+
+    @property
+    def character_set(self):
+        """
+        Gets the character_set of this ExternalContainerDatabase.
+        The character set of the external database.
+
+
+        :return: The character_set of this ExternalContainerDatabase.
+        :rtype: str
+        """
+        return self._character_set
+
+    @character_set.setter
+    def character_set(self, character_set):
+        """
+        Sets the character_set of this ExternalContainerDatabase.
+        The character set of the external database.
+
+
+        :param character_set: The character_set of this ExternalContainerDatabase.
+        :type: str
+        """
+        self._character_set = character_set
+
+    @property
+    def ncharacter_set(self):
+        """
+        Gets the ncharacter_set of this ExternalContainerDatabase.
+        The national character of the external database.
+
+
+        :return: The ncharacter_set of this ExternalContainerDatabase.
+        :rtype: str
+        """
+        return self._ncharacter_set
+
+    @ncharacter_set.setter
+    def ncharacter_set(self, ncharacter_set):
+        """
+        Sets the ncharacter_set of this ExternalContainerDatabase.
+        The national character of the external database.
+
+
+        :param ncharacter_set: The ncharacter_set of this ExternalContainerDatabase.
+        :type: str
+        """
+        self._ncharacter_set = ncharacter_set
+
+    @property
+    def db_packs(self):
+        """
+        Gets the db_packs of this ExternalContainerDatabase.
+        The database packs licensed for the external Oracle Database.
+
+
+        :return: The db_packs of this ExternalContainerDatabase.
+        :rtype: str
+        """
+        return self._db_packs
+
+    @db_packs.setter
+    def db_packs(self, db_packs):
+        """
+        Sets the db_packs of this ExternalContainerDatabase.
+        The database packs licensed for the external Oracle Database.
+
+
+        :param db_packs: The db_packs of this ExternalContainerDatabase.
+        :type: str
+        """
+        self._db_packs = db_packs
+
+    @property
+    def database_management_config(self):
+        """
+        Gets the database_management_config of this ExternalContainerDatabase.
+
+        :return: The database_management_config of this ExternalContainerDatabase.
+        :rtype: oci.database.models.DatabaseManagementConfig
+        """
+        return self._database_management_config
+
+    @database_management_config.setter
+    def database_management_config(self, database_management_config):
+        """
+        Sets the database_management_config of this ExternalContainerDatabase.
+
+        :param database_management_config: The database_management_config of this ExternalContainerDatabase.
+        :type: oci.database.models.DatabaseManagementConfig
+        """
+        self._database_management_config = database_management_config
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/external_container_database_summary.py
+++ b/src/oci/database/models/external_container_database_summary.py
@@ -1,0 +1,650 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ExternalContainerDatabaseSummary(object):
+    """
+    An Oracle Cloud Infrastructure resource that allows you to manage an external Oracle container database.
+    """
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalContainerDatabaseSummary.
+    #: This constant has a value of "PROVISIONING"
+    LIFECYCLE_STATE_PROVISIONING = "PROVISIONING"
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalContainerDatabaseSummary.
+    #: This constant has a value of "NOT_CONNECTED"
+    LIFECYCLE_STATE_NOT_CONNECTED = "NOT_CONNECTED"
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalContainerDatabaseSummary.
+    #: This constant has a value of "AVAILABLE"
+    LIFECYCLE_STATE_AVAILABLE = "AVAILABLE"
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalContainerDatabaseSummary.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalContainerDatabaseSummary.
+    #: This constant has a value of "TERMINATING"
+    LIFECYCLE_STATE_TERMINATING = "TERMINATING"
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalContainerDatabaseSummary.
+    #: This constant has a value of "TERMINATED"
+    LIFECYCLE_STATE_TERMINATED = "TERMINATED"
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalContainerDatabaseSummary.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    #: A constant which can be used with the database_edition property of a ExternalContainerDatabaseSummary.
+    #: This constant has a value of "STANDARD_EDITION"
+    DATABASE_EDITION_STANDARD_EDITION = "STANDARD_EDITION"
+
+    #: A constant which can be used with the database_edition property of a ExternalContainerDatabaseSummary.
+    #: This constant has a value of "ENTERPRISE_EDITION"
+    DATABASE_EDITION_ENTERPRISE_EDITION = "ENTERPRISE_EDITION"
+
+    #: A constant which can be used with the database_edition property of a ExternalContainerDatabaseSummary.
+    #: This constant has a value of "ENTERPRISE_EDITION_HIGH_PERFORMANCE"
+    DATABASE_EDITION_ENTERPRISE_EDITION_HIGH_PERFORMANCE = "ENTERPRISE_EDITION_HIGH_PERFORMANCE"
+
+    #: A constant which can be used with the database_edition property of a ExternalContainerDatabaseSummary.
+    #: This constant has a value of "ENTERPRISE_EDITION_EXTREME_PERFORMANCE"
+    DATABASE_EDITION_ENTERPRISE_EDITION_EXTREME_PERFORMANCE = "ENTERPRISE_EDITION_EXTREME_PERFORMANCE"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ExternalContainerDatabaseSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ExternalContainerDatabaseSummary.
+        :type compartment_id: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this ExternalContainerDatabaseSummary.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this ExternalContainerDatabaseSummary.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param display_name:
+            The value to assign to the display_name property of this ExternalContainerDatabaseSummary.
+        :type display_name: str
+
+        :param id:
+            The value to assign to the id property of this ExternalContainerDatabaseSummary.
+        :type id: str
+
+        :param lifecycle_details:
+            The value to assign to the lifecycle_details property of this ExternalContainerDatabaseSummary.
+        :type lifecycle_details: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this ExternalContainerDatabaseSummary.
+            Allowed values for this property are: "PROVISIONING", "NOT_CONNECTED", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param time_created:
+            The value to assign to the time_created property of this ExternalContainerDatabaseSummary.
+        :type time_created: datetime
+
+        :param db_unique_name:
+            The value to assign to the db_unique_name property of this ExternalContainerDatabaseSummary.
+        :type db_unique_name: str
+
+        :param db_id:
+            The value to assign to the db_id property of this ExternalContainerDatabaseSummary.
+        :type db_id: str
+
+        :param database_version:
+            The value to assign to the database_version property of this ExternalContainerDatabaseSummary.
+        :type database_version: str
+
+        :param database_edition:
+            The value to assign to the database_edition property of this ExternalContainerDatabaseSummary.
+            Allowed values for this property are: "STANDARD_EDITION", "ENTERPRISE_EDITION", "ENTERPRISE_EDITION_HIGH_PERFORMANCE", "ENTERPRISE_EDITION_EXTREME_PERFORMANCE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type database_edition: str
+
+        :param time_zone:
+            The value to assign to the time_zone property of this ExternalContainerDatabaseSummary.
+        :type time_zone: str
+
+        :param character_set:
+            The value to assign to the character_set property of this ExternalContainerDatabaseSummary.
+        :type character_set: str
+
+        :param ncharacter_set:
+            The value to assign to the ncharacter_set property of this ExternalContainerDatabaseSummary.
+        :type ncharacter_set: str
+
+        :param db_packs:
+            The value to assign to the db_packs property of this ExternalContainerDatabaseSummary.
+        :type db_packs: str
+
+        :param database_management_config:
+            The value to assign to the database_management_config property of this ExternalContainerDatabaseSummary.
+        :type database_management_config: oci.database.models.DatabaseManagementConfig
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'display_name': 'str',
+            'id': 'str',
+            'lifecycle_details': 'str',
+            'lifecycle_state': 'str',
+            'time_created': 'datetime',
+            'db_unique_name': 'str',
+            'db_id': 'str',
+            'database_version': 'str',
+            'database_edition': 'str',
+            'time_zone': 'str',
+            'character_set': 'str',
+            'ncharacter_set': 'str',
+            'db_packs': 'str',
+            'database_management_config': 'DatabaseManagementConfig'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags',
+            'display_name': 'displayName',
+            'id': 'id',
+            'lifecycle_details': 'lifecycleDetails',
+            'lifecycle_state': 'lifecycleState',
+            'time_created': 'timeCreated',
+            'db_unique_name': 'dbUniqueName',
+            'db_id': 'dbId',
+            'database_version': 'databaseVersion',
+            'database_edition': 'databaseEdition',
+            'time_zone': 'timeZone',
+            'character_set': 'characterSet',
+            'ncharacter_set': 'ncharacterSet',
+            'db_packs': 'dbPacks',
+            'database_management_config': 'databaseManagementConfig'
+        }
+
+        self._compartment_id = None
+        self._freeform_tags = None
+        self._defined_tags = None
+        self._display_name = None
+        self._id = None
+        self._lifecycle_details = None
+        self._lifecycle_state = None
+        self._time_created = None
+        self._db_unique_name = None
+        self._db_id = None
+        self._database_version = None
+        self._database_edition = None
+        self._time_zone = None
+        self._character_set = None
+        self._ncharacter_set = None
+        self._db_packs = None
+        self._database_management_config = None
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this ExternalContainerDatabaseSummary.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this ExternalContainerDatabaseSummary.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this ExternalContainerDatabaseSummary.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this ExternalContainerDatabaseSummary.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this ExternalContainerDatabaseSummary.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this ExternalContainerDatabaseSummary.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this ExternalContainerDatabaseSummary.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this ExternalContainerDatabaseSummary.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this ExternalContainerDatabaseSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this ExternalContainerDatabaseSummary.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this ExternalContainerDatabaseSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this ExternalContainerDatabaseSummary.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this ExternalContainerDatabaseSummary.
+        The user-friendly name for the external database. The name does not have to be unique.
+
+
+        :return: The display_name of this ExternalContainerDatabaseSummary.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this ExternalContainerDatabaseSummary.
+        The user-friendly name for the external database. The name does not have to be unique.
+
+
+        :param display_name: The display_name of this ExternalContainerDatabaseSummary.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this ExternalContainerDatabaseSummary.
+        The `OCID`__ of the Oracle Cloud Infrastructure external database resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The id of this ExternalContainerDatabaseSummary.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this ExternalContainerDatabaseSummary.
+        The `OCID`__ of the Oracle Cloud Infrastructure external database resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param id: The id of this ExternalContainerDatabaseSummary.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def lifecycle_details(self):
+        """
+        Gets the lifecycle_details of this ExternalContainerDatabaseSummary.
+        Additional information about the current lifecycle state.
+
+
+        :return: The lifecycle_details of this ExternalContainerDatabaseSummary.
+        :rtype: str
+        """
+        return self._lifecycle_details
+
+    @lifecycle_details.setter
+    def lifecycle_details(self, lifecycle_details):
+        """
+        Sets the lifecycle_details of this ExternalContainerDatabaseSummary.
+        Additional information about the current lifecycle state.
+
+
+        :param lifecycle_details: The lifecycle_details of this ExternalContainerDatabaseSummary.
+        :type: str
+        """
+        self._lifecycle_details = lifecycle_details
+
+    @property
+    def lifecycle_state(self):
+        """
+        **[Required]** Gets the lifecycle_state of this ExternalContainerDatabaseSummary.
+        The current state of the Oracle Cloud Infrastructure external database resource.
+
+        Allowed values for this property are: "PROVISIONING", "NOT_CONNECTED", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this ExternalContainerDatabaseSummary.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this ExternalContainerDatabaseSummary.
+        The current state of the Oracle Cloud Infrastructure external database resource.
+
+
+        :param lifecycle_state: The lifecycle_state of this ExternalContainerDatabaseSummary.
+        :type: str
+        """
+        allowed_values = ["PROVISIONING", "NOT_CONNECTED", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def time_created(self):
+        """
+        **[Required]** Gets the time_created of this ExternalContainerDatabaseSummary.
+        The date and time the database was created.
+
+
+        :return: The time_created of this ExternalContainerDatabaseSummary.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this ExternalContainerDatabaseSummary.
+        The date and time the database was created.
+
+
+        :param time_created: The time_created of this ExternalContainerDatabaseSummary.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def db_unique_name(self):
+        """
+        Gets the db_unique_name of this ExternalContainerDatabaseSummary.
+        The `DB_UNIQUE_NAME` of the external database.
+
+
+        :return: The db_unique_name of this ExternalContainerDatabaseSummary.
+        :rtype: str
+        """
+        return self._db_unique_name
+
+    @db_unique_name.setter
+    def db_unique_name(self, db_unique_name):
+        """
+        Sets the db_unique_name of this ExternalContainerDatabaseSummary.
+        The `DB_UNIQUE_NAME` of the external database.
+
+
+        :param db_unique_name: The db_unique_name of this ExternalContainerDatabaseSummary.
+        :type: str
+        """
+        self._db_unique_name = db_unique_name
+
+    @property
+    def db_id(self):
+        """
+        Gets the db_id of this ExternalContainerDatabaseSummary.
+        The Oracle Database ID, which identifies an Oracle Database located outside of Oracle Cloud.
+
+
+        :return: The db_id of this ExternalContainerDatabaseSummary.
+        :rtype: str
+        """
+        return self._db_id
+
+    @db_id.setter
+    def db_id(self, db_id):
+        """
+        Sets the db_id of this ExternalContainerDatabaseSummary.
+        The Oracle Database ID, which identifies an Oracle Database located outside of Oracle Cloud.
+
+
+        :param db_id: The db_id of this ExternalContainerDatabaseSummary.
+        :type: str
+        """
+        self._db_id = db_id
+
+    @property
+    def database_version(self):
+        """
+        Gets the database_version of this ExternalContainerDatabaseSummary.
+        The Oracle Database version.
+
+
+        :return: The database_version of this ExternalContainerDatabaseSummary.
+        :rtype: str
+        """
+        return self._database_version
+
+    @database_version.setter
+    def database_version(self, database_version):
+        """
+        Sets the database_version of this ExternalContainerDatabaseSummary.
+        The Oracle Database version.
+
+
+        :param database_version: The database_version of this ExternalContainerDatabaseSummary.
+        :type: str
+        """
+        self._database_version = database_version
+
+    @property
+    def database_edition(self):
+        """
+        Gets the database_edition of this ExternalContainerDatabaseSummary.
+        The Oracle Database edition.
+
+        Allowed values for this property are: "STANDARD_EDITION", "ENTERPRISE_EDITION", "ENTERPRISE_EDITION_HIGH_PERFORMANCE", "ENTERPRISE_EDITION_EXTREME_PERFORMANCE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The database_edition of this ExternalContainerDatabaseSummary.
+        :rtype: str
+        """
+        return self._database_edition
+
+    @database_edition.setter
+    def database_edition(self, database_edition):
+        """
+        Sets the database_edition of this ExternalContainerDatabaseSummary.
+        The Oracle Database edition.
+
+
+        :param database_edition: The database_edition of this ExternalContainerDatabaseSummary.
+        :type: str
+        """
+        allowed_values = ["STANDARD_EDITION", "ENTERPRISE_EDITION", "ENTERPRISE_EDITION_HIGH_PERFORMANCE", "ENTERPRISE_EDITION_EXTREME_PERFORMANCE"]
+        if not value_allowed_none_or_none_sentinel(database_edition, allowed_values):
+            database_edition = 'UNKNOWN_ENUM_VALUE'
+        self._database_edition = database_edition
+
+    @property
+    def time_zone(self):
+        """
+        Gets the time_zone of this ExternalContainerDatabaseSummary.
+        The time zone of the external database.
+        It is a time zone offset (a character type in the format '[+|-]TZH:TZM') or a time zone region name,
+        depending on how the time zone value was specified when the database was created / last altered.
+
+
+        :return: The time_zone of this ExternalContainerDatabaseSummary.
+        :rtype: str
+        """
+        return self._time_zone
+
+    @time_zone.setter
+    def time_zone(self, time_zone):
+        """
+        Sets the time_zone of this ExternalContainerDatabaseSummary.
+        The time zone of the external database.
+        It is a time zone offset (a character type in the format '[+|-]TZH:TZM') or a time zone region name,
+        depending on how the time zone value was specified when the database was created / last altered.
+
+
+        :param time_zone: The time_zone of this ExternalContainerDatabaseSummary.
+        :type: str
+        """
+        self._time_zone = time_zone
+
+    @property
+    def character_set(self):
+        """
+        Gets the character_set of this ExternalContainerDatabaseSummary.
+        The character set of the external database.
+
+
+        :return: The character_set of this ExternalContainerDatabaseSummary.
+        :rtype: str
+        """
+        return self._character_set
+
+    @character_set.setter
+    def character_set(self, character_set):
+        """
+        Sets the character_set of this ExternalContainerDatabaseSummary.
+        The character set of the external database.
+
+
+        :param character_set: The character_set of this ExternalContainerDatabaseSummary.
+        :type: str
+        """
+        self._character_set = character_set
+
+    @property
+    def ncharacter_set(self):
+        """
+        Gets the ncharacter_set of this ExternalContainerDatabaseSummary.
+        The national character of the external database.
+
+
+        :return: The ncharacter_set of this ExternalContainerDatabaseSummary.
+        :rtype: str
+        """
+        return self._ncharacter_set
+
+    @ncharacter_set.setter
+    def ncharacter_set(self, ncharacter_set):
+        """
+        Sets the ncharacter_set of this ExternalContainerDatabaseSummary.
+        The national character of the external database.
+
+
+        :param ncharacter_set: The ncharacter_set of this ExternalContainerDatabaseSummary.
+        :type: str
+        """
+        self._ncharacter_set = ncharacter_set
+
+    @property
+    def db_packs(self):
+        """
+        Gets the db_packs of this ExternalContainerDatabaseSummary.
+        The database packs licensed for the external Oracle Database.
+
+
+        :return: The db_packs of this ExternalContainerDatabaseSummary.
+        :rtype: str
+        """
+        return self._db_packs
+
+    @db_packs.setter
+    def db_packs(self, db_packs):
+        """
+        Sets the db_packs of this ExternalContainerDatabaseSummary.
+        The database packs licensed for the external Oracle Database.
+
+
+        :param db_packs: The db_packs of this ExternalContainerDatabaseSummary.
+        :type: str
+        """
+        self._db_packs = db_packs
+
+    @property
+    def database_management_config(self):
+        """
+        Gets the database_management_config of this ExternalContainerDatabaseSummary.
+
+        :return: The database_management_config of this ExternalContainerDatabaseSummary.
+        :rtype: oci.database.models.DatabaseManagementConfig
+        """
+        return self._database_management_config
+
+    @database_management_config.setter
+    def database_management_config(self, database_management_config):
+        """
+        Sets the database_management_config of this ExternalContainerDatabaseSummary.
+
+        :param database_management_config: The database_management_config of this ExternalContainerDatabaseSummary.
+        :type: oci.database.models.DatabaseManagementConfig
+        """
+        self._database_management_config = database_management_config
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/external_database_base.py
+++ b/src/oci/database/models/external_database_base.py
@@ -1,0 +1,652 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ExternalDatabaseBase(object):
+    """
+    A resource that allows you to manage an Oracle Database located outside of Oracle Cloud using Oracle Cloud Infrastructure's Console and APIs.
+    """
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalDatabaseBase.
+    #: This constant has a value of "PROVISIONING"
+    LIFECYCLE_STATE_PROVISIONING = "PROVISIONING"
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalDatabaseBase.
+    #: This constant has a value of "NOT_CONNECTED"
+    LIFECYCLE_STATE_NOT_CONNECTED = "NOT_CONNECTED"
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalDatabaseBase.
+    #: This constant has a value of "AVAILABLE"
+    LIFECYCLE_STATE_AVAILABLE = "AVAILABLE"
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalDatabaseBase.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalDatabaseBase.
+    #: This constant has a value of "TERMINATING"
+    LIFECYCLE_STATE_TERMINATING = "TERMINATING"
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalDatabaseBase.
+    #: This constant has a value of "TERMINATED"
+    LIFECYCLE_STATE_TERMINATED = "TERMINATED"
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalDatabaseBase.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    #: A constant which can be used with the database_edition property of a ExternalDatabaseBase.
+    #: This constant has a value of "STANDARD_EDITION"
+    DATABASE_EDITION_STANDARD_EDITION = "STANDARD_EDITION"
+
+    #: A constant which can be used with the database_edition property of a ExternalDatabaseBase.
+    #: This constant has a value of "ENTERPRISE_EDITION"
+    DATABASE_EDITION_ENTERPRISE_EDITION = "ENTERPRISE_EDITION"
+
+    #: A constant which can be used with the database_edition property of a ExternalDatabaseBase.
+    #: This constant has a value of "ENTERPRISE_EDITION_HIGH_PERFORMANCE"
+    DATABASE_EDITION_ENTERPRISE_EDITION_HIGH_PERFORMANCE = "ENTERPRISE_EDITION_HIGH_PERFORMANCE"
+
+    #: A constant which can be used with the database_edition property of a ExternalDatabaseBase.
+    #: This constant has a value of "ENTERPRISE_EDITION_EXTREME_PERFORMANCE"
+    DATABASE_EDITION_ENTERPRISE_EDITION_EXTREME_PERFORMANCE = "ENTERPRISE_EDITION_EXTREME_PERFORMANCE"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ExternalDatabaseBase object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ExternalDatabaseBase.
+        :type compartment_id: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this ExternalDatabaseBase.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this ExternalDatabaseBase.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param display_name:
+            The value to assign to the display_name property of this ExternalDatabaseBase.
+        :type display_name: str
+
+        :param id:
+            The value to assign to the id property of this ExternalDatabaseBase.
+        :type id: str
+
+        :param lifecycle_details:
+            The value to assign to the lifecycle_details property of this ExternalDatabaseBase.
+        :type lifecycle_details: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this ExternalDatabaseBase.
+            Allowed values for this property are: "PROVISIONING", "NOT_CONNECTED", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED"
+        :type lifecycle_state: str
+
+        :param time_created:
+            The value to assign to the time_created property of this ExternalDatabaseBase.
+        :type time_created: datetime
+
+        :param db_unique_name:
+            The value to assign to the db_unique_name property of this ExternalDatabaseBase.
+        :type db_unique_name: str
+
+        :param db_id:
+            The value to assign to the db_id property of this ExternalDatabaseBase.
+        :type db_id: str
+
+        :param database_version:
+            The value to assign to the database_version property of this ExternalDatabaseBase.
+        :type database_version: str
+
+        :param database_edition:
+            The value to assign to the database_edition property of this ExternalDatabaseBase.
+            Allowed values for this property are: "STANDARD_EDITION", "ENTERPRISE_EDITION", "ENTERPRISE_EDITION_HIGH_PERFORMANCE", "ENTERPRISE_EDITION_EXTREME_PERFORMANCE"
+        :type database_edition: str
+
+        :param time_zone:
+            The value to assign to the time_zone property of this ExternalDatabaseBase.
+        :type time_zone: str
+
+        :param character_set:
+            The value to assign to the character_set property of this ExternalDatabaseBase.
+        :type character_set: str
+
+        :param ncharacter_set:
+            The value to assign to the ncharacter_set property of this ExternalDatabaseBase.
+        :type ncharacter_set: str
+
+        :param db_packs:
+            The value to assign to the db_packs property of this ExternalDatabaseBase.
+        :type db_packs: str
+
+        :param database_management_config:
+            The value to assign to the database_management_config property of this ExternalDatabaseBase.
+        :type database_management_config: oci.database.models.DatabaseManagementConfig
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'display_name': 'str',
+            'id': 'str',
+            'lifecycle_details': 'str',
+            'lifecycle_state': 'str',
+            'time_created': 'datetime',
+            'db_unique_name': 'str',
+            'db_id': 'str',
+            'database_version': 'str',
+            'database_edition': 'str',
+            'time_zone': 'str',
+            'character_set': 'str',
+            'ncharacter_set': 'str',
+            'db_packs': 'str',
+            'database_management_config': 'DatabaseManagementConfig'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags',
+            'display_name': 'displayName',
+            'id': 'id',
+            'lifecycle_details': 'lifecycleDetails',
+            'lifecycle_state': 'lifecycleState',
+            'time_created': 'timeCreated',
+            'db_unique_name': 'dbUniqueName',
+            'db_id': 'dbId',
+            'database_version': 'databaseVersion',
+            'database_edition': 'databaseEdition',
+            'time_zone': 'timeZone',
+            'character_set': 'characterSet',
+            'ncharacter_set': 'ncharacterSet',
+            'db_packs': 'dbPacks',
+            'database_management_config': 'databaseManagementConfig'
+        }
+
+        self._compartment_id = None
+        self._freeform_tags = None
+        self._defined_tags = None
+        self._display_name = None
+        self._id = None
+        self._lifecycle_details = None
+        self._lifecycle_state = None
+        self._time_created = None
+        self._db_unique_name = None
+        self._db_id = None
+        self._database_version = None
+        self._database_edition = None
+        self._time_zone = None
+        self._character_set = None
+        self._ncharacter_set = None
+        self._db_packs = None
+        self._database_management_config = None
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this ExternalDatabaseBase.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this ExternalDatabaseBase.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this ExternalDatabaseBase.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this ExternalDatabaseBase.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this ExternalDatabaseBase.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this ExternalDatabaseBase.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this ExternalDatabaseBase.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this ExternalDatabaseBase.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this ExternalDatabaseBase.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this ExternalDatabaseBase.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this ExternalDatabaseBase.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this ExternalDatabaseBase.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this ExternalDatabaseBase.
+        The user-friendly name for the external database. The name does not have to be unique.
+
+
+        :return: The display_name of this ExternalDatabaseBase.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this ExternalDatabaseBase.
+        The user-friendly name for the external database. The name does not have to be unique.
+
+
+        :param display_name: The display_name of this ExternalDatabaseBase.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this ExternalDatabaseBase.
+        The `OCID`__ of the Oracle Cloud Infrastructure external database resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The id of this ExternalDatabaseBase.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this ExternalDatabaseBase.
+        The `OCID`__ of the Oracle Cloud Infrastructure external database resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param id: The id of this ExternalDatabaseBase.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def lifecycle_details(self):
+        """
+        Gets the lifecycle_details of this ExternalDatabaseBase.
+        Additional information about the current lifecycle state.
+
+
+        :return: The lifecycle_details of this ExternalDatabaseBase.
+        :rtype: str
+        """
+        return self._lifecycle_details
+
+    @lifecycle_details.setter
+    def lifecycle_details(self, lifecycle_details):
+        """
+        Sets the lifecycle_details of this ExternalDatabaseBase.
+        Additional information about the current lifecycle state.
+
+
+        :param lifecycle_details: The lifecycle_details of this ExternalDatabaseBase.
+        :type: str
+        """
+        self._lifecycle_details = lifecycle_details
+
+    @property
+    def lifecycle_state(self):
+        """
+        **[Required]** Gets the lifecycle_state of this ExternalDatabaseBase.
+        The current state of the Oracle Cloud Infrastructure external database resource.
+
+        Allowed values for this property are: "PROVISIONING", "NOT_CONNECTED", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED"
+
+
+        :return: The lifecycle_state of this ExternalDatabaseBase.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this ExternalDatabaseBase.
+        The current state of the Oracle Cloud Infrastructure external database resource.
+
+
+        :param lifecycle_state: The lifecycle_state of this ExternalDatabaseBase.
+        :type: str
+        """
+        allowed_values = ["PROVISIONING", "NOT_CONNECTED", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            raise ValueError(
+                "Invalid value for `lifecycle_state`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def time_created(self):
+        """
+        **[Required]** Gets the time_created of this ExternalDatabaseBase.
+        The date and time the database was created.
+
+
+        :return: The time_created of this ExternalDatabaseBase.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this ExternalDatabaseBase.
+        The date and time the database was created.
+
+
+        :param time_created: The time_created of this ExternalDatabaseBase.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def db_unique_name(self):
+        """
+        Gets the db_unique_name of this ExternalDatabaseBase.
+        The `DB_UNIQUE_NAME` of the external database.
+
+
+        :return: The db_unique_name of this ExternalDatabaseBase.
+        :rtype: str
+        """
+        return self._db_unique_name
+
+    @db_unique_name.setter
+    def db_unique_name(self, db_unique_name):
+        """
+        Sets the db_unique_name of this ExternalDatabaseBase.
+        The `DB_UNIQUE_NAME` of the external database.
+
+
+        :param db_unique_name: The db_unique_name of this ExternalDatabaseBase.
+        :type: str
+        """
+        self._db_unique_name = db_unique_name
+
+    @property
+    def db_id(self):
+        """
+        Gets the db_id of this ExternalDatabaseBase.
+        The Oracle Database ID, which identifies an Oracle Database located outside of Oracle Cloud.
+
+
+        :return: The db_id of this ExternalDatabaseBase.
+        :rtype: str
+        """
+        return self._db_id
+
+    @db_id.setter
+    def db_id(self, db_id):
+        """
+        Sets the db_id of this ExternalDatabaseBase.
+        The Oracle Database ID, which identifies an Oracle Database located outside of Oracle Cloud.
+
+
+        :param db_id: The db_id of this ExternalDatabaseBase.
+        :type: str
+        """
+        self._db_id = db_id
+
+    @property
+    def database_version(self):
+        """
+        Gets the database_version of this ExternalDatabaseBase.
+        The Oracle Database version.
+
+
+        :return: The database_version of this ExternalDatabaseBase.
+        :rtype: str
+        """
+        return self._database_version
+
+    @database_version.setter
+    def database_version(self, database_version):
+        """
+        Sets the database_version of this ExternalDatabaseBase.
+        The Oracle Database version.
+
+
+        :param database_version: The database_version of this ExternalDatabaseBase.
+        :type: str
+        """
+        self._database_version = database_version
+
+    @property
+    def database_edition(self):
+        """
+        Gets the database_edition of this ExternalDatabaseBase.
+        The Oracle Database edition.
+
+        Allowed values for this property are: "STANDARD_EDITION", "ENTERPRISE_EDITION", "ENTERPRISE_EDITION_HIGH_PERFORMANCE", "ENTERPRISE_EDITION_EXTREME_PERFORMANCE"
+
+
+        :return: The database_edition of this ExternalDatabaseBase.
+        :rtype: str
+        """
+        return self._database_edition
+
+    @database_edition.setter
+    def database_edition(self, database_edition):
+        """
+        Sets the database_edition of this ExternalDatabaseBase.
+        The Oracle Database edition.
+
+
+        :param database_edition: The database_edition of this ExternalDatabaseBase.
+        :type: str
+        """
+        allowed_values = ["STANDARD_EDITION", "ENTERPRISE_EDITION", "ENTERPRISE_EDITION_HIGH_PERFORMANCE", "ENTERPRISE_EDITION_EXTREME_PERFORMANCE"]
+        if not value_allowed_none_or_none_sentinel(database_edition, allowed_values):
+            raise ValueError(
+                "Invalid value for `database_edition`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._database_edition = database_edition
+
+    @property
+    def time_zone(self):
+        """
+        Gets the time_zone of this ExternalDatabaseBase.
+        The time zone of the external database.
+        It is a time zone offset (a character type in the format '[+|-]TZH:TZM') or a time zone region name,
+        depending on how the time zone value was specified when the database was created / last altered.
+
+
+        :return: The time_zone of this ExternalDatabaseBase.
+        :rtype: str
+        """
+        return self._time_zone
+
+    @time_zone.setter
+    def time_zone(self, time_zone):
+        """
+        Sets the time_zone of this ExternalDatabaseBase.
+        The time zone of the external database.
+        It is a time zone offset (a character type in the format '[+|-]TZH:TZM') or a time zone region name,
+        depending on how the time zone value was specified when the database was created / last altered.
+
+
+        :param time_zone: The time_zone of this ExternalDatabaseBase.
+        :type: str
+        """
+        self._time_zone = time_zone
+
+    @property
+    def character_set(self):
+        """
+        Gets the character_set of this ExternalDatabaseBase.
+        The character set of the external database.
+
+
+        :return: The character_set of this ExternalDatabaseBase.
+        :rtype: str
+        """
+        return self._character_set
+
+    @character_set.setter
+    def character_set(self, character_set):
+        """
+        Sets the character_set of this ExternalDatabaseBase.
+        The character set of the external database.
+
+
+        :param character_set: The character_set of this ExternalDatabaseBase.
+        :type: str
+        """
+        self._character_set = character_set
+
+    @property
+    def ncharacter_set(self):
+        """
+        Gets the ncharacter_set of this ExternalDatabaseBase.
+        The national character of the external database.
+
+
+        :return: The ncharacter_set of this ExternalDatabaseBase.
+        :rtype: str
+        """
+        return self._ncharacter_set
+
+    @ncharacter_set.setter
+    def ncharacter_set(self, ncharacter_set):
+        """
+        Sets the ncharacter_set of this ExternalDatabaseBase.
+        The national character of the external database.
+
+
+        :param ncharacter_set: The ncharacter_set of this ExternalDatabaseBase.
+        :type: str
+        """
+        self._ncharacter_set = ncharacter_set
+
+    @property
+    def db_packs(self):
+        """
+        Gets the db_packs of this ExternalDatabaseBase.
+        The database packs licensed for the external Oracle Database.
+
+
+        :return: The db_packs of this ExternalDatabaseBase.
+        :rtype: str
+        """
+        return self._db_packs
+
+    @db_packs.setter
+    def db_packs(self, db_packs):
+        """
+        Sets the db_packs of this ExternalDatabaseBase.
+        The database packs licensed for the external Oracle Database.
+
+
+        :param db_packs: The db_packs of this ExternalDatabaseBase.
+        :type: str
+        """
+        self._db_packs = db_packs
+
+    @property
+    def database_management_config(self):
+        """
+        Gets the database_management_config of this ExternalDatabaseBase.
+
+        :return: The database_management_config of this ExternalDatabaseBase.
+        :rtype: oci.database.models.DatabaseManagementConfig
+        """
+        return self._database_management_config
+
+    @database_management_config.setter
+    def database_management_config(self, database_management_config):
+        """
+        Sets the database_management_config of this ExternalDatabaseBase.
+
+        :param database_management_config: The database_management_config of this ExternalDatabaseBase.
+        :type: oci.database.models.DatabaseManagementConfig
+        """
+        self._database_management_config = database_management_config
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/external_database_connector.py
+++ b/src/oci/database/models/external_database_connector.py
@@ -1,0 +1,508 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ExternalDatabaseConnector(object):
+    """
+    An Oracle Cloud Infrastructure resource used to connect to an external Oracle Database.
+    This resource stores the database connection string, user credentials, and related details that allow you to
+    manage your external database using the Oracle Cloud Infrastructure Console and API interfaces.
+    """
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalDatabaseConnector.
+    #: This constant has a value of "PROVISIONING"
+    LIFECYCLE_STATE_PROVISIONING = "PROVISIONING"
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalDatabaseConnector.
+    #: This constant has a value of "AVAILABLE"
+    LIFECYCLE_STATE_AVAILABLE = "AVAILABLE"
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalDatabaseConnector.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalDatabaseConnector.
+    #: This constant has a value of "TERMINATING"
+    LIFECYCLE_STATE_TERMINATING = "TERMINATING"
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalDatabaseConnector.
+    #: This constant has a value of "TERMINATED"
+    LIFECYCLE_STATE_TERMINATED = "TERMINATED"
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalDatabaseConnector.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    #: A constant which can be used with the connector_type property of a ExternalDatabaseConnector.
+    #: This constant has a value of "MACS"
+    CONNECTOR_TYPE_MACS = "MACS"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ExternalDatabaseConnector object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
+        to a service operations then you should favor using a subclass over the base class:
+
+        * :class:`~oci.database.models.ExternalMacsConnector`
+
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ExternalDatabaseConnector.
+        :type compartment_id: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this ExternalDatabaseConnector.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this ExternalDatabaseConnector.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param display_name:
+            The value to assign to the display_name property of this ExternalDatabaseConnector.
+        :type display_name: str
+
+        :param id:
+            The value to assign to the id property of this ExternalDatabaseConnector.
+        :type id: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this ExternalDatabaseConnector.
+            Allowed values for this property are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param lifecycle_details:
+            The value to assign to the lifecycle_details property of this ExternalDatabaseConnector.
+        :type lifecycle_details: str
+
+        :param time_created:
+            The value to assign to the time_created property of this ExternalDatabaseConnector.
+        :type time_created: datetime
+
+        :param connector_type:
+            The value to assign to the connector_type property of this ExternalDatabaseConnector.
+            Allowed values for this property are: "MACS", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type connector_type: str
+
+        :param external_database_id:
+            The value to assign to the external_database_id property of this ExternalDatabaseConnector.
+        :type external_database_id: str
+
+        :param connection_status:
+            The value to assign to the connection_status property of this ExternalDatabaseConnector.
+        :type connection_status: str
+
+        :param time_connection_status_last_updated:
+            The value to assign to the time_connection_status_last_updated property of this ExternalDatabaseConnector.
+        :type time_connection_status_last_updated: datetime
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'display_name': 'str',
+            'id': 'str',
+            'lifecycle_state': 'str',
+            'lifecycle_details': 'str',
+            'time_created': 'datetime',
+            'connector_type': 'str',
+            'external_database_id': 'str',
+            'connection_status': 'str',
+            'time_connection_status_last_updated': 'datetime'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags',
+            'display_name': 'displayName',
+            'id': 'id',
+            'lifecycle_state': 'lifecycleState',
+            'lifecycle_details': 'lifecycleDetails',
+            'time_created': 'timeCreated',
+            'connector_type': 'connectorType',
+            'external_database_id': 'externalDatabaseId',
+            'connection_status': 'connectionStatus',
+            'time_connection_status_last_updated': 'timeConnectionStatusLastUpdated'
+        }
+
+        self._compartment_id = None
+        self._freeform_tags = None
+        self._defined_tags = None
+        self._display_name = None
+        self._id = None
+        self._lifecycle_state = None
+        self._lifecycle_details = None
+        self._time_created = None
+        self._connector_type = None
+        self._external_database_id = None
+        self._connection_status = None
+        self._time_connection_status_last_updated = None
+
+    @staticmethod
+    def get_subtype(object_dictionary):
+        """
+        Given the hash representation of a subtype of this class,
+        use the info in the hash to return the class of the subtype.
+        """
+        type = object_dictionary['connectorType']
+
+        if type == 'MACS':
+            return 'ExternalMacsConnector'
+        else:
+            return 'ExternalDatabaseConnector'
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this ExternalDatabaseConnector.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this ExternalDatabaseConnector.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this ExternalDatabaseConnector.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this ExternalDatabaseConnector.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this ExternalDatabaseConnector.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this ExternalDatabaseConnector.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this ExternalDatabaseConnector.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this ExternalDatabaseConnector.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this ExternalDatabaseConnector.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this ExternalDatabaseConnector.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this ExternalDatabaseConnector.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this ExternalDatabaseConnector.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this ExternalDatabaseConnector.
+        The user-friendly name for the
+        :func:`create_external_database_connector_details`.
+        The name does not have to be unique.
+
+
+        :return: The display_name of this ExternalDatabaseConnector.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this ExternalDatabaseConnector.
+        The user-friendly name for the
+        :func:`create_external_database_connector_details`.
+        The name does not have to be unique.
+
+
+        :param display_name: The display_name of this ExternalDatabaseConnector.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this ExternalDatabaseConnector.
+        The `OCID`__ of the
+        :func:`create_external_database_connector_details`.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The id of this ExternalDatabaseConnector.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this ExternalDatabaseConnector.
+        The `OCID`__ of the
+        :func:`create_external_database_connector_details`.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param id: The id of this ExternalDatabaseConnector.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def lifecycle_state(self):
+        """
+        **[Required]** Gets the lifecycle_state of this ExternalDatabaseConnector.
+        The current lifecycle state of the external database connector resource.
+
+        Allowed values for this property are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this ExternalDatabaseConnector.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this ExternalDatabaseConnector.
+        The current lifecycle state of the external database connector resource.
+
+
+        :param lifecycle_state: The lifecycle_state of this ExternalDatabaseConnector.
+        :type: str
+        """
+        allowed_values = ["PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def lifecycle_details(self):
+        """
+        Gets the lifecycle_details of this ExternalDatabaseConnector.
+        Additional information about the current lifecycle state.
+
+
+        :return: The lifecycle_details of this ExternalDatabaseConnector.
+        :rtype: str
+        """
+        return self._lifecycle_details
+
+    @lifecycle_details.setter
+    def lifecycle_details(self, lifecycle_details):
+        """
+        Sets the lifecycle_details of this ExternalDatabaseConnector.
+        Additional information about the current lifecycle state.
+
+
+        :param lifecycle_details: The lifecycle_details of this ExternalDatabaseConnector.
+        :type: str
+        """
+        self._lifecycle_details = lifecycle_details
+
+    @property
+    def time_created(self):
+        """
+        **[Required]** Gets the time_created of this ExternalDatabaseConnector.
+        The date and time the external connector was created.
+
+
+        :return: The time_created of this ExternalDatabaseConnector.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this ExternalDatabaseConnector.
+        The date and time the external connector was created.
+
+
+        :param time_created: The time_created of this ExternalDatabaseConnector.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def connector_type(self):
+        """
+        **[Required]** Gets the connector_type of this ExternalDatabaseConnector.
+        The type of connector used by the external database resource.
+
+        Allowed values for this property are: "MACS", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The connector_type of this ExternalDatabaseConnector.
+        :rtype: str
+        """
+        return self._connector_type
+
+    @connector_type.setter
+    def connector_type(self, connector_type):
+        """
+        Sets the connector_type of this ExternalDatabaseConnector.
+        The type of connector used by the external database resource.
+
+
+        :param connector_type: The connector_type of this ExternalDatabaseConnector.
+        :type: str
+        """
+        allowed_values = ["MACS"]
+        if not value_allowed_none_or_none_sentinel(connector_type, allowed_values):
+            connector_type = 'UNKNOWN_ENUM_VALUE'
+        self._connector_type = connector_type
+
+    @property
+    def external_database_id(self):
+        """
+        **[Required]** Gets the external_database_id of this ExternalDatabaseConnector.
+        The `OCID`__ of the external database resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The external_database_id of this ExternalDatabaseConnector.
+        :rtype: str
+        """
+        return self._external_database_id
+
+    @external_database_id.setter
+    def external_database_id(self, external_database_id):
+        """
+        Sets the external_database_id of this ExternalDatabaseConnector.
+        The `OCID`__ of the external database resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param external_database_id: The external_database_id of this ExternalDatabaseConnector.
+        :type: str
+        """
+        self._external_database_id = external_database_id
+
+    @property
+    def connection_status(self):
+        """
+        **[Required]** Gets the connection_status of this ExternalDatabaseConnector.
+        The status of connectivity to the external database.
+
+
+        :return: The connection_status of this ExternalDatabaseConnector.
+        :rtype: str
+        """
+        return self._connection_status
+
+    @connection_status.setter
+    def connection_status(self, connection_status):
+        """
+        Sets the connection_status of this ExternalDatabaseConnector.
+        The status of connectivity to the external database.
+
+
+        :param connection_status: The connection_status of this ExternalDatabaseConnector.
+        :type: str
+        """
+        self._connection_status = connection_status
+
+    @property
+    def time_connection_status_last_updated(self):
+        """
+        **[Required]** Gets the time_connection_status_last_updated of this ExternalDatabaseConnector.
+        The date and time the connectionStatus of this external connector was last updated.
+
+
+        :return: The time_connection_status_last_updated of this ExternalDatabaseConnector.
+        :rtype: datetime
+        """
+        return self._time_connection_status_last_updated
+
+    @time_connection_status_last_updated.setter
+    def time_connection_status_last_updated(self, time_connection_status_last_updated):
+        """
+        Sets the time_connection_status_last_updated of this ExternalDatabaseConnector.
+        The date and time the connectionStatus of this external connector was last updated.
+
+
+        :param time_connection_status_last_updated: The time_connection_status_last_updated of this ExternalDatabaseConnector.
+        :type: datetime
+        """
+        self._time_connection_status_last_updated = time_connection_status_last_updated
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/external_database_connector_summary.py
+++ b/src/oci/database/models/external_database_connector_summary.py
@@ -1,0 +1,476 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ExternalDatabaseConnectorSummary(object):
+    """
+    An Oracle Cloud Infrastructure resource used to connect to an external Oracle Database.
+    This resource stores the database connection string, user credentials, and related details that allow you to
+    manage your external database using the Oracle Cloud Infrastructure Console and API interfaces.
+    """
+
+    #: A constant which can be used with the connector_type property of a ExternalDatabaseConnectorSummary.
+    #: This constant has a value of "MACS"
+    CONNECTOR_TYPE_MACS = "MACS"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ExternalDatabaseConnectorSummary object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
+        to a service operations then you should favor using a subclass over the base class:
+
+        * :class:`~oci.database.models.ExternalMacsConnectorSummary`
+
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ExternalDatabaseConnectorSummary.
+        :type compartment_id: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this ExternalDatabaseConnectorSummary.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this ExternalDatabaseConnectorSummary.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param display_name:
+            The value to assign to the display_name property of this ExternalDatabaseConnectorSummary.
+        :type display_name: str
+
+        :param id:
+            The value to assign to the id property of this ExternalDatabaseConnectorSummary.
+        :type id: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this ExternalDatabaseConnectorSummary.
+        :type lifecycle_state: str
+
+        :param lifecycle_details:
+            The value to assign to the lifecycle_details property of this ExternalDatabaseConnectorSummary.
+        :type lifecycle_details: str
+
+        :param time_created:
+            The value to assign to the time_created property of this ExternalDatabaseConnectorSummary.
+        :type time_created: datetime
+
+        :param connector_type:
+            The value to assign to the connector_type property of this ExternalDatabaseConnectorSummary.
+            Allowed values for this property are: "MACS", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type connector_type: str
+
+        :param external_database_id:
+            The value to assign to the external_database_id property of this ExternalDatabaseConnectorSummary.
+        :type external_database_id: str
+
+        :param connection_status:
+            The value to assign to the connection_status property of this ExternalDatabaseConnectorSummary.
+        :type connection_status: str
+
+        :param time_connection_status_last_updated:
+            The value to assign to the time_connection_status_last_updated property of this ExternalDatabaseConnectorSummary.
+        :type time_connection_status_last_updated: datetime
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'display_name': 'str',
+            'id': 'str',
+            'lifecycle_state': 'str',
+            'lifecycle_details': 'str',
+            'time_created': 'datetime',
+            'connector_type': 'str',
+            'external_database_id': 'str',
+            'connection_status': 'str',
+            'time_connection_status_last_updated': 'datetime'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags',
+            'display_name': 'displayName',
+            'id': 'id',
+            'lifecycle_state': 'lifecycleState',
+            'lifecycle_details': 'lifecycleDetails',
+            'time_created': 'timeCreated',
+            'connector_type': 'connectorType',
+            'external_database_id': 'externalDatabaseId',
+            'connection_status': 'connectionStatus',
+            'time_connection_status_last_updated': 'timeConnectionStatusLastUpdated'
+        }
+
+        self._compartment_id = None
+        self._freeform_tags = None
+        self._defined_tags = None
+        self._display_name = None
+        self._id = None
+        self._lifecycle_state = None
+        self._lifecycle_details = None
+        self._time_created = None
+        self._connector_type = None
+        self._external_database_id = None
+        self._connection_status = None
+        self._time_connection_status_last_updated = None
+
+    @staticmethod
+    def get_subtype(object_dictionary):
+        """
+        Given the hash representation of a subtype of this class,
+        use the info in the hash to return the class of the subtype.
+        """
+        type = object_dictionary['connectorType']
+
+        if type == 'MACS':
+            return 'ExternalMacsConnectorSummary'
+        else:
+            return 'ExternalDatabaseConnectorSummary'
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this ExternalDatabaseConnectorSummary.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this ExternalDatabaseConnectorSummary.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this ExternalDatabaseConnectorSummary.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this ExternalDatabaseConnectorSummary.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this ExternalDatabaseConnectorSummary.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this ExternalDatabaseConnectorSummary.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this ExternalDatabaseConnectorSummary.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this ExternalDatabaseConnectorSummary.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this ExternalDatabaseConnectorSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this ExternalDatabaseConnectorSummary.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this ExternalDatabaseConnectorSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this ExternalDatabaseConnectorSummary.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this ExternalDatabaseConnectorSummary.
+        The user-friendly name for the
+        :func:`create_external_database_connector_details`.
+        The name does not have to be unique.
+
+
+        :return: The display_name of this ExternalDatabaseConnectorSummary.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this ExternalDatabaseConnectorSummary.
+        The user-friendly name for the
+        :func:`create_external_database_connector_details`.
+        The name does not have to be unique.
+
+
+        :param display_name: The display_name of this ExternalDatabaseConnectorSummary.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this ExternalDatabaseConnectorSummary.
+        The `OCID`__ of the
+        :func:`create_external_database_connector_details`.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The id of this ExternalDatabaseConnectorSummary.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this ExternalDatabaseConnectorSummary.
+        The `OCID`__ of the
+        :func:`create_external_database_connector_details`.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param id: The id of this ExternalDatabaseConnectorSummary.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def lifecycle_state(self):
+        """
+        **[Required]** Gets the lifecycle_state of this ExternalDatabaseConnectorSummary.
+        The current lifecycle state of the external database connector resource.
+
+
+        :return: The lifecycle_state of this ExternalDatabaseConnectorSummary.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this ExternalDatabaseConnectorSummary.
+        The current lifecycle state of the external database connector resource.
+
+
+        :param lifecycle_state: The lifecycle_state of this ExternalDatabaseConnectorSummary.
+        :type: str
+        """
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def lifecycle_details(self):
+        """
+        Gets the lifecycle_details of this ExternalDatabaseConnectorSummary.
+        Additional information about the current lifecycle state.
+
+
+        :return: The lifecycle_details of this ExternalDatabaseConnectorSummary.
+        :rtype: str
+        """
+        return self._lifecycle_details
+
+    @lifecycle_details.setter
+    def lifecycle_details(self, lifecycle_details):
+        """
+        Sets the lifecycle_details of this ExternalDatabaseConnectorSummary.
+        Additional information about the current lifecycle state.
+
+
+        :param lifecycle_details: The lifecycle_details of this ExternalDatabaseConnectorSummary.
+        :type: str
+        """
+        self._lifecycle_details = lifecycle_details
+
+    @property
+    def time_created(self):
+        """
+        **[Required]** Gets the time_created of this ExternalDatabaseConnectorSummary.
+        The date and time the external connector was created.
+
+
+        :return: The time_created of this ExternalDatabaseConnectorSummary.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this ExternalDatabaseConnectorSummary.
+        The date and time the external connector was created.
+
+
+        :param time_created: The time_created of this ExternalDatabaseConnectorSummary.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def connector_type(self):
+        """
+        **[Required]** Gets the connector_type of this ExternalDatabaseConnectorSummary.
+        The type of connector used by the external database resource.
+
+        Allowed values for this property are: "MACS", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The connector_type of this ExternalDatabaseConnectorSummary.
+        :rtype: str
+        """
+        return self._connector_type
+
+    @connector_type.setter
+    def connector_type(self, connector_type):
+        """
+        Sets the connector_type of this ExternalDatabaseConnectorSummary.
+        The type of connector used by the external database resource.
+
+
+        :param connector_type: The connector_type of this ExternalDatabaseConnectorSummary.
+        :type: str
+        """
+        allowed_values = ["MACS"]
+        if not value_allowed_none_or_none_sentinel(connector_type, allowed_values):
+            connector_type = 'UNKNOWN_ENUM_VALUE'
+        self._connector_type = connector_type
+
+    @property
+    def external_database_id(self):
+        """
+        **[Required]** Gets the external_database_id of this ExternalDatabaseConnectorSummary.
+        The `OCID`__ of the external database resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The external_database_id of this ExternalDatabaseConnectorSummary.
+        :rtype: str
+        """
+        return self._external_database_id
+
+    @external_database_id.setter
+    def external_database_id(self, external_database_id):
+        """
+        Sets the external_database_id of this ExternalDatabaseConnectorSummary.
+        The `OCID`__ of the external database resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param external_database_id: The external_database_id of this ExternalDatabaseConnectorSummary.
+        :type: str
+        """
+        self._external_database_id = external_database_id
+
+    @property
+    def connection_status(self):
+        """
+        **[Required]** Gets the connection_status of this ExternalDatabaseConnectorSummary.
+        The status of connectivity to the external database.
+
+
+        :return: The connection_status of this ExternalDatabaseConnectorSummary.
+        :rtype: str
+        """
+        return self._connection_status
+
+    @connection_status.setter
+    def connection_status(self, connection_status):
+        """
+        Sets the connection_status of this ExternalDatabaseConnectorSummary.
+        The status of connectivity to the external database.
+
+
+        :param connection_status: The connection_status of this ExternalDatabaseConnectorSummary.
+        :type: str
+        """
+        self._connection_status = connection_status
+
+    @property
+    def time_connection_status_last_updated(self):
+        """
+        **[Required]** Gets the time_connection_status_last_updated of this ExternalDatabaseConnectorSummary.
+        The date and time the `connectionStatus` of this external connector was last updated.
+
+
+        :return: The time_connection_status_last_updated of this ExternalDatabaseConnectorSummary.
+        :rtype: datetime
+        """
+        return self._time_connection_status_last_updated
+
+    @time_connection_status_last_updated.setter
+    def time_connection_status_last_updated(self, time_connection_status_last_updated):
+        """
+        Sets the time_connection_status_last_updated of this ExternalDatabaseConnectorSummary.
+        The date and time the `connectionStatus` of this external connector was last updated.
+
+
+        :param time_connection_status_last_updated: The time_connection_status_last_updated of this ExternalDatabaseConnectorSummary.
+        :type: datetime
+        """
+        self._time_connection_status_last_updated = time_connection_status_last_updated
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/external_macs_connector.py
+++ b/src/oci/database/models/external_macs_connector.py
@@ -1,0 +1,216 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .external_database_connector import ExternalDatabaseConnector
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ExternalMacsConnector(ExternalDatabaseConnector):
+    """
+    An Oracle Cloud Infrastructure resource that uses the `Management Agent cloud service (MACS)`__ to connect to an external Oracle Database.
+
+    __ https://docs.cloud.oracle.com/iaas/management-agents/index.html
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ExternalMacsConnector object with values from keyword arguments. The default value of the :py:attr:`~oci.database.models.ExternalMacsConnector.connector_type` attribute
+        of this class is ``MACS`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ExternalMacsConnector.
+        :type compartment_id: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this ExternalMacsConnector.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this ExternalMacsConnector.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param display_name:
+            The value to assign to the display_name property of this ExternalMacsConnector.
+        :type display_name: str
+
+        :param id:
+            The value to assign to the id property of this ExternalMacsConnector.
+        :type id: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this ExternalMacsConnector.
+            Allowed values for this property are: "PROVISIONING", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED"
+        :type lifecycle_state: str
+
+        :param lifecycle_details:
+            The value to assign to the lifecycle_details property of this ExternalMacsConnector.
+        :type lifecycle_details: str
+
+        :param time_created:
+            The value to assign to the time_created property of this ExternalMacsConnector.
+        :type time_created: datetime
+
+        :param connector_type:
+            The value to assign to the connector_type property of this ExternalMacsConnector.
+            Allowed values for this property are: "MACS"
+        :type connector_type: str
+
+        :param external_database_id:
+            The value to assign to the external_database_id property of this ExternalMacsConnector.
+        :type external_database_id: str
+
+        :param connection_status:
+            The value to assign to the connection_status property of this ExternalMacsConnector.
+        :type connection_status: str
+
+        :param time_connection_status_last_updated:
+            The value to assign to the time_connection_status_last_updated property of this ExternalMacsConnector.
+        :type time_connection_status_last_updated: datetime
+
+        :param connection_string:
+            The value to assign to the connection_string property of this ExternalMacsConnector.
+        :type connection_string: oci.database.models.DatabaseConnectionString
+
+        :param connection_credentials:
+            The value to assign to the connection_credentials property of this ExternalMacsConnector.
+        :type connection_credentials: oci.database.models.DatabaseConnectionCredentials
+
+        :param connector_agent_id:
+            The value to assign to the connector_agent_id property of this ExternalMacsConnector.
+        :type connector_agent_id: str
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'display_name': 'str',
+            'id': 'str',
+            'lifecycle_state': 'str',
+            'lifecycle_details': 'str',
+            'time_created': 'datetime',
+            'connector_type': 'str',
+            'external_database_id': 'str',
+            'connection_status': 'str',
+            'time_connection_status_last_updated': 'datetime',
+            'connection_string': 'DatabaseConnectionString',
+            'connection_credentials': 'DatabaseConnectionCredentials',
+            'connector_agent_id': 'str'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags',
+            'display_name': 'displayName',
+            'id': 'id',
+            'lifecycle_state': 'lifecycleState',
+            'lifecycle_details': 'lifecycleDetails',
+            'time_created': 'timeCreated',
+            'connector_type': 'connectorType',
+            'external_database_id': 'externalDatabaseId',
+            'connection_status': 'connectionStatus',
+            'time_connection_status_last_updated': 'timeConnectionStatusLastUpdated',
+            'connection_string': 'connectionString',
+            'connection_credentials': 'connectionCredentials',
+            'connector_agent_id': 'connectorAgentId'
+        }
+
+        self._compartment_id = None
+        self._freeform_tags = None
+        self._defined_tags = None
+        self._display_name = None
+        self._id = None
+        self._lifecycle_state = None
+        self._lifecycle_details = None
+        self._time_created = None
+        self._connector_type = None
+        self._external_database_id = None
+        self._connection_status = None
+        self._time_connection_status_last_updated = None
+        self._connection_string = None
+        self._connection_credentials = None
+        self._connector_agent_id = None
+        self._connector_type = 'MACS'
+
+    @property
+    def connection_string(self):
+        """
+        **[Required]** Gets the connection_string of this ExternalMacsConnector.
+
+        :return: The connection_string of this ExternalMacsConnector.
+        :rtype: oci.database.models.DatabaseConnectionString
+        """
+        return self._connection_string
+
+    @connection_string.setter
+    def connection_string(self, connection_string):
+        """
+        Sets the connection_string of this ExternalMacsConnector.
+
+        :param connection_string: The connection_string of this ExternalMacsConnector.
+        :type: oci.database.models.DatabaseConnectionString
+        """
+        self._connection_string = connection_string
+
+    @property
+    def connection_credentials(self):
+        """
+        **[Required]** Gets the connection_credentials of this ExternalMacsConnector.
+
+        :return: The connection_credentials of this ExternalMacsConnector.
+        :rtype: oci.database.models.DatabaseConnectionCredentials
+        """
+        return self._connection_credentials
+
+    @connection_credentials.setter
+    def connection_credentials(self, connection_credentials):
+        """
+        Sets the connection_credentials of this ExternalMacsConnector.
+
+        :param connection_credentials: The connection_credentials of this ExternalMacsConnector.
+        :type: oci.database.models.DatabaseConnectionCredentials
+        """
+        self._connection_credentials = connection_credentials
+
+    @property
+    def connector_agent_id(self):
+        """
+        **[Required]** Gets the connector_agent_id of this ExternalMacsConnector.
+        The ID of the agent used for the
+        :func:`create_external_database_connector_details`.
+
+
+        :return: The connector_agent_id of this ExternalMacsConnector.
+        :rtype: str
+        """
+        return self._connector_agent_id
+
+    @connector_agent_id.setter
+    def connector_agent_id(self, connector_agent_id):
+        """
+        Sets the connector_agent_id of this ExternalMacsConnector.
+        The ID of the agent used for the
+        :func:`create_external_database_connector_details`.
+
+
+        :param connector_agent_id: The connector_agent_id of this ExternalMacsConnector.
+        :type: str
+        """
+        self._connector_agent_id = connector_agent_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/external_macs_connector_summary.py
+++ b/src/oci/database/models/external_macs_connector_summary.py
@@ -1,0 +1,215 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .external_database_connector_summary import ExternalDatabaseConnectorSummary
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ExternalMacsConnectorSummary(ExternalDatabaseConnectorSummary):
+    """
+    An Oracle Cloud Infrastructure resource that uses the `Management Agent cloud service (MACS)`__ to connect to an external Oracle Database.
+
+    __ https://docs.cloud.oracle.com/iaas/management-agents/index.html
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ExternalMacsConnectorSummary object with values from keyword arguments. The default value of the :py:attr:`~oci.database.models.ExternalMacsConnectorSummary.connector_type` attribute
+        of this class is ``MACS`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ExternalMacsConnectorSummary.
+        :type compartment_id: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this ExternalMacsConnectorSummary.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this ExternalMacsConnectorSummary.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param display_name:
+            The value to assign to the display_name property of this ExternalMacsConnectorSummary.
+        :type display_name: str
+
+        :param id:
+            The value to assign to the id property of this ExternalMacsConnectorSummary.
+        :type id: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this ExternalMacsConnectorSummary.
+        :type lifecycle_state: str
+
+        :param lifecycle_details:
+            The value to assign to the lifecycle_details property of this ExternalMacsConnectorSummary.
+        :type lifecycle_details: str
+
+        :param time_created:
+            The value to assign to the time_created property of this ExternalMacsConnectorSummary.
+        :type time_created: datetime
+
+        :param connector_type:
+            The value to assign to the connector_type property of this ExternalMacsConnectorSummary.
+            Allowed values for this property are: "MACS"
+        :type connector_type: str
+
+        :param external_database_id:
+            The value to assign to the external_database_id property of this ExternalMacsConnectorSummary.
+        :type external_database_id: str
+
+        :param connection_status:
+            The value to assign to the connection_status property of this ExternalMacsConnectorSummary.
+        :type connection_status: str
+
+        :param time_connection_status_last_updated:
+            The value to assign to the time_connection_status_last_updated property of this ExternalMacsConnectorSummary.
+        :type time_connection_status_last_updated: datetime
+
+        :param connection_string:
+            The value to assign to the connection_string property of this ExternalMacsConnectorSummary.
+        :type connection_string: oci.database.models.DatabaseConnectionString
+
+        :param connection_credentials:
+            The value to assign to the connection_credentials property of this ExternalMacsConnectorSummary.
+        :type connection_credentials: oci.database.models.DatabaseConnectionCredentials
+
+        :param connector_agent_id:
+            The value to assign to the connector_agent_id property of this ExternalMacsConnectorSummary.
+        :type connector_agent_id: str
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'display_name': 'str',
+            'id': 'str',
+            'lifecycle_state': 'str',
+            'lifecycle_details': 'str',
+            'time_created': 'datetime',
+            'connector_type': 'str',
+            'external_database_id': 'str',
+            'connection_status': 'str',
+            'time_connection_status_last_updated': 'datetime',
+            'connection_string': 'DatabaseConnectionString',
+            'connection_credentials': 'DatabaseConnectionCredentials',
+            'connector_agent_id': 'str'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags',
+            'display_name': 'displayName',
+            'id': 'id',
+            'lifecycle_state': 'lifecycleState',
+            'lifecycle_details': 'lifecycleDetails',
+            'time_created': 'timeCreated',
+            'connector_type': 'connectorType',
+            'external_database_id': 'externalDatabaseId',
+            'connection_status': 'connectionStatus',
+            'time_connection_status_last_updated': 'timeConnectionStatusLastUpdated',
+            'connection_string': 'connectionString',
+            'connection_credentials': 'connectionCredentials',
+            'connector_agent_id': 'connectorAgentId'
+        }
+
+        self._compartment_id = None
+        self._freeform_tags = None
+        self._defined_tags = None
+        self._display_name = None
+        self._id = None
+        self._lifecycle_state = None
+        self._lifecycle_details = None
+        self._time_created = None
+        self._connector_type = None
+        self._external_database_id = None
+        self._connection_status = None
+        self._time_connection_status_last_updated = None
+        self._connection_string = None
+        self._connection_credentials = None
+        self._connector_agent_id = None
+        self._connector_type = 'MACS'
+
+    @property
+    def connection_string(self):
+        """
+        **[Required]** Gets the connection_string of this ExternalMacsConnectorSummary.
+
+        :return: The connection_string of this ExternalMacsConnectorSummary.
+        :rtype: oci.database.models.DatabaseConnectionString
+        """
+        return self._connection_string
+
+    @connection_string.setter
+    def connection_string(self, connection_string):
+        """
+        Sets the connection_string of this ExternalMacsConnectorSummary.
+
+        :param connection_string: The connection_string of this ExternalMacsConnectorSummary.
+        :type: oci.database.models.DatabaseConnectionString
+        """
+        self._connection_string = connection_string
+
+    @property
+    def connection_credentials(self):
+        """
+        **[Required]** Gets the connection_credentials of this ExternalMacsConnectorSummary.
+
+        :return: The connection_credentials of this ExternalMacsConnectorSummary.
+        :rtype: oci.database.models.DatabaseConnectionCredentials
+        """
+        return self._connection_credentials
+
+    @connection_credentials.setter
+    def connection_credentials(self, connection_credentials):
+        """
+        Sets the connection_credentials of this ExternalMacsConnectorSummary.
+
+        :param connection_credentials: The connection_credentials of this ExternalMacsConnectorSummary.
+        :type: oci.database.models.DatabaseConnectionCredentials
+        """
+        self._connection_credentials = connection_credentials
+
+    @property
+    def connector_agent_id(self):
+        """
+        **[Required]** Gets the connector_agent_id of this ExternalMacsConnectorSummary.
+        The ID of the agent used for the
+        :func:`create_external_database_connector_details`.
+
+
+        :return: The connector_agent_id of this ExternalMacsConnectorSummary.
+        :rtype: str
+        """
+        return self._connector_agent_id
+
+    @connector_agent_id.setter
+    def connector_agent_id(self, connector_agent_id):
+        """
+        Sets the connector_agent_id of this ExternalMacsConnectorSummary.
+        The ID of the agent used for the
+        :func:`create_external_database_connector_details`.
+
+
+        :param connector_agent_id: The connector_agent_id of this ExternalMacsConnectorSummary.
+        :type: str
+        """
+        self._connector_agent_id = connector_agent_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/external_non_container_database.py
+++ b/src/oci/database/models/external_non_container_database.py
@@ -1,0 +1,650 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ExternalNonContainerDatabase(object):
+    """
+    an external Oracle non-container database.
+    """
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalNonContainerDatabase.
+    #: This constant has a value of "PROVISIONING"
+    LIFECYCLE_STATE_PROVISIONING = "PROVISIONING"
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalNonContainerDatabase.
+    #: This constant has a value of "NOT_CONNECTED"
+    LIFECYCLE_STATE_NOT_CONNECTED = "NOT_CONNECTED"
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalNonContainerDatabase.
+    #: This constant has a value of "AVAILABLE"
+    LIFECYCLE_STATE_AVAILABLE = "AVAILABLE"
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalNonContainerDatabase.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalNonContainerDatabase.
+    #: This constant has a value of "TERMINATING"
+    LIFECYCLE_STATE_TERMINATING = "TERMINATING"
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalNonContainerDatabase.
+    #: This constant has a value of "TERMINATED"
+    LIFECYCLE_STATE_TERMINATED = "TERMINATED"
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalNonContainerDatabase.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    #: A constant which can be used with the database_edition property of a ExternalNonContainerDatabase.
+    #: This constant has a value of "STANDARD_EDITION"
+    DATABASE_EDITION_STANDARD_EDITION = "STANDARD_EDITION"
+
+    #: A constant which can be used with the database_edition property of a ExternalNonContainerDatabase.
+    #: This constant has a value of "ENTERPRISE_EDITION"
+    DATABASE_EDITION_ENTERPRISE_EDITION = "ENTERPRISE_EDITION"
+
+    #: A constant which can be used with the database_edition property of a ExternalNonContainerDatabase.
+    #: This constant has a value of "ENTERPRISE_EDITION_HIGH_PERFORMANCE"
+    DATABASE_EDITION_ENTERPRISE_EDITION_HIGH_PERFORMANCE = "ENTERPRISE_EDITION_HIGH_PERFORMANCE"
+
+    #: A constant which can be used with the database_edition property of a ExternalNonContainerDatabase.
+    #: This constant has a value of "ENTERPRISE_EDITION_EXTREME_PERFORMANCE"
+    DATABASE_EDITION_ENTERPRISE_EDITION_EXTREME_PERFORMANCE = "ENTERPRISE_EDITION_EXTREME_PERFORMANCE"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ExternalNonContainerDatabase object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ExternalNonContainerDatabase.
+        :type compartment_id: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this ExternalNonContainerDatabase.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this ExternalNonContainerDatabase.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param display_name:
+            The value to assign to the display_name property of this ExternalNonContainerDatabase.
+        :type display_name: str
+
+        :param id:
+            The value to assign to the id property of this ExternalNonContainerDatabase.
+        :type id: str
+
+        :param lifecycle_details:
+            The value to assign to the lifecycle_details property of this ExternalNonContainerDatabase.
+        :type lifecycle_details: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this ExternalNonContainerDatabase.
+            Allowed values for this property are: "PROVISIONING", "NOT_CONNECTED", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param time_created:
+            The value to assign to the time_created property of this ExternalNonContainerDatabase.
+        :type time_created: datetime
+
+        :param db_unique_name:
+            The value to assign to the db_unique_name property of this ExternalNonContainerDatabase.
+        :type db_unique_name: str
+
+        :param db_id:
+            The value to assign to the db_id property of this ExternalNonContainerDatabase.
+        :type db_id: str
+
+        :param database_version:
+            The value to assign to the database_version property of this ExternalNonContainerDatabase.
+        :type database_version: str
+
+        :param database_edition:
+            The value to assign to the database_edition property of this ExternalNonContainerDatabase.
+            Allowed values for this property are: "STANDARD_EDITION", "ENTERPRISE_EDITION", "ENTERPRISE_EDITION_HIGH_PERFORMANCE", "ENTERPRISE_EDITION_EXTREME_PERFORMANCE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type database_edition: str
+
+        :param time_zone:
+            The value to assign to the time_zone property of this ExternalNonContainerDatabase.
+        :type time_zone: str
+
+        :param character_set:
+            The value to assign to the character_set property of this ExternalNonContainerDatabase.
+        :type character_set: str
+
+        :param ncharacter_set:
+            The value to assign to the ncharacter_set property of this ExternalNonContainerDatabase.
+        :type ncharacter_set: str
+
+        :param db_packs:
+            The value to assign to the db_packs property of this ExternalNonContainerDatabase.
+        :type db_packs: str
+
+        :param database_management_config:
+            The value to assign to the database_management_config property of this ExternalNonContainerDatabase.
+        :type database_management_config: oci.database.models.DatabaseManagementConfig
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'display_name': 'str',
+            'id': 'str',
+            'lifecycle_details': 'str',
+            'lifecycle_state': 'str',
+            'time_created': 'datetime',
+            'db_unique_name': 'str',
+            'db_id': 'str',
+            'database_version': 'str',
+            'database_edition': 'str',
+            'time_zone': 'str',
+            'character_set': 'str',
+            'ncharacter_set': 'str',
+            'db_packs': 'str',
+            'database_management_config': 'DatabaseManagementConfig'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags',
+            'display_name': 'displayName',
+            'id': 'id',
+            'lifecycle_details': 'lifecycleDetails',
+            'lifecycle_state': 'lifecycleState',
+            'time_created': 'timeCreated',
+            'db_unique_name': 'dbUniqueName',
+            'db_id': 'dbId',
+            'database_version': 'databaseVersion',
+            'database_edition': 'databaseEdition',
+            'time_zone': 'timeZone',
+            'character_set': 'characterSet',
+            'ncharacter_set': 'ncharacterSet',
+            'db_packs': 'dbPacks',
+            'database_management_config': 'databaseManagementConfig'
+        }
+
+        self._compartment_id = None
+        self._freeform_tags = None
+        self._defined_tags = None
+        self._display_name = None
+        self._id = None
+        self._lifecycle_details = None
+        self._lifecycle_state = None
+        self._time_created = None
+        self._db_unique_name = None
+        self._db_id = None
+        self._database_version = None
+        self._database_edition = None
+        self._time_zone = None
+        self._character_set = None
+        self._ncharacter_set = None
+        self._db_packs = None
+        self._database_management_config = None
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this ExternalNonContainerDatabase.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this ExternalNonContainerDatabase.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this ExternalNonContainerDatabase.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this ExternalNonContainerDatabase.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this ExternalNonContainerDatabase.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this ExternalNonContainerDatabase.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this ExternalNonContainerDatabase.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this ExternalNonContainerDatabase.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this ExternalNonContainerDatabase.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this ExternalNonContainerDatabase.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this ExternalNonContainerDatabase.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this ExternalNonContainerDatabase.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this ExternalNonContainerDatabase.
+        The user-friendly name for the external database. The name does not have to be unique.
+
+
+        :return: The display_name of this ExternalNonContainerDatabase.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this ExternalNonContainerDatabase.
+        The user-friendly name for the external database. The name does not have to be unique.
+
+
+        :param display_name: The display_name of this ExternalNonContainerDatabase.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this ExternalNonContainerDatabase.
+        The `OCID`__ of the Oracle Cloud Infrastructure external database resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The id of this ExternalNonContainerDatabase.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this ExternalNonContainerDatabase.
+        The `OCID`__ of the Oracle Cloud Infrastructure external database resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param id: The id of this ExternalNonContainerDatabase.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def lifecycle_details(self):
+        """
+        Gets the lifecycle_details of this ExternalNonContainerDatabase.
+        Additional information about the current lifecycle state.
+
+
+        :return: The lifecycle_details of this ExternalNonContainerDatabase.
+        :rtype: str
+        """
+        return self._lifecycle_details
+
+    @lifecycle_details.setter
+    def lifecycle_details(self, lifecycle_details):
+        """
+        Sets the lifecycle_details of this ExternalNonContainerDatabase.
+        Additional information about the current lifecycle state.
+
+
+        :param lifecycle_details: The lifecycle_details of this ExternalNonContainerDatabase.
+        :type: str
+        """
+        self._lifecycle_details = lifecycle_details
+
+    @property
+    def lifecycle_state(self):
+        """
+        **[Required]** Gets the lifecycle_state of this ExternalNonContainerDatabase.
+        The current state of the Oracle Cloud Infrastructure external database resource.
+
+        Allowed values for this property are: "PROVISIONING", "NOT_CONNECTED", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this ExternalNonContainerDatabase.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this ExternalNonContainerDatabase.
+        The current state of the Oracle Cloud Infrastructure external database resource.
+
+
+        :param lifecycle_state: The lifecycle_state of this ExternalNonContainerDatabase.
+        :type: str
+        """
+        allowed_values = ["PROVISIONING", "NOT_CONNECTED", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def time_created(self):
+        """
+        **[Required]** Gets the time_created of this ExternalNonContainerDatabase.
+        The date and time the database was created.
+
+
+        :return: The time_created of this ExternalNonContainerDatabase.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this ExternalNonContainerDatabase.
+        The date and time the database was created.
+
+
+        :param time_created: The time_created of this ExternalNonContainerDatabase.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def db_unique_name(self):
+        """
+        Gets the db_unique_name of this ExternalNonContainerDatabase.
+        The `DB_UNIQUE_NAME` of the external database.
+
+
+        :return: The db_unique_name of this ExternalNonContainerDatabase.
+        :rtype: str
+        """
+        return self._db_unique_name
+
+    @db_unique_name.setter
+    def db_unique_name(self, db_unique_name):
+        """
+        Sets the db_unique_name of this ExternalNonContainerDatabase.
+        The `DB_UNIQUE_NAME` of the external database.
+
+
+        :param db_unique_name: The db_unique_name of this ExternalNonContainerDatabase.
+        :type: str
+        """
+        self._db_unique_name = db_unique_name
+
+    @property
+    def db_id(self):
+        """
+        Gets the db_id of this ExternalNonContainerDatabase.
+        The Oracle Database ID, which identifies an Oracle Database located outside of Oracle Cloud.
+
+
+        :return: The db_id of this ExternalNonContainerDatabase.
+        :rtype: str
+        """
+        return self._db_id
+
+    @db_id.setter
+    def db_id(self, db_id):
+        """
+        Sets the db_id of this ExternalNonContainerDatabase.
+        The Oracle Database ID, which identifies an Oracle Database located outside of Oracle Cloud.
+
+
+        :param db_id: The db_id of this ExternalNonContainerDatabase.
+        :type: str
+        """
+        self._db_id = db_id
+
+    @property
+    def database_version(self):
+        """
+        Gets the database_version of this ExternalNonContainerDatabase.
+        The Oracle Database version.
+
+
+        :return: The database_version of this ExternalNonContainerDatabase.
+        :rtype: str
+        """
+        return self._database_version
+
+    @database_version.setter
+    def database_version(self, database_version):
+        """
+        Sets the database_version of this ExternalNonContainerDatabase.
+        The Oracle Database version.
+
+
+        :param database_version: The database_version of this ExternalNonContainerDatabase.
+        :type: str
+        """
+        self._database_version = database_version
+
+    @property
+    def database_edition(self):
+        """
+        Gets the database_edition of this ExternalNonContainerDatabase.
+        The Oracle Database edition.
+
+        Allowed values for this property are: "STANDARD_EDITION", "ENTERPRISE_EDITION", "ENTERPRISE_EDITION_HIGH_PERFORMANCE", "ENTERPRISE_EDITION_EXTREME_PERFORMANCE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The database_edition of this ExternalNonContainerDatabase.
+        :rtype: str
+        """
+        return self._database_edition
+
+    @database_edition.setter
+    def database_edition(self, database_edition):
+        """
+        Sets the database_edition of this ExternalNonContainerDatabase.
+        The Oracle Database edition.
+
+
+        :param database_edition: The database_edition of this ExternalNonContainerDatabase.
+        :type: str
+        """
+        allowed_values = ["STANDARD_EDITION", "ENTERPRISE_EDITION", "ENTERPRISE_EDITION_HIGH_PERFORMANCE", "ENTERPRISE_EDITION_EXTREME_PERFORMANCE"]
+        if not value_allowed_none_or_none_sentinel(database_edition, allowed_values):
+            database_edition = 'UNKNOWN_ENUM_VALUE'
+        self._database_edition = database_edition
+
+    @property
+    def time_zone(self):
+        """
+        Gets the time_zone of this ExternalNonContainerDatabase.
+        The time zone of the external database.
+        It is a time zone offset (a character type in the format '[+|-]TZH:TZM') or a time zone region name,
+        depending on how the time zone value was specified when the database was created / last altered.
+
+
+        :return: The time_zone of this ExternalNonContainerDatabase.
+        :rtype: str
+        """
+        return self._time_zone
+
+    @time_zone.setter
+    def time_zone(self, time_zone):
+        """
+        Sets the time_zone of this ExternalNonContainerDatabase.
+        The time zone of the external database.
+        It is a time zone offset (a character type in the format '[+|-]TZH:TZM') or a time zone region name,
+        depending on how the time zone value was specified when the database was created / last altered.
+
+
+        :param time_zone: The time_zone of this ExternalNonContainerDatabase.
+        :type: str
+        """
+        self._time_zone = time_zone
+
+    @property
+    def character_set(self):
+        """
+        Gets the character_set of this ExternalNonContainerDatabase.
+        The character set of the external database.
+
+
+        :return: The character_set of this ExternalNonContainerDatabase.
+        :rtype: str
+        """
+        return self._character_set
+
+    @character_set.setter
+    def character_set(self, character_set):
+        """
+        Sets the character_set of this ExternalNonContainerDatabase.
+        The character set of the external database.
+
+
+        :param character_set: The character_set of this ExternalNonContainerDatabase.
+        :type: str
+        """
+        self._character_set = character_set
+
+    @property
+    def ncharacter_set(self):
+        """
+        Gets the ncharacter_set of this ExternalNonContainerDatabase.
+        The national character of the external database.
+
+
+        :return: The ncharacter_set of this ExternalNonContainerDatabase.
+        :rtype: str
+        """
+        return self._ncharacter_set
+
+    @ncharacter_set.setter
+    def ncharacter_set(self, ncharacter_set):
+        """
+        Sets the ncharacter_set of this ExternalNonContainerDatabase.
+        The national character of the external database.
+
+
+        :param ncharacter_set: The ncharacter_set of this ExternalNonContainerDatabase.
+        :type: str
+        """
+        self._ncharacter_set = ncharacter_set
+
+    @property
+    def db_packs(self):
+        """
+        Gets the db_packs of this ExternalNonContainerDatabase.
+        The database packs licensed for the external Oracle Database.
+
+
+        :return: The db_packs of this ExternalNonContainerDatabase.
+        :rtype: str
+        """
+        return self._db_packs
+
+    @db_packs.setter
+    def db_packs(self, db_packs):
+        """
+        Sets the db_packs of this ExternalNonContainerDatabase.
+        The database packs licensed for the external Oracle Database.
+
+
+        :param db_packs: The db_packs of this ExternalNonContainerDatabase.
+        :type: str
+        """
+        self._db_packs = db_packs
+
+    @property
+    def database_management_config(self):
+        """
+        Gets the database_management_config of this ExternalNonContainerDatabase.
+
+        :return: The database_management_config of this ExternalNonContainerDatabase.
+        :rtype: oci.database.models.DatabaseManagementConfig
+        """
+        return self._database_management_config
+
+    @database_management_config.setter
+    def database_management_config(self, database_management_config):
+        """
+        Sets the database_management_config of this ExternalNonContainerDatabase.
+
+        :param database_management_config: The database_management_config of this ExternalNonContainerDatabase.
+        :type: oci.database.models.DatabaseManagementConfig
+        """
+        self._database_management_config = database_management_config
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/external_non_container_database_summary.py
+++ b/src/oci/database/models/external_non_container_database_summary.py
@@ -1,0 +1,651 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ExternalNonContainerDatabaseSummary(object):
+    """
+    An Oracle Cloud Infrastructure external non-container database resource. This resource is used to manage a non-container
+    database located outside of Oracle Cloud.
+    """
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalNonContainerDatabaseSummary.
+    #: This constant has a value of "PROVISIONING"
+    LIFECYCLE_STATE_PROVISIONING = "PROVISIONING"
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalNonContainerDatabaseSummary.
+    #: This constant has a value of "NOT_CONNECTED"
+    LIFECYCLE_STATE_NOT_CONNECTED = "NOT_CONNECTED"
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalNonContainerDatabaseSummary.
+    #: This constant has a value of "AVAILABLE"
+    LIFECYCLE_STATE_AVAILABLE = "AVAILABLE"
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalNonContainerDatabaseSummary.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalNonContainerDatabaseSummary.
+    #: This constant has a value of "TERMINATING"
+    LIFECYCLE_STATE_TERMINATING = "TERMINATING"
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalNonContainerDatabaseSummary.
+    #: This constant has a value of "TERMINATED"
+    LIFECYCLE_STATE_TERMINATED = "TERMINATED"
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalNonContainerDatabaseSummary.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    #: A constant which can be used with the database_edition property of a ExternalNonContainerDatabaseSummary.
+    #: This constant has a value of "STANDARD_EDITION"
+    DATABASE_EDITION_STANDARD_EDITION = "STANDARD_EDITION"
+
+    #: A constant which can be used with the database_edition property of a ExternalNonContainerDatabaseSummary.
+    #: This constant has a value of "ENTERPRISE_EDITION"
+    DATABASE_EDITION_ENTERPRISE_EDITION = "ENTERPRISE_EDITION"
+
+    #: A constant which can be used with the database_edition property of a ExternalNonContainerDatabaseSummary.
+    #: This constant has a value of "ENTERPRISE_EDITION_HIGH_PERFORMANCE"
+    DATABASE_EDITION_ENTERPRISE_EDITION_HIGH_PERFORMANCE = "ENTERPRISE_EDITION_HIGH_PERFORMANCE"
+
+    #: A constant which can be used with the database_edition property of a ExternalNonContainerDatabaseSummary.
+    #: This constant has a value of "ENTERPRISE_EDITION_EXTREME_PERFORMANCE"
+    DATABASE_EDITION_ENTERPRISE_EDITION_EXTREME_PERFORMANCE = "ENTERPRISE_EDITION_EXTREME_PERFORMANCE"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ExternalNonContainerDatabaseSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ExternalNonContainerDatabaseSummary.
+        :type compartment_id: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this ExternalNonContainerDatabaseSummary.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this ExternalNonContainerDatabaseSummary.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param display_name:
+            The value to assign to the display_name property of this ExternalNonContainerDatabaseSummary.
+        :type display_name: str
+
+        :param id:
+            The value to assign to the id property of this ExternalNonContainerDatabaseSummary.
+        :type id: str
+
+        :param lifecycle_details:
+            The value to assign to the lifecycle_details property of this ExternalNonContainerDatabaseSummary.
+        :type lifecycle_details: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this ExternalNonContainerDatabaseSummary.
+            Allowed values for this property are: "PROVISIONING", "NOT_CONNECTED", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param time_created:
+            The value to assign to the time_created property of this ExternalNonContainerDatabaseSummary.
+        :type time_created: datetime
+
+        :param db_unique_name:
+            The value to assign to the db_unique_name property of this ExternalNonContainerDatabaseSummary.
+        :type db_unique_name: str
+
+        :param db_id:
+            The value to assign to the db_id property of this ExternalNonContainerDatabaseSummary.
+        :type db_id: str
+
+        :param database_version:
+            The value to assign to the database_version property of this ExternalNonContainerDatabaseSummary.
+        :type database_version: str
+
+        :param database_edition:
+            The value to assign to the database_edition property of this ExternalNonContainerDatabaseSummary.
+            Allowed values for this property are: "STANDARD_EDITION", "ENTERPRISE_EDITION", "ENTERPRISE_EDITION_HIGH_PERFORMANCE", "ENTERPRISE_EDITION_EXTREME_PERFORMANCE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type database_edition: str
+
+        :param time_zone:
+            The value to assign to the time_zone property of this ExternalNonContainerDatabaseSummary.
+        :type time_zone: str
+
+        :param character_set:
+            The value to assign to the character_set property of this ExternalNonContainerDatabaseSummary.
+        :type character_set: str
+
+        :param ncharacter_set:
+            The value to assign to the ncharacter_set property of this ExternalNonContainerDatabaseSummary.
+        :type ncharacter_set: str
+
+        :param db_packs:
+            The value to assign to the db_packs property of this ExternalNonContainerDatabaseSummary.
+        :type db_packs: str
+
+        :param database_management_config:
+            The value to assign to the database_management_config property of this ExternalNonContainerDatabaseSummary.
+        :type database_management_config: oci.database.models.DatabaseManagementConfig
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'display_name': 'str',
+            'id': 'str',
+            'lifecycle_details': 'str',
+            'lifecycle_state': 'str',
+            'time_created': 'datetime',
+            'db_unique_name': 'str',
+            'db_id': 'str',
+            'database_version': 'str',
+            'database_edition': 'str',
+            'time_zone': 'str',
+            'character_set': 'str',
+            'ncharacter_set': 'str',
+            'db_packs': 'str',
+            'database_management_config': 'DatabaseManagementConfig'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags',
+            'display_name': 'displayName',
+            'id': 'id',
+            'lifecycle_details': 'lifecycleDetails',
+            'lifecycle_state': 'lifecycleState',
+            'time_created': 'timeCreated',
+            'db_unique_name': 'dbUniqueName',
+            'db_id': 'dbId',
+            'database_version': 'databaseVersion',
+            'database_edition': 'databaseEdition',
+            'time_zone': 'timeZone',
+            'character_set': 'characterSet',
+            'ncharacter_set': 'ncharacterSet',
+            'db_packs': 'dbPacks',
+            'database_management_config': 'databaseManagementConfig'
+        }
+
+        self._compartment_id = None
+        self._freeform_tags = None
+        self._defined_tags = None
+        self._display_name = None
+        self._id = None
+        self._lifecycle_details = None
+        self._lifecycle_state = None
+        self._time_created = None
+        self._db_unique_name = None
+        self._db_id = None
+        self._database_version = None
+        self._database_edition = None
+        self._time_zone = None
+        self._character_set = None
+        self._ncharacter_set = None
+        self._db_packs = None
+        self._database_management_config = None
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this ExternalNonContainerDatabaseSummary.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this ExternalNonContainerDatabaseSummary.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this ExternalNonContainerDatabaseSummary.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this ExternalNonContainerDatabaseSummary.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this ExternalNonContainerDatabaseSummary.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this ExternalNonContainerDatabaseSummary.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this ExternalNonContainerDatabaseSummary.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this ExternalNonContainerDatabaseSummary.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this ExternalNonContainerDatabaseSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this ExternalNonContainerDatabaseSummary.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this ExternalNonContainerDatabaseSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this ExternalNonContainerDatabaseSummary.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this ExternalNonContainerDatabaseSummary.
+        The user-friendly name for the external database. The name does not have to be unique.
+
+
+        :return: The display_name of this ExternalNonContainerDatabaseSummary.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this ExternalNonContainerDatabaseSummary.
+        The user-friendly name for the external database. The name does not have to be unique.
+
+
+        :param display_name: The display_name of this ExternalNonContainerDatabaseSummary.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this ExternalNonContainerDatabaseSummary.
+        The `OCID`__ of the Oracle Cloud Infrastructure external database resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The id of this ExternalNonContainerDatabaseSummary.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this ExternalNonContainerDatabaseSummary.
+        The `OCID`__ of the Oracle Cloud Infrastructure external database resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param id: The id of this ExternalNonContainerDatabaseSummary.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def lifecycle_details(self):
+        """
+        Gets the lifecycle_details of this ExternalNonContainerDatabaseSummary.
+        Additional information about the current lifecycle state.
+
+
+        :return: The lifecycle_details of this ExternalNonContainerDatabaseSummary.
+        :rtype: str
+        """
+        return self._lifecycle_details
+
+    @lifecycle_details.setter
+    def lifecycle_details(self, lifecycle_details):
+        """
+        Sets the lifecycle_details of this ExternalNonContainerDatabaseSummary.
+        Additional information about the current lifecycle state.
+
+
+        :param lifecycle_details: The lifecycle_details of this ExternalNonContainerDatabaseSummary.
+        :type: str
+        """
+        self._lifecycle_details = lifecycle_details
+
+    @property
+    def lifecycle_state(self):
+        """
+        **[Required]** Gets the lifecycle_state of this ExternalNonContainerDatabaseSummary.
+        The current state of the Oracle Cloud Infrastructure external database resource.
+
+        Allowed values for this property are: "PROVISIONING", "NOT_CONNECTED", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this ExternalNonContainerDatabaseSummary.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this ExternalNonContainerDatabaseSummary.
+        The current state of the Oracle Cloud Infrastructure external database resource.
+
+
+        :param lifecycle_state: The lifecycle_state of this ExternalNonContainerDatabaseSummary.
+        :type: str
+        """
+        allowed_values = ["PROVISIONING", "NOT_CONNECTED", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def time_created(self):
+        """
+        **[Required]** Gets the time_created of this ExternalNonContainerDatabaseSummary.
+        The date and time the database was created.
+
+
+        :return: The time_created of this ExternalNonContainerDatabaseSummary.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this ExternalNonContainerDatabaseSummary.
+        The date and time the database was created.
+
+
+        :param time_created: The time_created of this ExternalNonContainerDatabaseSummary.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def db_unique_name(self):
+        """
+        Gets the db_unique_name of this ExternalNonContainerDatabaseSummary.
+        The `DB_UNIQUE_NAME` of the external database.
+
+
+        :return: The db_unique_name of this ExternalNonContainerDatabaseSummary.
+        :rtype: str
+        """
+        return self._db_unique_name
+
+    @db_unique_name.setter
+    def db_unique_name(self, db_unique_name):
+        """
+        Sets the db_unique_name of this ExternalNonContainerDatabaseSummary.
+        The `DB_UNIQUE_NAME` of the external database.
+
+
+        :param db_unique_name: The db_unique_name of this ExternalNonContainerDatabaseSummary.
+        :type: str
+        """
+        self._db_unique_name = db_unique_name
+
+    @property
+    def db_id(self):
+        """
+        Gets the db_id of this ExternalNonContainerDatabaseSummary.
+        The Oracle Database ID, which identifies an Oracle Database located outside of Oracle Cloud.
+
+
+        :return: The db_id of this ExternalNonContainerDatabaseSummary.
+        :rtype: str
+        """
+        return self._db_id
+
+    @db_id.setter
+    def db_id(self, db_id):
+        """
+        Sets the db_id of this ExternalNonContainerDatabaseSummary.
+        The Oracle Database ID, which identifies an Oracle Database located outside of Oracle Cloud.
+
+
+        :param db_id: The db_id of this ExternalNonContainerDatabaseSummary.
+        :type: str
+        """
+        self._db_id = db_id
+
+    @property
+    def database_version(self):
+        """
+        Gets the database_version of this ExternalNonContainerDatabaseSummary.
+        The Oracle Database version.
+
+
+        :return: The database_version of this ExternalNonContainerDatabaseSummary.
+        :rtype: str
+        """
+        return self._database_version
+
+    @database_version.setter
+    def database_version(self, database_version):
+        """
+        Sets the database_version of this ExternalNonContainerDatabaseSummary.
+        The Oracle Database version.
+
+
+        :param database_version: The database_version of this ExternalNonContainerDatabaseSummary.
+        :type: str
+        """
+        self._database_version = database_version
+
+    @property
+    def database_edition(self):
+        """
+        Gets the database_edition of this ExternalNonContainerDatabaseSummary.
+        The Oracle Database edition.
+
+        Allowed values for this property are: "STANDARD_EDITION", "ENTERPRISE_EDITION", "ENTERPRISE_EDITION_HIGH_PERFORMANCE", "ENTERPRISE_EDITION_EXTREME_PERFORMANCE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The database_edition of this ExternalNonContainerDatabaseSummary.
+        :rtype: str
+        """
+        return self._database_edition
+
+    @database_edition.setter
+    def database_edition(self, database_edition):
+        """
+        Sets the database_edition of this ExternalNonContainerDatabaseSummary.
+        The Oracle Database edition.
+
+
+        :param database_edition: The database_edition of this ExternalNonContainerDatabaseSummary.
+        :type: str
+        """
+        allowed_values = ["STANDARD_EDITION", "ENTERPRISE_EDITION", "ENTERPRISE_EDITION_HIGH_PERFORMANCE", "ENTERPRISE_EDITION_EXTREME_PERFORMANCE"]
+        if not value_allowed_none_or_none_sentinel(database_edition, allowed_values):
+            database_edition = 'UNKNOWN_ENUM_VALUE'
+        self._database_edition = database_edition
+
+    @property
+    def time_zone(self):
+        """
+        Gets the time_zone of this ExternalNonContainerDatabaseSummary.
+        The time zone of the external database.
+        It is a time zone offset (a character type in the format '[+|-]TZH:TZM') or a time zone region name,
+        depending on how the time zone value was specified when the database was created / last altered.
+
+
+        :return: The time_zone of this ExternalNonContainerDatabaseSummary.
+        :rtype: str
+        """
+        return self._time_zone
+
+    @time_zone.setter
+    def time_zone(self, time_zone):
+        """
+        Sets the time_zone of this ExternalNonContainerDatabaseSummary.
+        The time zone of the external database.
+        It is a time zone offset (a character type in the format '[+|-]TZH:TZM') or a time zone region name,
+        depending on how the time zone value was specified when the database was created / last altered.
+
+
+        :param time_zone: The time_zone of this ExternalNonContainerDatabaseSummary.
+        :type: str
+        """
+        self._time_zone = time_zone
+
+    @property
+    def character_set(self):
+        """
+        Gets the character_set of this ExternalNonContainerDatabaseSummary.
+        The character set of the external database.
+
+
+        :return: The character_set of this ExternalNonContainerDatabaseSummary.
+        :rtype: str
+        """
+        return self._character_set
+
+    @character_set.setter
+    def character_set(self, character_set):
+        """
+        Sets the character_set of this ExternalNonContainerDatabaseSummary.
+        The character set of the external database.
+
+
+        :param character_set: The character_set of this ExternalNonContainerDatabaseSummary.
+        :type: str
+        """
+        self._character_set = character_set
+
+    @property
+    def ncharacter_set(self):
+        """
+        Gets the ncharacter_set of this ExternalNonContainerDatabaseSummary.
+        The national character of the external database.
+
+
+        :return: The ncharacter_set of this ExternalNonContainerDatabaseSummary.
+        :rtype: str
+        """
+        return self._ncharacter_set
+
+    @ncharacter_set.setter
+    def ncharacter_set(self, ncharacter_set):
+        """
+        Sets the ncharacter_set of this ExternalNonContainerDatabaseSummary.
+        The national character of the external database.
+
+
+        :param ncharacter_set: The ncharacter_set of this ExternalNonContainerDatabaseSummary.
+        :type: str
+        """
+        self._ncharacter_set = ncharacter_set
+
+    @property
+    def db_packs(self):
+        """
+        Gets the db_packs of this ExternalNonContainerDatabaseSummary.
+        The database packs licensed for the external Oracle Database.
+
+
+        :return: The db_packs of this ExternalNonContainerDatabaseSummary.
+        :rtype: str
+        """
+        return self._db_packs
+
+    @db_packs.setter
+    def db_packs(self, db_packs):
+        """
+        Sets the db_packs of this ExternalNonContainerDatabaseSummary.
+        The database packs licensed for the external Oracle Database.
+
+
+        :param db_packs: The db_packs of this ExternalNonContainerDatabaseSummary.
+        :type: str
+        """
+        self._db_packs = db_packs
+
+    @property
+    def database_management_config(self):
+        """
+        Gets the database_management_config of this ExternalNonContainerDatabaseSummary.
+
+        :return: The database_management_config of this ExternalNonContainerDatabaseSummary.
+        :rtype: oci.database.models.DatabaseManagementConfig
+        """
+        return self._database_management_config
+
+    @database_management_config.setter
+    def database_management_config(self, database_management_config):
+        """
+        Sets the database_management_config of this ExternalNonContainerDatabaseSummary.
+
+        :param database_management_config: The database_management_config of this ExternalNonContainerDatabaseSummary.
+        :type: oci.database.models.DatabaseManagementConfig
+        """
+        self._database_management_config = database_management_config
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/external_pluggable_database.py
+++ b/src/oci/database/models/external_pluggable_database.py
@@ -1,0 +1,726 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ExternalPluggableDatabase(object):
+    """
+    an external Oracle pluggable database.
+    """
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalPluggableDatabase.
+    #: This constant has a value of "PROVISIONING"
+    LIFECYCLE_STATE_PROVISIONING = "PROVISIONING"
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalPluggableDatabase.
+    #: This constant has a value of "NOT_CONNECTED"
+    LIFECYCLE_STATE_NOT_CONNECTED = "NOT_CONNECTED"
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalPluggableDatabase.
+    #: This constant has a value of "AVAILABLE"
+    LIFECYCLE_STATE_AVAILABLE = "AVAILABLE"
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalPluggableDatabase.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalPluggableDatabase.
+    #: This constant has a value of "TERMINATING"
+    LIFECYCLE_STATE_TERMINATING = "TERMINATING"
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalPluggableDatabase.
+    #: This constant has a value of "TERMINATED"
+    LIFECYCLE_STATE_TERMINATED = "TERMINATED"
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalPluggableDatabase.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    #: A constant which can be used with the database_edition property of a ExternalPluggableDatabase.
+    #: This constant has a value of "STANDARD_EDITION"
+    DATABASE_EDITION_STANDARD_EDITION = "STANDARD_EDITION"
+
+    #: A constant which can be used with the database_edition property of a ExternalPluggableDatabase.
+    #: This constant has a value of "ENTERPRISE_EDITION"
+    DATABASE_EDITION_ENTERPRISE_EDITION = "ENTERPRISE_EDITION"
+
+    #: A constant which can be used with the database_edition property of a ExternalPluggableDatabase.
+    #: This constant has a value of "ENTERPRISE_EDITION_HIGH_PERFORMANCE"
+    DATABASE_EDITION_ENTERPRISE_EDITION_HIGH_PERFORMANCE = "ENTERPRISE_EDITION_HIGH_PERFORMANCE"
+
+    #: A constant which can be used with the database_edition property of a ExternalPluggableDatabase.
+    #: This constant has a value of "ENTERPRISE_EDITION_EXTREME_PERFORMANCE"
+    DATABASE_EDITION_ENTERPRISE_EDITION_EXTREME_PERFORMANCE = "ENTERPRISE_EDITION_EXTREME_PERFORMANCE"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ExternalPluggableDatabase object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param source_id:
+            The value to assign to the source_id property of this ExternalPluggableDatabase.
+        :type source_id: str
+
+        :param external_container_database_id:
+            The value to assign to the external_container_database_id property of this ExternalPluggableDatabase.
+        :type external_container_database_id: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ExternalPluggableDatabase.
+        :type compartment_id: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this ExternalPluggableDatabase.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this ExternalPluggableDatabase.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param display_name:
+            The value to assign to the display_name property of this ExternalPluggableDatabase.
+        :type display_name: str
+
+        :param id:
+            The value to assign to the id property of this ExternalPluggableDatabase.
+        :type id: str
+
+        :param lifecycle_details:
+            The value to assign to the lifecycle_details property of this ExternalPluggableDatabase.
+        :type lifecycle_details: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this ExternalPluggableDatabase.
+            Allowed values for this property are: "PROVISIONING", "NOT_CONNECTED", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param time_created:
+            The value to assign to the time_created property of this ExternalPluggableDatabase.
+        :type time_created: datetime
+
+        :param db_unique_name:
+            The value to assign to the db_unique_name property of this ExternalPluggableDatabase.
+        :type db_unique_name: str
+
+        :param db_id:
+            The value to assign to the db_id property of this ExternalPluggableDatabase.
+        :type db_id: str
+
+        :param database_version:
+            The value to assign to the database_version property of this ExternalPluggableDatabase.
+        :type database_version: str
+
+        :param database_edition:
+            The value to assign to the database_edition property of this ExternalPluggableDatabase.
+            Allowed values for this property are: "STANDARD_EDITION", "ENTERPRISE_EDITION", "ENTERPRISE_EDITION_HIGH_PERFORMANCE", "ENTERPRISE_EDITION_EXTREME_PERFORMANCE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type database_edition: str
+
+        :param time_zone:
+            The value to assign to the time_zone property of this ExternalPluggableDatabase.
+        :type time_zone: str
+
+        :param character_set:
+            The value to assign to the character_set property of this ExternalPluggableDatabase.
+        :type character_set: str
+
+        :param ncharacter_set:
+            The value to assign to the ncharacter_set property of this ExternalPluggableDatabase.
+        :type ncharacter_set: str
+
+        :param db_packs:
+            The value to assign to the db_packs property of this ExternalPluggableDatabase.
+        :type db_packs: str
+
+        :param database_management_config:
+            The value to assign to the database_management_config property of this ExternalPluggableDatabase.
+        :type database_management_config: oci.database.models.DatabaseManagementConfig
+
+        """
+        self.swagger_types = {
+            'source_id': 'str',
+            'external_container_database_id': 'str',
+            'compartment_id': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'display_name': 'str',
+            'id': 'str',
+            'lifecycle_details': 'str',
+            'lifecycle_state': 'str',
+            'time_created': 'datetime',
+            'db_unique_name': 'str',
+            'db_id': 'str',
+            'database_version': 'str',
+            'database_edition': 'str',
+            'time_zone': 'str',
+            'character_set': 'str',
+            'ncharacter_set': 'str',
+            'db_packs': 'str',
+            'database_management_config': 'DatabaseManagementConfig'
+        }
+
+        self.attribute_map = {
+            'source_id': 'sourceId',
+            'external_container_database_id': 'externalContainerDatabaseId',
+            'compartment_id': 'compartmentId',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags',
+            'display_name': 'displayName',
+            'id': 'id',
+            'lifecycle_details': 'lifecycleDetails',
+            'lifecycle_state': 'lifecycleState',
+            'time_created': 'timeCreated',
+            'db_unique_name': 'dbUniqueName',
+            'db_id': 'dbId',
+            'database_version': 'databaseVersion',
+            'database_edition': 'databaseEdition',
+            'time_zone': 'timeZone',
+            'character_set': 'characterSet',
+            'ncharacter_set': 'ncharacterSet',
+            'db_packs': 'dbPacks',
+            'database_management_config': 'databaseManagementConfig'
+        }
+
+        self._source_id = None
+        self._external_container_database_id = None
+        self._compartment_id = None
+        self._freeform_tags = None
+        self._defined_tags = None
+        self._display_name = None
+        self._id = None
+        self._lifecycle_details = None
+        self._lifecycle_state = None
+        self._time_created = None
+        self._db_unique_name = None
+        self._db_id = None
+        self._database_version = None
+        self._database_edition = None
+        self._time_zone = None
+        self._character_set = None
+        self._ncharacter_set = None
+        self._db_packs = None
+        self._database_management_config = None
+
+    @property
+    def source_id(self):
+        """
+        Gets the source_id of this ExternalPluggableDatabase.
+        The `OCID`__ of the the non-container database that was converted
+        to a pluggable database to create this resource.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :return: The source_id of this ExternalPluggableDatabase.
+        :rtype: str
+        """
+        return self._source_id
+
+    @source_id.setter
+    def source_id(self, source_id):
+        """
+        Sets the source_id of this ExternalPluggableDatabase.
+        The `OCID`__ of the the non-container database that was converted
+        to a pluggable database to create this resource.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :param source_id: The source_id of this ExternalPluggableDatabase.
+        :type: str
+        """
+        self._source_id = source_id
+
+    @property
+    def external_container_database_id(self):
+        """
+        **[Required]** Gets the external_container_database_id of this ExternalPluggableDatabase.
+        The `OCID`__ of the
+        :func:`create_external_container_database_details` that contains
+        the specified :func:`create_external_pluggable_database_details` resource.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :return: The external_container_database_id of this ExternalPluggableDatabase.
+        :rtype: str
+        """
+        return self._external_container_database_id
+
+    @external_container_database_id.setter
+    def external_container_database_id(self, external_container_database_id):
+        """
+        Sets the external_container_database_id of this ExternalPluggableDatabase.
+        The `OCID`__ of the
+        :func:`create_external_container_database_details` that contains
+        the specified :func:`create_external_pluggable_database_details` resource.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :param external_container_database_id: The external_container_database_id of this ExternalPluggableDatabase.
+        :type: str
+        """
+        self._external_container_database_id = external_container_database_id
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this ExternalPluggableDatabase.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this ExternalPluggableDatabase.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this ExternalPluggableDatabase.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this ExternalPluggableDatabase.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this ExternalPluggableDatabase.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this ExternalPluggableDatabase.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this ExternalPluggableDatabase.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this ExternalPluggableDatabase.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this ExternalPluggableDatabase.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this ExternalPluggableDatabase.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this ExternalPluggableDatabase.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this ExternalPluggableDatabase.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this ExternalPluggableDatabase.
+        The user-friendly name for the external database. The name does not have to be unique.
+
+
+        :return: The display_name of this ExternalPluggableDatabase.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this ExternalPluggableDatabase.
+        The user-friendly name for the external database. The name does not have to be unique.
+
+
+        :param display_name: The display_name of this ExternalPluggableDatabase.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this ExternalPluggableDatabase.
+        The `OCID`__ of the Oracle Cloud Infrastructure external database resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The id of this ExternalPluggableDatabase.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this ExternalPluggableDatabase.
+        The `OCID`__ of the Oracle Cloud Infrastructure external database resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param id: The id of this ExternalPluggableDatabase.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def lifecycle_details(self):
+        """
+        Gets the lifecycle_details of this ExternalPluggableDatabase.
+        Additional information about the current lifecycle state.
+
+
+        :return: The lifecycle_details of this ExternalPluggableDatabase.
+        :rtype: str
+        """
+        return self._lifecycle_details
+
+    @lifecycle_details.setter
+    def lifecycle_details(self, lifecycle_details):
+        """
+        Sets the lifecycle_details of this ExternalPluggableDatabase.
+        Additional information about the current lifecycle state.
+
+
+        :param lifecycle_details: The lifecycle_details of this ExternalPluggableDatabase.
+        :type: str
+        """
+        self._lifecycle_details = lifecycle_details
+
+    @property
+    def lifecycle_state(self):
+        """
+        **[Required]** Gets the lifecycle_state of this ExternalPluggableDatabase.
+        The current state of the Oracle Cloud Infrastructure external database resource.
+
+        Allowed values for this property are: "PROVISIONING", "NOT_CONNECTED", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this ExternalPluggableDatabase.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this ExternalPluggableDatabase.
+        The current state of the Oracle Cloud Infrastructure external database resource.
+
+
+        :param lifecycle_state: The lifecycle_state of this ExternalPluggableDatabase.
+        :type: str
+        """
+        allowed_values = ["PROVISIONING", "NOT_CONNECTED", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def time_created(self):
+        """
+        **[Required]** Gets the time_created of this ExternalPluggableDatabase.
+        The date and time the database was created.
+
+
+        :return: The time_created of this ExternalPluggableDatabase.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this ExternalPluggableDatabase.
+        The date and time the database was created.
+
+
+        :param time_created: The time_created of this ExternalPluggableDatabase.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def db_unique_name(self):
+        """
+        Gets the db_unique_name of this ExternalPluggableDatabase.
+        The `DB_UNIQUE_NAME` of the external database.
+
+
+        :return: The db_unique_name of this ExternalPluggableDatabase.
+        :rtype: str
+        """
+        return self._db_unique_name
+
+    @db_unique_name.setter
+    def db_unique_name(self, db_unique_name):
+        """
+        Sets the db_unique_name of this ExternalPluggableDatabase.
+        The `DB_UNIQUE_NAME` of the external database.
+
+
+        :param db_unique_name: The db_unique_name of this ExternalPluggableDatabase.
+        :type: str
+        """
+        self._db_unique_name = db_unique_name
+
+    @property
+    def db_id(self):
+        """
+        Gets the db_id of this ExternalPluggableDatabase.
+        The Oracle Database ID, which identifies an Oracle Database located outside of Oracle Cloud.
+
+
+        :return: The db_id of this ExternalPluggableDatabase.
+        :rtype: str
+        """
+        return self._db_id
+
+    @db_id.setter
+    def db_id(self, db_id):
+        """
+        Sets the db_id of this ExternalPluggableDatabase.
+        The Oracle Database ID, which identifies an Oracle Database located outside of Oracle Cloud.
+
+
+        :param db_id: The db_id of this ExternalPluggableDatabase.
+        :type: str
+        """
+        self._db_id = db_id
+
+    @property
+    def database_version(self):
+        """
+        Gets the database_version of this ExternalPluggableDatabase.
+        The Oracle Database version.
+
+
+        :return: The database_version of this ExternalPluggableDatabase.
+        :rtype: str
+        """
+        return self._database_version
+
+    @database_version.setter
+    def database_version(self, database_version):
+        """
+        Sets the database_version of this ExternalPluggableDatabase.
+        The Oracle Database version.
+
+
+        :param database_version: The database_version of this ExternalPluggableDatabase.
+        :type: str
+        """
+        self._database_version = database_version
+
+    @property
+    def database_edition(self):
+        """
+        Gets the database_edition of this ExternalPluggableDatabase.
+        The Oracle Database edition.
+
+        Allowed values for this property are: "STANDARD_EDITION", "ENTERPRISE_EDITION", "ENTERPRISE_EDITION_HIGH_PERFORMANCE", "ENTERPRISE_EDITION_EXTREME_PERFORMANCE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The database_edition of this ExternalPluggableDatabase.
+        :rtype: str
+        """
+        return self._database_edition
+
+    @database_edition.setter
+    def database_edition(self, database_edition):
+        """
+        Sets the database_edition of this ExternalPluggableDatabase.
+        The Oracle Database edition.
+
+
+        :param database_edition: The database_edition of this ExternalPluggableDatabase.
+        :type: str
+        """
+        allowed_values = ["STANDARD_EDITION", "ENTERPRISE_EDITION", "ENTERPRISE_EDITION_HIGH_PERFORMANCE", "ENTERPRISE_EDITION_EXTREME_PERFORMANCE"]
+        if not value_allowed_none_or_none_sentinel(database_edition, allowed_values):
+            database_edition = 'UNKNOWN_ENUM_VALUE'
+        self._database_edition = database_edition
+
+    @property
+    def time_zone(self):
+        """
+        Gets the time_zone of this ExternalPluggableDatabase.
+        The time zone of the external database.
+        It is a time zone offset (a character type in the format '[+|-]TZH:TZM') or a time zone region name,
+        depending on how the time zone value was specified when the database was created / last altered.
+
+
+        :return: The time_zone of this ExternalPluggableDatabase.
+        :rtype: str
+        """
+        return self._time_zone
+
+    @time_zone.setter
+    def time_zone(self, time_zone):
+        """
+        Sets the time_zone of this ExternalPluggableDatabase.
+        The time zone of the external database.
+        It is a time zone offset (a character type in the format '[+|-]TZH:TZM') or a time zone region name,
+        depending on how the time zone value was specified when the database was created / last altered.
+
+
+        :param time_zone: The time_zone of this ExternalPluggableDatabase.
+        :type: str
+        """
+        self._time_zone = time_zone
+
+    @property
+    def character_set(self):
+        """
+        Gets the character_set of this ExternalPluggableDatabase.
+        The character set of the external database.
+
+
+        :return: The character_set of this ExternalPluggableDatabase.
+        :rtype: str
+        """
+        return self._character_set
+
+    @character_set.setter
+    def character_set(self, character_set):
+        """
+        Sets the character_set of this ExternalPluggableDatabase.
+        The character set of the external database.
+
+
+        :param character_set: The character_set of this ExternalPluggableDatabase.
+        :type: str
+        """
+        self._character_set = character_set
+
+    @property
+    def ncharacter_set(self):
+        """
+        Gets the ncharacter_set of this ExternalPluggableDatabase.
+        The national character of the external database.
+
+
+        :return: The ncharacter_set of this ExternalPluggableDatabase.
+        :rtype: str
+        """
+        return self._ncharacter_set
+
+    @ncharacter_set.setter
+    def ncharacter_set(self, ncharacter_set):
+        """
+        Sets the ncharacter_set of this ExternalPluggableDatabase.
+        The national character of the external database.
+
+
+        :param ncharacter_set: The ncharacter_set of this ExternalPluggableDatabase.
+        :type: str
+        """
+        self._ncharacter_set = ncharacter_set
+
+    @property
+    def db_packs(self):
+        """
+        Gets the db_packs of this ExternalPluggableDatabase.
+        The database packs licensed for the external Oracle Database.
+
+
+        :return: The db_packs of this ExternalPluggableDatabase.
+        :rtype: str
+        """
+        return self._db_packs
+
+    @db_packs.setter
+    def db_packs(self, db_packs):
+        """
+        Sets the db_packs of this ExternalPluggableDatabase.
+        The database packs licensed for the external Oracle Database.
+
+
+        :param db_packs: The db_packs of this ExternalPluggableDatabase.
+        :type: str
+        """
+        self._db_packs = db_packs
+
+    @property
+    def database_management_config(self):
+        """
+        Gets the database_management_config of this ExternalPluggableDatabase.
+
+        :return: The database_management_config of this ExternalPluggableDatabase.
+        :rtype: oci.database.models.DatabaseManagementConfig
+        """
+        return self._database_management_config
+
+    @database_management_config.setter
+    def database_management_config(self, database_management_config):
+        """
+        Sets the database_management_config of this ExternalPluggableDatabase.
+
+        :param database_management_config: The database_management_config of this ExternalPluggableDatabase.
+        :type: oci.database.models.DatabaseManagementConfig
+        """
+        self._database_management_config = database_management_config
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/external_pluggable_database_summary.py
+++ b/src/oci/database/models/external_pluggable_database_summary.py
@@ -1,0 +1,726 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ExternalPluggableDatabaseSummary(object):
+    """
+    An Oracle Cloud Infrastructure resource that allows you to manage an external pluggable database.
+    """
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalPluggableDatabaseSummary.
+    #: This constant has a value of "PROVISIONING"
+    LIFECYCLE_STATE_PROVISIONING = "PROVISIONING"
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalPluggableDatabaseSummary.
+    #: This constant has a value of "NOT_CONNECTED"
+    LIFECYCLE_STATE_NOT_CONNECTED = "NOT_CONNECTED"
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalPluggableDatabaseSummary.
+    #: This constant has a value of "AVAILABLE"
+    LIFECYCLE_STATE_AVAILABLE = "AVAILABLE"
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalPluggableDatabaseSummary.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalPluggableDatabaseSummary.
+    #: This constant has a value of "TERMINATING"
+    LIFECYCLE_STATE_TERMINATING = "TERMINATING"
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalPluggableDatabaseSummary.
+    #: This constant has a value of "TERMINATED"
+    LIFECYCLE_STATE_TERMINATED = "TERMINATED"
+
+    #: A constant which can be used with the lifecycle_state property of a ExternalPluggableDatabaseSummary.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    #: A constant which can be used with the database_edition property of a ExternalPluggableDatabaseSummary.
+    #: This constant has a value of "STANDARD_EDITION"
+    DATABASE_EDITION_STANDARD_EDITION = "STANDARD_EDITION"
+
+    #: A constant which can be used with the database_edition property of a ExternalPluggableDatabaseSummary.
+    #: This constant has a value of "ENTERPRISE_EDITION"
+    DATABASE_EDITION_ENTERPRISE_EDITION = "ENTERPRISE_EDITION"
+
+    #: A constant which can be used with the database_edition property of a ExternalPluggableDatabaseSummary.
+    #: This constant has a value of "ENTERPRISE_EDITION_HIGH_PERFORMANCE"
+    DATABASE_EDITION_ENTERPRISE_EDITION_HIGH_PERFORMANCE = "ENTERPRISE_EDITION_HIGH_PERFORMANCE"
+
+    #: A constant which can be used with the database_edition property of a ExternalPluggableDatabaseSummary.
+    #: This constant has a value of "ENTERPRISE_EDITION_EXTREME_PERFORMANCE"
+    DATABASE_EDITION_ENTERPRISE_EDITION_EXTREME_PERFORMANCE = "ENTERPRISE_EDITION_EXTREME_PERFORMANCE"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ExternalPluggableDatabaseSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param source_id:
+            The value to assign to the source_id property of this ExternalPluggableDatabaseSummary.
+        :type source_id: str
+
+        :param external_container_database_id:
+            The value to assign to the external_container_database_id property of this ExternalPluggableDatabaseSummary.
+        :type external_container_database_id: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ExternalPluggableDatabaseSummary.
+        :type compartment_id: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this ExternalPluggableDatabaseSummary.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this ExternalPluggableDatabaseSummary.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param display_name:
+            The value to assign to the display_name property of this ExternalPluggableDatabaseSummary.
+        :type display_name: str
+
+        :param id:
+            The value to assign to the id property of this ExternalPluggableDatabaseSummary.
+        :type id: str
+
+        :param lifecycle_details:
+            The value to assign to the lifecycle_details property of this ExternalPluggableDatabaseSummary.
+        :type lifecycle_details: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this ExternalPluggableDatabaseSummary.
+            Allowed values for this property are: "PROVISIONING", "NOT_CONNECTED", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param time_created:
+            The value to assign to the time_created property of this ExternalPluggableDatabaseSummary.
+        :type time_created: datetime
+
+        :param db_unique_name:
+            The value to assign to the db_unique_name property of this ExternalPluggableDatabaseSummary.
+        :type db_unique_name: str
+
+        :param db_id:
+            The value to assign to the db_id property of this ExternalPluggableDatabaseSummary.
+        :type db_id: str
+
+        :param database_version:
+            The value to assign to the database_version property of this ExternalPluggableDatabaseSummary.
+        :type database_version: str
+
+        :param database_edition:
+            The value to assign to the database_edition property of this ExternalPluggableDatabaseSummary.
+            Allowed values for this property are: "STANDARD_EDITION", "ENTERPRISE_EDITION", "ENTERPRISE_EDITION_HIGH_PERFORMANCE", "ENTERPRISE_EDITION_EXTREME_PERFORMANCE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type database_edition: str
+
+        :param time_zone:
+            The value to assign to the time_zone property of this ExternalPluggableDatabaseSummary.
+        :type time_zone: str
+
+        :param character_set:
+            The value to assign to the character_set property of this ExternalPluggableDatabaseSummary.
+        :type character_set: str
+
+        :param ncharacter_set:
+            The value to assign to the ncharacter_set property of this ExternalPluggableDatabaseSummary.
+        :type ncharacter_set: str
+
+        :param db_packs:
+            The value to assign to the db_packs property of this ExternalPluggableDatabaseSummary.
+        :type db_packs: str
+
+        :param database_management_config:
+            The value to assign to the database_management_config property of this ExternalPluggableDatabaseSummary.
+        :type database_management_config: oci.database.models.DatabaseManagementConfig
+
+        """
+        self.swagger_types = {
+            'source_id': 'str',
+            'external_container_database_id': 'str',
+            'compartment_id': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'display_name': 'str',
+            'id': 'str',
+            'lifecycle_details': 'str',
+            'lifecycle_state': 'str',
+            'time_created': 'datetime',
+            'db_unique_name': 'str',
+            'db_id': 'str',
+            'database_version': 'str',
+            'database_edition': 'str',
+            'time_zone': 'str',
+            'character_set': 'str',
+            'ncharacter_set': 'str',
+            'db_packs': 'str',
+            'database_management_config': 'DatabaseManagementConfig'
+        }
+
+        self.attribute_map = {
+            'source_id': 'sourceId',
+            'external_container_database_id': 'externalContainerDatabaseId',
+            'compartment_id': 'compartmentId',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags',
+            'display_name': 'displayName',
+            'id': 'id',
+            'lifecycle_details': 'lifecycleDetails',
+            'lifecycle_state': 'lifecycleState',
+            'time_created': 'timeCreated',
+            'db_unique_name': 'dbUniqueName',
+            'db_id': 'dbId',
+            'database_version': 'databaseVersion',
+            'database_edition': 'databaseEdition',
+            'time_zone': 'timeZone',
+            'character_set': 'characterSet',
+            'ncharacter_set': 'ncharacterSet',
+            'db_packs': 'dbPacks',
+            'database_management_config': 'databaseManagementConfig'
+        }
+
+        self._source_id = None
+        self._external_container_database_id = None
+        self._compartment_id = None
+        self._freeform_tags = None
+        self._defined_tags = None
+        self._display_name = None
+        self._id = None
+        self._lifecycle_details = None
+        self._lifecycle_state = None
+        self._time_created = None
+        self._db_unique_name = None
+        self._db_id = None
+        self._database_version = None
+        self._database_edition = None
+        self._time_zone = None
+        self._character_set = None
+        self._ncharacter_set = None
+        self._db_packs = None
+        self._database_management_config = None
+
+    @property
+    def source_id(self):
+        """
+        Gets the source_id of this ExternalPluggableDatabaseSummary.
+        The `OCID`__ of the the non-container database that was converted
+        to a pluggable database to create this resource.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :return: The source_id of this ExternalPluggableDatabaseSummary.
+        :rtype: str
+        """
+        return self._source_id
+
+    @source_id.setter
+    def source_id(self, source_id):
+        """
+        Sets the source_id of this ExternalPluggableDatabaseSummary.
+        The `OCID`__ of the the non-container database that was converted
+        to a pluggable database to create this resource.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :param source_id: The source_id of this ExternalPluggableDatabaseSummary.
+        :type: str
+        """
+        self._source_id = source_id
+
+    @property
+    def external_container_database_id(self):
+        """
+        **[Required]** Gets the external_container_database_id of this ExternalPluggableDatabaseSummary.
+        The `OCID`__ of the
+        :func:`create_external_container_database_details` that contains
+        the specified :func:`create_external_pluggable_database_details` resource.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :return: The external_container_database_id of this ExternalPluggableDatabaseSummary.
+        :rtype: str
+        """
+        return self._external_container_database_id
+
+    @external_container_database_id.setter
+    def external_container_database_id(self, external_container_database_id):
+        """
+        Sets the external_container_database_id of this ExternalPluggableDatabaseSummary.
+        The `OCID`__ of the
+        :func:`create_external_container_database_details` that contains
+        the specified :func:`create_external_pluggable_database_details` resource.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :param external_container_database_id: The external_container_database_id of this ExternalPluggableDatabaseSummary.
+        :type: str
+        """
+        self._external_container_database_id = external_container_database_id
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this ExternalPluggableDatabaseSummary.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this ExternalPluggableDatabaseSummary.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this ExternalPluggableDatabaseSummary.
+        The `OCID`__ of the compartment.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this ExternalPluggableDatabaseSummary.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this ExternalPluggableDatabaseSummary.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this ExternalPluggableDatabaseSummary.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this ExternalPluggableDatabaseSummary.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this ExternalPluggableDatabaseSummary.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this ExternalPluggableDatabaseSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this ExternalPluggableDatabaseSummary.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this ExternalPluggableDatabaseSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this ExternalPluggableDatabaseSummary.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this ExternalPluggableDatabaseSummary.
+        The user-friendly name for the external database. The name does not have to be unique.
+
+
+        :return: The display_name of this ExternalPluggableDatabaseSummary.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this ExternalPluggableDatabaseSummary.
+        The user-friendly name for the external database. The name does not have to be unique.
+
+
+        :param display_name: The display_name of this ExternalPluggableDatabaseSummary.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this ExternalPluggableDatabaseSummary.
+        The `OCID`__ of the Oracle Cloud Infrastructure external database resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The id of this ExternalPluggableDatabaseSummary.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this ExternalPluggableDatabaseSummary.
+        The `OCID`__ of the Oracle Cloud Infrastructure external database resource.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param id: The id of this ExternalPluggableDatabaseSummary.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def lifecycle_details(self):
+        """
+        Gets the lifecycle_details of this ExternalPluggableDatabaseSummary.
+        Additional information about the current lifecycle state.
+
+
+        :return: The lifecycle_details of this ExternalPluggableDatabaseSummary.
+        :rtype: str
+        """
+        return self._lifecycle_details
+
+    @lifecycle_details.setter
+    def lifecycle_details(self, lifecycle_details):
+        """
+        Sets the lifecycle_details of this ExternalPluggableDatabaseSummary.
+        Additional information about the current lifecycle state.
+
+
+        :param lifecycle_details: The lifecycle_details of this ExternalPluggableDatabaseSummary.
+        :type: str
+        """
+        self._lifecycle_details = lifecycle_details
+
+    @property
+    def lifecycle_state(self):
+        """
+        **[Required]** Gets the lifecycle_state of this ExternalPluggableDatabaseSummary.
+        The current state of the Oracle Cloud Infrastructure external database resource.
+
+        Allowed values for this property are: "PROVISIONING", "NOT_CONNECTED", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this ExternalPluggableDatabaseSummary.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this ExternalPluggableDatabaseSummary.
+        The current state of the Oracle Cloud Infrastructure external database resource.
+
+
+        :param lifecycle_state: The lifecycle_state of this ExternalPluggableDatabaseSummary.
+        :type: str
+        """
+        allowed_values = ["PROVISIONING", "NOT_CONNECTED", "AVAILABLE", "UPDATING", "TERMINATING", "TERMINATED", "FAILED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def time_created(self):
+        """
+        **[Required]** Gets the time_created of this ExternalPluggableDatabaseSummary.
+        The date and time the database was created.
+
+
+        :return: The time_created of this ExternalPluggableDatabaseSummary.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this ExternalPluggableDatabaseSummary.
+        The date and time the database was created.
+
+
+        :param time_created: The time_created of this ExternalPluggableDatabaseSummary.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def db_unique_name(self):
+        """
+        Gets the db_unique_name of this ExternalPluggableDatabaseSummary.
+        The `DB_UNIQUE_NAME` of the external database.
+
+
+        :return: The db_unique_name of this ExternalPluggableDatabaseSummary.
+        :rtype: str
+        """
+        return self._db_unique_name
+
+    @db_unique_name.setter
+    def db_unique_name(self, db_unique_name):
+        """
+        Sets the db_unique_name of this ExternalPluggableDatabaseSummary.
+        The `DB_UNIQUE_NAME` of the external database.
+
+
+        :param db_unique_name: The db_unique_name of this ExternalPluggableDatabaseSummary.
+        :type: str
+        """
+        self._db_unique_name = db_unique_name
+
+    @property
+    def db_id(self):
+        """
+        Gets the db_id of this ExternalPluggableDatabaseSummary.
+        The Oracle Database ID, which identifies an Oracle Database located outside of Oracle Cloud.
+
+
+        :return: The db_id of this ExternalPluggableDatabaseSummary.
+        :rtype: str
+        """
+        return self._db_id
+
+    @db_id.setter
+    def db_id(self, db_id):
+        """
+        Sets the db_id of this ExternalPluggableDatabaseSummary.
+        The Oracle Database ID, which identifies an Oracle Database located outside of Oracle Cloud.
+
+
+        :param db_id: The db_id of this ExternalPluggableDatabaseSummary.
+        :type: str
+        """
+        self._db_id = db_id
+
+    @property
+    def database_version(self):
+        """
+        Gets the database_version of this ExternalPluggableDatabaseSummary.
+        The Oracle Database version.
+
+
+        :return: The database_version of this ExternalPluggableDatabaseSummary.
+        :rtype: str
+        """
+        return self._database_version
+
+    @database_version.setter
+    def database_version(self, database_version):
+        """
+        Sets the database_version of this ExternalPluggableDatabaseSummary.
+        The Oracle Database version.
+
+
+        :param database_version: The database_version of this ExternalPluggableDatabaseSummary.
+        :type: str
+        """
+        self._database_version = database_version
+
+    @property
+    def database_edition(self):
+        """
+        Gets the database_edition of this ExternalPluggableDatabaseSummary.
+        The Oracle Database edition.
+
+        Allowed values for this property are: "STANDARD_EDITION", "ENTERPRISE_EDITION", "ENTERPRISE_EDITION_HIGH_PERFORMANCE", "ENTERPRISE_EDITION_EXTREME_PERFORMANCE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The database_edition of this ExternalPluggableDatabaseSummary.
+        :rtype: str
+        """
+        return self._database_edition
+
+    @database_edition.setter
+    def database_edition(self, database_edition):
+        """
+        Sets the database_edition of this ExternalPluggableDatabaseSummary.
+        The Oracle Database edition.
+
+
+        :param database_edition: The database_edition of this ExternalPluggableDatabaseSummary.
+        :type: str
+        """
+        allowed_values = ["STANDARD_EDITION", "ENTERPRISE_EDITION", "ENTERPRISE_EDITION_HIGH_PERFORMANCE", "ENTERPRISE_EDITION_EXTREME_PERFORMANCE"]
+        if not value_allowed_none_or_none_sentinel(database_edition, allowed_values):
+            database_edition = 'UNKNOWN_ENUM_VALUE'
+        self._database_edition = database_edition
+
+    @property
+    def time_zone(self):
+        """
+        Gets the time_zone of this ExternalPluggableDatabaseSummary.
+        The time zone of the external database.
+        It is a time zone offset (a character type in the format '[+|-]TZH:TZM') or a time zone region name,
+        depending on how the time zone value was specified when the database was created / last altered.
+
+
+        :return: The time_zone of this ExternalPluggableDatabaseSummary.
+        :rtype: str
+        """
+        return self._time_zone
+
+    @time_zone.setter
+    def time_zone(self, time_zone):
+        """
+        Sets the time_zone of this ExternalPluggableDatabaseSummary.
+        The time zone of the external database.
+        It is a time zone offset (a character type in the format '[+|-]TZH:TZM') or a time zone region name,
+        depending on how the time zone value was specified when the database was created / last altered.
+
+
+        :param time_zone: The time_zone of this ExternalPluggableDatabaseSummary.
+        :type: str
+        """
+        self._time_zone = time_zone
+
+    @property
+    def character_set(self):
+        """
+        Gets the character_set of this ExternalPluggableDatabaseSummary.
+        The character set of the external database.
+
+
+        :return: The character_set of this ExternalPluggableDatabaseSummary.
+        :rtype: str
+        """
+        return self._character_set
+
+    @character_set.setter
+    def character_set(self, character_set):
+        """
+        Sets the character_set of this ExternalPluggableDatabaseSummary.
+        The character set of the external database.
+
+
+        :param character_set: The character_set of this ExternalPluggableDatabaseSummary.
+        :type: str
+        """
+        self._character_set = character_set
+
+    @property
+    def ncharacter_set(self):
+        """
+        Gets the ncharacter_set of this ExternalPluggableDatabaseSummary.
+        The national character of the external database.
+
+
+        :return: The ncharacter_set of this ExternalPluggableDatabaseSummary.
+        :rtype: str
+        """
+        return self._ncharacter_set
+
+    @ncharacter_set.setter
+    def ncharacter_set(self, ncharacter_set):
+        """
+        Sets the ncharacter_set of this ExternalPluggableDatabaseSummary.
+        The national character of the external database.
+
+
+        :param ncharacter_set: The ncharacter_set of this ExternalPluggableDatabaseSummary.
+        :type: str
+        """
+        self._ncharacter_set = ncharacter_set
+
+    @property
+    def db_packs(self):
+        """
+        Gets the db_packs of this ExternalPluggableDatabaseSummary.
+        The database packs licensed for the external Oracle Database.
+
+
+        :return: The db_packs of this ExternalPluggableDatabaseSummary.
+        :rtype: str
+        """
+        return self._db_packs
+
+    @db_packs.setter
+    def db_packs(self, db_packs):
+        """
+        Sets the db_packs of this ExternalPluggableDatabaseSummary.
+        The database packs licensed for the external Oracle Database.
+
+
+        :param db_packs: The db_packs of this ExternalPluggableDatabaseSummary.
+        :type: str
+        """
+        self._db_packs = db_packs
+
+    @property
+    def database_management_config(self):
+        """
+        Gets the database_management_config of this ExternalPluggableDatabaseSummary.
+
+        :return: The database_management_config of this ExternalPluggableDatabaseSummary.
+        :rtype: oci.database.models.DatabaseManagementConfig
+        """
+        return self._database_management_config
+
+    @database_management_config.setter
+    def database_management_config(self, database_management_config):
+        """
+        Sets the database_management_config of this ExternalPluggableDatabaseSummary.
+
+        :param database_management_config: The database_management_config of this ExternalPluggableDatabaseSummary.
+        :type: oci.database.models.DatabaseManagementConfig
+        """
+        self._database_management_config = database_management_config
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/maintenance_run.py
+++ b/src/oci/database/models/maintenance_run.py
@@ -521,9 +521,7 @@ class MaintenanceRun(object):
     def patch_id(self):
         """
         Gets the patch_id of this MaintenanceRun.
-        The `OCID`__ of the patch to be applied in the maintenance run.
-
-        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        The unique identifier of the patch. The identifier string includes the patch type, the Oracle Database version, and the patch creation date (using the format YYMMDD). For example, the identifier `ru_patch_19.9.0.0_201030` is used for an RU patch for Oracle Database 19.9.0.0 that was released October 30, 2020.
 
 
         :return: The patch_id of this MaintenanceRun.
@@ -535,9 +533,7 @@ class MaintenanceRun(object):
     def patch_id(self, patch_id):
         """
         Sets the patch_id of this MaintenanceRun.
-        The `OCID`__ of the patch to be applied in the maintenance run.
-
-        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        The unique identifier of the patch. The identifier string includes the patch type, the Oracle Database version, and the patch creation date (using the format YYMMDD). For example, the identifier `ru_patch_19.9.0.0_201030` is used for an RU patch for Oracle Database 19.9.0.0 that was released October 30, 2020.
 
 
         :param patch_id: The patch_id of this MaintenanceRun.

--- a/src/oci/database/models/maintenance_run_summary.py
+++ b/src/oci/database/models/maintenance_run_summary.py
@@ -521,9 +521,7 @@ class MaintenanceRunSummary(object):
     def patch_id(self):
         """
         Gets the patch_id of this MaintenanceRunSummary.
-        The `OCID`__ of the patch to be applied in the maintenance run.
-
-        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        The unique identifier of the patch. The identifier string includes the patch type, the Oracle Database version, and the patch creation date (using the format YYMMDD). For example, the identifier `ru_patch_19.9.0.0_201030` is used for an RU patch for Oracle Database 19.9.0.0 that was released October 30, 2020.
 
 
         :return: The patch_id of this MaintenanceRunSummary.
@@ -535,9 +533,7 @@ class MaintenanceRunSummary(object):
     def patch_id(self, patch_id):
         """
         Sets the patch_id of this MaintenanceRunSummary.
-        The `OCID`__ of the patch to be applied in the maintenance run.
-
-        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        The unique identifier of the patch. The identifier string includes the patch type, the Oracle Database version, and the patch creation date (using the format YYMMDD). For example, the identifier `ru_patch_19.9.0.0_201030` is used for an RU patch for Oracle Database 19.9.0.0 that was released October 30, 2020.
 
 
         :param patch_id: The patch_id of this MaintenanceRunSummary.

--- a/src/oci/database/models/update.py
+++ b/src/oci/database/models/update.py
@@ -25,6 +25,10 @@ class Update(object):
     #: This constant has a value of "PRECHECK"
     LAST_ACTION_PRECHECK = "PRECHECK"
 
+    #: A constant which can be used with the last_action property of a Update.
+    #: This constant has a value of "ROLLBACK"
+    LAST_ACTION_ROLLBACK = "ROLLBACK"
+
     #: A constant which can be used with the available_actions property of a Update.
     #: This constant has a value of "ROLLING_APPLY"
     AVAILABLE_ACTIONS_ROLLING_APPLY = "ROLLING_APPLY"
@@ -37,6 +41,10 @@ class Update(object):
     #: This constant has a value of "PRECHECK"
     AVAILABLE_ACTIONS_PRECHECK = "PRECHECK"
 
+    #: A constant which can be used with the available_actions property of a Update.
+    #: This constant has a value of "ROLLBACK"
+    AVAILABLE_ACTIONS_ROLLBACK = "ROLLBACK"
+
     #: A constant which can be used with the update_type property of a Update.
     #: This constant has a value of "GI_UPGRADE"
     UPDATE_TYPE_GI_UPGRADE = "GI_UPGRADE"
@@ -44,6 +52,10 @@ class Update(object):
     #: A constant which can be used with the update_type property of a Update.
     #: This constant has a value of "GI_PATCH"
     UPDATE_TYPE_GI_PATCH = "GI_PATCH"
+
+    #: A constant which can be used with the update_type property of a Update.
+    #: This constant has a value of "OS_UPDATE"
+    UPDATE_TYPE_OS_UPDATE = "OS_UPDATE"
 
     #: A constant which can be used with the lifecycle_state property of a Update.
     #: This constant has a value of "AVAILABLE"
@@ -76,19 +88,19 @@ class Update(object):
 
         :param last_action:
             The value to assign to the last_action property of this Update.
-            Allowed values for this property are: "ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK", "ROLLBACK", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type last_action: str
 
         :param available_actions:
             The value to assign to the available_actions property of this Update.
-            Allowed values for items in this list are: "ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for items in this list are: "ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK", "ROLLBACK", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type available_actions: list[str]
 
         :param update_type:
             The value to assign to the update_type property of this Update.
-            Allowed values for this property are: "GI_UPGRADE", "GI_PATCH", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "GI_UPGRADE", "GI_PATCH", "OS_UPDATE", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type update_type: str
 
@@ -203,7 +215,7 @@ class Update(object):
         Gets the last_action of this Update.
         The update action.
 
-        Allowed values for this property are: "ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK", "ROLLBACK", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -222,7 +234,7 @@ class Update(object):
         :param last_action: The last_action of this Update.
         :type: str
         """
-        allowed_values = ["ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK"]
+        allowed_values = ["ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK", "ROLLBACK"]
         if not value_allowed_none_or_none_sentinel(last_action, allowed_values):
             last_action = 'UNKNOWN_ENUM_VALUE'
         self._last_action = last_action
@@ -233,7 +245,7 @@ class Update(object):
         Gets the available_actions of this Update.
         The possible actions performed by the update operation on the infrastructure components.
 
-        Allowed values for items in this list are: "ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for items in this list are: "ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK", "ROLLBACK", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -252,7 +264,7 @@ class Update(object):
         :param available_actions: The available_actions of this Update.
         :type: list[str]
         """
-        allowed_values = ["ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK"]
+        allowed_values = ["ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK", "ROLLBACK"]
         if available_actions:
             available_actions[:] = ['UNKNOWN_ENUM_VALUE' if not value_allowed_none_or_none_sentinel(x, allowed_values) else x for x in available_actions]
         self._available_actions = available_actions
@@ -263,7 +275,7 @@ class Update(object):
         **[Required]** Gets the update_type of this Update.
         The type of cloud VM cluster maintenance update.
 
-        Allowed values for this property are: "GI_UPGRADE", "GI_PATCH", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "GI_UPGRADE", "GI_PATCH", "OS_UPDATE", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -282,7 +294,7 @@ class Update(object):
         :param update_type: The update_type of this Update.
         :type: str
         """
-        allowed_values = ["GI_UPGRADE", "GI_PATCH"]
+        allowed_values = ["GI_UPGRADE", "GI_PATCH", "OS_UPDATE"]
         if not value_allowed_none_or_none_sentinel(update_type, allowed_values):
             update_type = 'UNKNOWN_ENUM_VALUE'
         self._update_type = update_type

--- a/src/oci/database/models/update_details.py
+++ b/src/oci/database/models/update_details.py
@@ -25,6 +25,10 @@ class UpdateDetails(object):
     #: This constant has a value of "PRECHECK"
     UPDATE_ACTION_PRECHECK = "PRECHECK"
 
+    #: A constant which can be used with the update_action property of a UpdateDetails.
+    #: This constant has a value of "ROLLBACK"
+    UPDATE_ACTION_ROLLBACK = "ROLLBACK"
+
     def __init__(self, **kwargs):
         """
         Initializes a new UpdateDetails object with values from keyword arguments.
@@ -36,7 +40,7 @@ class UpdateDetails(object):
 
         :param update_action:
             The value to assign to the update_action property of this UpdateDetails.
-            Allowed values for this property are: "ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK"
+            Allowed values for this property are: "ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK", "ROLLBACK"
         :type update_action: str
 
         """
@@ -87,7 +91,7 @@ class UpdateDetails(object):
         Gets the update_action of this UpdateDetails.
         The update action.
 
-        Allowed values for this property are: "ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK"
+        Allowed values for this property are: "ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK", "ROLLBACK"
 
 
         :return: The update_action of this UpdateDetails.
@@ -105,7 +109,7 @@ class UpdateDetails(object):
         :param update_action: The update_action of this UpdateDetails.
         :type: str
         """
-        allowed_values = ["ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK"]
+        allowed_values = ["ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK", "ROLLBACK"]
         if not value_allowed_none_or_none_sentinel(update_action, allowed_values):
             raise ValueError(
                 "Invalid value for `update_action`, must be None or one of {0}"

--- a/src/oci/database/models/update_external_container_database_details.py
+++ b/src/oci/database/models/update_external_container_database_details.py
@@ -1,0 +1,148 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateExternalContainerDatabaseDetails(object):
+    """
+    Details for updating an external container database.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateExternalContainerDatabaseDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this UpdateExternalContainerDatabaseDetails.
+        :type display_name: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this UpdateExternalContainerDatabaseDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this UpdateExternalContainerDatabaseDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._display_name = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this UpdateExternalContainerDatabaseDetails.
+        The user-friendly name for the external database. The name does not have to be unique.
+
+
+        :return: The display_name of this UpdateExternalContainerDatabaseDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this UpdateExternalContainerDatabaseDetails.
+        The user-friendly name for the external database. The name does not have to be unique.
+
+
+        :param display_name: The display_name of this UpdateExternalContainerDatabaseDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this UpdateExternalContainerDatabaseDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this UpdateExternalContainerDatabaseDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this UpdateExternalContainerDatabaseDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this UpdateExternalContainerDatabaseDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this UpdateExternalContainerDatabaseDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this UpdateExternalContainerDatabaseDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this UpdateExternalContainerDatabaseDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this UpdateExternalContainerDatabaseDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/update_external_database_connector_details.py
+++ b/src/oci/database/models/update_external_database_connector_details.py
@@ -1,0 +1,213 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateExternalDatabaseConnectorDetails(object):
+    """
+    Details for updating an external database connector.
+    """
+
+    #: A constant which can be used with the connector_type property of a UpdateExternalDatabaseConnectorDetails.
+    #: This constant has a value of "MACS"
+    CONNECTOR_TYPE_MACS = "MACS"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateExternalDatabaseConnectorDetails object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
+        to a service operations then you should favor using a subclass over the base class:
+
+        * :class:`~oci.database.models.UpdateExternalMacsConnectorDetails`
+
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this UpdateExternalDatabaseConnectorDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this UpdateExternalDatabaseConnectorDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param display_name:
+            The value to assign to the display_name property of this UpdateExternalDatabaseConnectorDetails.
+        :type display_name: str
+
+        :param connector_type:
+            The value to assign to the connector_type property of this UpdateExternalDatabaseConnectorDetails.
+            Allowed values for this property are: "MACS"
+        :type connector_type: str
+
+        """
+        self.swagger_types = {
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'display_name': 'str',
+            'connector_type': 'str'
+        }
+
+        self.attribute_map = {
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags',
+            'display_name': 'displayName',
+            'connector_type': 'connectorType'
+        }
+
+        self._freeform_tags = None
+        self._defined_tags = None
+        self._display_name = None
+        self._connector_type = None
+
+    @staticmethod
+    def get_subtype(object_dictionary):
+        """
+        Given the hash representation of a subtype of this class,
+        use the info in the hash to return the class of the subtype.
+        """
+        type = object_dictionary['connectorType']
+
+        if type == 'MACS':
+            return 'UpdateExternalMacsConnectorDetails'
+        else:
+            return 'UpdateExternalDatabaseConnectorDetails'
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this UpdateExternalDatabaseConnectorDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this UpdateExternalDatabaseConnectorDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this UpdateExternalDatabaseConnectorDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this UpdateExternalDatabaseConnectorDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this UpdateExternalDatabaseConnectorDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this UpdateExternalDatabaseConnectorDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this UpdateExternalDatabaseConnectorDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this UpdateExternalDatabaseConnectorDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this UpdateExternalDatabaseConnectorDetails.
+        The user-friendly name for the
+        :func:`create_external_database_connector_details`.
+        The name does not have to be unique.
+
+
+        :return: The display_name of this UpdateExternalDatabaseConnectorDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this UpdateExternalDatabaseConnectorDetails.
+        The user-friendly name for the
+        :func:`create_external_database_connector_details`.
+        The name does not have to be unique.
+
+
+        :param display_name: The display_name of this UpdateExternalDatabaseConnectorDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def connector_type(self):
+        """
+        Gets the connector_type of this UpdateExternalDatabaseConnectorDetails.
+        The type of connector used by the external database resource.
+
+        Allowed values for this property are: "MACS"
+
+
+        :return: The connector_type of this UpdateExternalDatabaseConnectorDetails.
+        :rtype: str
+        """
+        return self._connector_type
+
+    @connector_type.setter
+    def connector_type(self, connector_type):
+        """
+        Sets the connector_type of this UpdateExternalDatabaseConnectorDetails.
+        The type of connector used by the external database resource.
+
+
+        :param connector_type: The connector_type of this UpdateExternalDatabaseConnectorDetails.
+        :type: str
+        """
+        allowed_values = ["MACS"]
+        if not value_allowed_none_or_none_sentinel(connector_type, allowed_values):
+            raise ValueError(
+                "Invalid value for `connector_type`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._connector_type = connector_type
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/update_external_database_details_base.py
+++ b/src/oci/database/models/update_external_database_details_base.py
@@ -1,0 +1,148 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateExternalDatabaseDetailsBase(object):
+    """
+    Details for updating an external database.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateExternalDatabaseDetailsBase object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this UpdateExternalDatabaseDetailsBase.
+        :type display_name: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this UpdateExternalDatabaseDetailsBase.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this UpdateExternalDatabaseDetailsBase.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._display_name = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this UpdateExternalDatabaseDetailsBase.
+        The user-friendly name for the external database. The name does not have to be unique.
+
+
+        :return: The display_name of this UpdateExternalDatabaseDetailsBase.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this UpdateExternalDatabaseDetailsBase.
+        The user-friendly name for the external database. The name does not have to be unique.
+
+
+        :param display_name: The display_name of this UpdateExternalDatabaseDetailsBase.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this UpdateExternalDatabaseDetailsBase.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this UpdateExternalDatabaseDetailsBase.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this UpdateExternalDatabaseDetailsBase.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this UpdateExternalDatabaseDetailsBase.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this UpdateExternalDatabaseDetailsBase.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this UpdateExternalDatabaseDetailsBase.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this UpdateExternalDatabaseDetailsBase.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this UpdateExternalDatabaseDetailsBase.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/update_external_macs_connector_details.py
+++ b/src/oci/database/models/update_external_macs_connector_details.py
@@ -1,0 +1,126 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .update_external_database_connector_details import UpdateExternalDatabaseConnectorDetails
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateExternalMacsConnectorDetails(UpdateExternalDatabaseConnectorDetails):
+    """
+    Details for updating an external `Management Agent cloud service (MACS)`__ database connection.
+
+    __ https://docs.cloud.oracle.com/iaas/management-agents/index.html
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateExternalMacsConnectorDetails object with values from keyword arguments. The default value of the :py:attr:`~oci.database.models.UpdateExternalMacsConnectorDetails.connector_type` attribute
+        of this class is ``MACS`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this UpdateExternalMacsConnectorDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this UpdateExternalMacsConnectorDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param display_name:
+            The value to assign to the display_name property of this UpdateExternalMacsConnectorDetails.
+        :type display_name: str
+
+        :param connector_type:
+            The value to assign to the connector_type property of this UpdateExternalMacsConnectorDetails.
+            Allowed values for this property are: "MACS"
+        :type connector_type: str
+
+        :param connection_string:
+            The value to assign to the connection_string property of this UpdateExternalMacsConnectorDetails.
+        :type connection_string: oci.database.models.DatabaseConnectionString
+
+        :param connection_credentials:
+            The value to assign to the connection_credentials property of this UpdateExternalMacsConnectorDetails.
+        :type connection_credentials: oci.database.models.DatabaseConnectionCredentials
+
+        """
+        self.swagger_types = {
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'display_name': 'str',
+            'connector_type': 'str',
+            'connection_string': 'DatabaseConnectionString',
+            'connection_credentials': 'DatabaseConnectionCredentials'
+        }
+
+        self.attribute_map = {
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags',
+            'display_name': 'displayName',
+            'connector_type': 'connectorType',
+            'connection_string': 'connectionString',
+            'connection_credentials': 'connectionCredentials'
+        }
+
+        self._freeform_tags = None
+        self._defined_tags = None
+        self._display_name = None
+        self._connector_type = None
+        self._connection_string = None
+        self._connection_credentials = None
+        self._connector_type = 'MACS'
+
+    @property
+    def connection_string(self):
+        """
+        Gets the connection_string of this UpdateExternalMacsConnectorDetails.
+
+        :return: The connection_string of this UpdateExternalMacsConnectorDetails.
+        :rtype: oci.database.models.DatabaseConnectionString
+        """
+        return self._connection_string
+
+    @connection_string.setter
+    def connection_string(self, connection_string):
+        """
+        Sets the connection_string of this UpdateExternalMacsConnectorDetails.
+
+        :param connection_string: The connection_string of this UpdateExternalMacsConnectorDetails.
+        :type: oci.database.models.DatabaseConnectionString
+        """
+        self._connection_string = connection_string
+
+    @property
+    def connection_credentials(self):
+        """
+        Gets the connection_credentials of this UpdateExternalMacsConnectorDetails.
+
+        :return: The connection_credentials of this UpdateExternalMacsConnectorDetails.
+        :rtype: oci.database.models.DatabaseConnectionCredentials
+        """
+        return self._connection_credentials
+
+    @connection_credentials.setter
+    def connection_credentials(self, connection_credentials):
+        """
+        Sets the connection_credentials of this UpdateExternalMacsConnectorDetails.
+
+        :param connection_credentials: The connection_credentials of this UpdateExternalMacsConnectorDetails.
+        :type: oci.database.models.DatabaseConnectionCredentials
+        """
+        self._connection_credentials = connection_credentials
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/update_external_non_container_database_details.py
+++ b/src/oci/database/models/update_external_non_container_database_details.py
@@ -1,0 +1,148 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateExternalNonContainerDatabaseDetails(object):
+    """
+    Details for updating an external non-container database.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateExternalNonContainerDatabaseDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this UpdateExternalNonContainerDatabaseDetails.
+        :type display_name: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this UpdateExternalNonContainerDatabaseDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this UpdateExternalNonContainerDatabaseDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._display_name = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this UpdateExternalNonContainerDatabaseDetails.
+        The user-friendly name for the external database. The name does not have to be unique.
+
+
+        :return: The display_name of this UpdateExternalNonContainerDatabaseDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this UpdateExternalNonContainerDatabaseDetails.
+        The user-friendly name for the external database. The name does not have to be unique.
+
+
+        :param display_name: The display_name of this UpdateExternalNonContainerDatabaseDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this UpdateExternalNonContainerDatabaseDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this UpdateExternalNonContainerDatabaseDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this UpdateExternalNonContainerDatabaseDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this UpdateExternalNonContainerDatabaseDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this UpdateExternalNonContainerDatabaseDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this UpdateExternalNonContainerDatabaseDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this UpdateExternalNonContainerDatabaseDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this UpdateExternalNonContainerDatabaseDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/update_external_pluggable_database_details.py
+++ b/src/oci/database/models/update_external_pluggable_database_details.py
@@ -1,0 +1,148 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateExternalPluggableDatabaseDetails(object):
+    """
+    Details for updating an external pluggable database.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateExternalPluggableDatabaseDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this UpdateExternalPluggableDatabaseDetails.
+        :type display_name: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this UpdateExternalPluggableDatabaseDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this UpdateExternalPluggableDatabaseDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._display_name = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this UpdateExternalPluggableDatabaseDetails.
+        The user-friendly name for the external database. The name does not have to be unique.
+
+
+        :return: The display_name of this UpdateExternalPluggableDatabaseDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this UpdateExternalPluggableDatabaseDetails.
+        The user-friendly name for the external database. The name does not have to be unique.
+
+
+        :param display_name: The display_name of this UpdateExternalPluggableDatabaseDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this UpdateExternalPluggableDatabaseDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this UpdateExternalPluggableDatabaseDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this UpdateExternalPluggableDatabaseDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this UpdateExternalPluggableDatabaseDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this UpdateExternalPluggableDatabaseDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this UpdateExternalPluggableDatabaseDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this UpdateExternalPluggableDatabaseDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this UpdateExternalPluggableDatabaseDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/update_history_entry.py
+++ b/src/oci/database/models/update_history_entry.py
@@ -25,6 +25,10 @@ class UpdateHistoryEntry(object):
     #: This constant has a value of "PRECHECK"
     UPDATE_ACTION_PRECHECK = "PRECHECK"
 
+    #: A constant which can be used with the update_action property of a UpdateHistoryEntry.
+    #: This constant has a value of "ROLLBACK"
+    UPDATE_ACTION_ROLLBACK = "ROLLBACK"
+
     #: A constant which can be used with the update_type property of a UpdateHistoryEntry.
     #: This constant has a value of "GI_UPGRADE"
     UPDATE_TYPE_GI_UPGRADE = "GI_UPGRADE"
@@ -32,6 +36,10 @@ class UpdateHistoryEntry(object):
     #: A constant which can be used with the update_type property of a UpdateHistoryEntry.
     #: This constant has a value of "GI_PATCH"
     UPDATE_TYPE_GI_PATCH = "GI_PATCH"
+
+    #: A constant which can be used with the update_type property of a UpdateHistoryEntry.
+    #: This constant has a value of "OS_UPDATE"
+    UPDATE_TYPE_OS_UPDATE = "OS_UPDATE"
 
     #: A constant which can be used with the lifecycle_state property of a UpdateHistoryEntry.
     #: This constant has a value of "IN_PROGRESS"
@@ -60,13 +68,13 @@ class UpdateHistoryEntry(object):
 
         :param update_action:
             The value to assign to the update_action property of this UpdateHistoryEntry.
-            Allowed values for this property are: "ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK", "ROLLBACK", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type update_action: str
 
         :param update_type:
             The value to assign to the update_type property of this UpdateHistoryEntry.
-            Allowed values for this property are: "GI_UPGRADE", "GI_PATCH", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "GI_UPGRADE", "GI_PATCH", "OS_UPDATE", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type update_type: str
 
@@ -182,7 +190,7 @@ class UpdateHistoryEntry(object):
         Gets the update_action of this UpdateHistoryEntry.
         The update action.
 
-        Allowed values for this property are: "ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK", "ROLLBACK", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -201,7 +209,7 @@ class UpdateHistoryEntry(object):
         :param update_action: The update_action of this UpdateHistoryEntry.
         :type: str
         """
-        allowed_values = ["ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK"]
+        allowed_values = ["ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK", "ROLLBACK"]
         if not value_allowed_none_or_none_sentinel(update_action, allowed_values):
             update_action = 'UNKNOWN_ENUM_VALUE'
         self._update_action = update_action
@@ -212,7 +220,7 @@ class UpdateHistoryEntry(object):
         **[Required]** Gets the update_type of this UpdateHistoryEntry.
         The type of cloud VM cluster maintenance update.
 
-        Allowed values for this property are: "GI_UPGRADE", "GI_PATCH", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "GI_UPGRADE", "GI_PATCH", "OS_UPDATE", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -231,7 +239,7 @@ class UpdateHistoryEntry(object):
         :param update_type: The update_type of this UpdateHistoryEntry.
         :type: str
         """
-        allowed_values = ["GI_UPGRADE", "GI_PATCH"]
+        allowed_values = ["GI_UPGRADE", "GI_PATCH", "OS_UPDATE"]
         if not value_allowed_none_or_none_sentinel(update_type, allowed_values):
             update_type = 'UNKNOWN_ENUM_VALUE'
         self._update_type = update_type

--- a/src/oci/database/models/update_history_entry_summary.py
+++ b/src/oci/database/models/update_history_entry_summary.py
@@ -25,6 +25,10 @@ class UpdateHistoryEntrySummary(object):
     #: This constant has a value of "PRECHECK"
     UPDATE_ACTION_PRECHECK = "PRECHECK"
 
+    #: A constant which can be used with the update_action property of a UpdateHistoryEntrySummary.
+    #: This constant has a value of "ROLLBACK"
+    UPDATE_ACTION_ROLLBACK = "ROLLBACK"
+
     #: A constant which can be used with the update_type property of a UpdateHistoryEntrySummary.
     #: This constant has a value of "GI_UPGRADE"
     UPDATE_TYPE_GI_UPGRADE = "GI_UPGRADE"
@@ -32,6 +36,10 @@ class UpdateHistoryEntrySummary(object):
     #: A constant which can be used with the update_type property of a UpdateHistoryEntrySummary.
     #: This constant has a value of "GI_PATCH"
     UPDATE_TYPE_GI_PATCH = "GI_PATCH"
+
+    #: A constant which can be used with the update_type property of a UpdateHistoryEntrySummary.
+    #: This constant has a value of "OS_UPDATE"
+    UPDATE_TYPE_OS_UPDATE = "OS_UPDATE"
 
     #: A constant which can be used with the lifecycle_state property of a UpdateHistoryEntrySummary.
     #: This constant has a value of "IN_PROGRESS"
@@ -60,13 +68,13 @@ class UpdateHistoryEntrySummary(object):
 
         :param update_action:
             The value to assign to the update_action property of this UpdateHistoryEntrySummary.
-            Allowed values for this property are: "ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK", "ROLLBACK", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type update_action: str
 
         :param update_type:
             The value to assign to the update_type property of this UpdateHistoryEntrySummary.
-            Allowed values for this property are: "GI_UPGRADE", "GI_PATCH", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "GI_UPGRADE", "GI_PATCH", "OS_UPDATE", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type update_type: str
 
@@ -182,7 +190,7 @@ class UpdateHistoryEntrySummary(object):
         Gets the update_action of this UpdateHistoryEntrySummary.
         The update action.
 
-        Allowed values for this property are: "ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK", "ROLLBACK", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -201,7 +209,7 @@ class UpdateHistoryEntrySummary(object):
         :param update_action: The update_action of this UpdateHistoryEntrySummary.
         :type: str
         """
-        allowed_values = ["ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK"]
+        allowed_values = ["ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK", "ROLLBACK"]
         if not value_allowed_none_or_none_sentinel(update_action, allowed_values):
             update_action = 'UNKNOWN_ENUM_VALUE'
         self._update_action = update_action
@@ -212,7 +220,7 @@ class UpdateHistoryEntrySummary(object):
         **[Required]** Gets the update_type of this UpdateHistoryEntrySummary.
         The type of cloud VM cluster maintenance update.
 
-        Allowed values for this property are: "GI_UPGRADE", "GI_PATCH", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "GI_UPGRADE", "GI_PATCH", "OS_UPDATE", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -231,7 +239,7 @@ class UpdateHistoryEntrySummary(object):
         :param update_type: The update_type of this UpdateHistoryEntrySummary.
         :type: str
         """
-        allowed_values = ["GI_UPGRADE", "GI_PATCH"]
+        allowed_values = ["GI_UPGRADE", "GI_PATCH", "OS_UPDATE"]
         if not value_allowed_none_or_none_sentinel(update_type, allowed_values):
             update_type = 'UNKNOWN_ENUM_VALUE'
         self._update_type = update_type

--- a/src/oci/database/models/update_summary.py
+++ b/src/oci/database/models/update_summary.py
@@ -31,6 +31,10 @@ class UpdateSummary(object):
     #: This constant has a value of "PRECHECK"
     LAST_ACTION_PRECHECK = "PRECHECK"
 
+    #: A constant which can be used with the last_action property of a UpdateSummary.
+    #: This constant has a value of "ROLLBACK"
+    LAST_ACTION_ROLLBACK = "ROLLBACK"
+
     #: A constant which can be used with the available_actions property of a UpdateSummary.
     #: This constant has a value of "ROLLING_APPLY"
     AVAILABLE_ACTIONS_ROLLING_APPLY = "ROLLING_APPLY"
@@ -43,6 +47,10 @@ class UpdateSummary(object):
     #: This constant has a value of "PRECHECK"
     AVAILABLE_ACTIONS_PRECHECK = "PRECHECK"
 
+    #: A constant which can be used with the available_actions property of a UpdateSummary.
+    #: This constant has a value of "ROLLBACK"
+    AVAILABLE_ACTIONS_ROLLBACK = "ROLLBACK"
+
     #: A constant which can be used with the update_type property of a UpdateSummary.
     #: This constant has a value of "GI_UPGRADE"
     UPDATE_TYPE_GI_UPGRADE = "GI_UPGRADE"
@@ -50,6 +58,10 @@ class UpdateSummary(object):
     #: A constant which can be used with the update_type property of a UpdateSummary.
     #: This constant has a value of "GI_PATCH"
     UPDATE_TYPE_GI_PATCH = "GI_PATCH"
+
+    #: A constant which can be used with the update_type property of a UpdateSummary.
+    #: This constant has a value of "OS_UPDATE"
+    UPDATE_TYPE_OS_UPDATE = "OS_UPDATE"
 
     #: A constant which can be used with the lifecycle_state property of a UpdateSummary.
     #: This constant has a value of "AVAILABLE"
@@ -82,19 +94,19 @@ class UpdateSummary(object):
 
         :param last_action:
             The value to assign to the last_action property of this UpdateSummary.
-            Allowed values for this property are: "ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK", "ROLLBACK", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type last_action: str
 
         :param available_actions:
             The value to assign to the available_actions property of this UpdateSummary.
-            Allowed values for items in this list are: "ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for items in this list are: "ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK", "ROLLBACK", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type available_actions: list[str]
 
         :param update_type:
             The value to assign to the update_type property of this UpdateSummary.
-            Allowed values for this property are: "GI_UPGRADE", "GI_PATCH", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "GI_UPGRADE", "GI_PATCH", "OS_UPDATE", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type update_type: str
 
@@ -209,7 +221,7 @@ class UpdateSummary(object):
         Gets the last_action of this UpdateSummary.
         The update action.
 
-        Allowed values for this property are: "ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK", "ROLLBACK", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -228,7 +240,7 @@ class UpdateSummary(object):
         :param last_action: The last_action of this UpdateSummary.
         :type: str
         """
-        allowed_values = ["ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK"]
+        allowed_values = ["ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK", "ROLLBACK"]
         if not value_allowed_none_or_none_sentinel(last_action, allowed_values):
             last_action = 'UNKNOWN_ENUM_VALUE'
         self._last_action = last_action
@@ -239,7 +251,7 @@ class UpdateSummary(object):
         Gets the available_actions of this UpdateSummary.
         The possible actions performed by the update operation on the infrastructure components.
 
-        Allowed values for items in this list are: "ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for items in this list are: "ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK", "ROLLBACK", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -258,7 +270,7 @@ class UpdateSummary(object):
         :param available_actions: The available_actions of this UpdateSummary.
         :type: list[str]
         """
-        allowed_values = ["ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK"]
+        allowed_values = ["ROLLING_APPLY", "NON_ROLLING_APPLY", "PRECHECK", "ROLLBACK"]
         if available_actions:
             available_actions[:] = ['UNKNOWN_ENUM_VALUE' if not value_allowed_none_or_none_sentinel(x, allowed_values) else x for x in available_actions]
         self._available_actions = available_actions
@@ -269,7 +281,7 @@ class UpdateSummary(object):
         **[Required]** Gets the update_type of this UpdateSummary.
         The type of cloud VM cluster maintenance update.
 
-        Allowed values for this property are: "GI_UPGRADE", "GI_PATCH", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "GI_UPGRADE", "GI_PATCH", "OS_UPDATE", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -288,7 +300,7 @@ class UpdateSummary(object):
         :param update_type: The update_type of this UpdateSummary.
         :type: str
         """
-        allowed_values = ["GI_UPGRADE", "GI_PATCH"]
+        allowed_values = ["GI_UPGRADE", "GI_PATCH", "OS_UPDATE"]
         if not value_allowed_none_or_none_sentinel(update_type, allowed_values):
             update_type = 'UNKNOWN_ENUM_VALUE'
         self._update_type = update_type

--- a/src/oci/object_storage/models/__init__.py
+++ b/src/oci/object_storage/models/__init__.py
@@ -42,6 +42,7 @@ from .retention_rule_summary import RetentionRuleSummary
 from .sse_customer_key_details import SSECustomerKeyDetails
 from .update_bucket_details import UpdateBucketDetails
 from .update_namespace_metadata_details import UpdateNamespaceMetadataDetails
+from .update_object_storage_tier_details import UpdateObjectStorageTierDetails
 from .update_retention_rule_details import UpdateRetentionRuleDetails
 from .work_request import WorkRequest
 from .work_request_error import WorkRequestError
@@ -89,6 +90,7 @@ object_storage_type_mapping = {
     "SSECustomerKeyDetails": SSECustomerKeyDetails,
     "UpdateBucketDetails": UpdateBucketDetails,
     "UpdateNamespaceMetadataDetails": UpdateNamespaceMetadataDetails,
+    "UpdateObjectStorageTierDetails": UpdateObjectStorageTierDetails,
     "UpdateRetentionRuleDetails": UpdateRetentionRuleDetails,
     "WorkRequest": WorkRequest,
     "WorkRequestError": WorkRequestError,

--- a/src/oci/object_storage/models/bucket.py
+++ b/src/oci/object_storage/models/bucket.py
@@ -217,7 +217,7 @@ class Bucket(object):
     def namespace(self):
         """
         **[Required]** Gets the namespace of this Bucket.
-        The Object Storage namespace in which the bucket lives.
+        The Object Storage namespace in which the bucket resides.
 
 
         :return: The namespace of this Bucket.
@@ -229,7 +229,7 @@ class Bucket(object):
     def namespace(self, namespace):
         """
         Sets the namespace of this Bucket.
-        The Object Storage namespace in which the bucket lives.
+        The Object Storage namespace in which the bucket resides.
 
 
         :param namespace: The namespace of this Bucket.
@@ -433,10 +433,10 @@ class Bucket(object):
     def storage_tier(self):
         """
         Gets the storage_tier of this Bucket.
-        The storage tier type assigned to the bucket. A bucket is set to 'Standard' tier by default, which means
-        objects uploaded or copied to the bucket will be in the standard storage tier. When the 'Archive' tier type
+        The storage tier type assigned to the bucket. A bucket is set to `Standard` tier by default, which means
+        objects uploaded or copied to the bucket will be in the standard storage tier. When the `Archive` tier type
         is set explicitly for a bucket, objects uploaded or copied to the bucket will be stored in archive storage.
-        The 'storageTier' property is immutable after bucket is created.
+        The `storageTier` property is immutable after bucket is created.
 
         Allowed values for this property are: "Standard", "Archive", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -451,10 +451,10 @@ class Bucket(object):
     def storage_tier(self, storage_tier):
         """
         Sets the storage_tier of this Bucket.
-        The storage tier type assigned to the bucket. A bucket is set to 'Standard' tier by default, which means
-        objects uploaded or copied to the bucket will be in the standard storage tier. When the 'Archive' tier type
+        The storage tier type assigned to the bucket. A bucket is set to `Standard` tier by default, which means
+        objects uploaded or copied to the bucket will be in the standard storage tier. When the `Archive` tier type
         is set explicitly for a bucket, objects uploaded or copied to the bucket will be stored in archive storage.
-        The 'storageTier' property is immutable after bucket is created.
+        The `storageTier` property is immutable after bucket is created.
 
 
         :param storage_tier: The storage_tier of this Bucket.

--- a/src/oci/object_storage/models/copy_object_details.py
+++ b/src/oci/object_storage/models/copy_object_details.py
@@ -19,6 +19,18 @@ class CopyObjectDetails(object):
     __ https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm
     """
 
+    #: A constant which can be used with the destination_object_storage_tier property of a CopyObjectDetails.
+    #: This constant has a value of "Standard"
+    DESTINATION_OBJECT_STORAGE_TIER_STANDARD = "Standard"
+
+    #: A constant which can be used with the destination_object_storage_tier property of a CopyObjectDetails.
+    #: This constant has a value of "InfrequentAccess"
+    DESTINATION_OBJECT_STORAGE_TIER_INFREQUENT_ACCESS = "InfrequentAccess"
+
+    #: A constant which can be used with the destination_object_storage_tier property of a CopyObjectDetails.
+    #: This constant has a value of "Archive"
+    DESTINATION_OBJECT_STORAGE_TIER_ARCHIVE = "Archive"
+
     def __init__(self, **kwargs):
         """
         Initializes a new CopyObjectDetails object with values from keyword arguments.
@@ -64,6 +76,11 @@ class CopyObjectDetails(object):
             The value to assign to the destination_object_metadata property of this CopyObjectDetails.
         :type destination_object_metadata: dict(str, str)
 
+        :param destination_object_storage_tier:
+            The value to assign to the destination_object_storage_tier property of this CopyObjectDetails.
+            Allowed values for this property are: "Standard", "InfrequentAccess", "Archive"
+        :type destination_object_storage_tier: str
+
         """
         self.swagger_types = {
             'source_object_name': 'str',
@@ -75,7 +92,8 @@ class CopyObjectDetails(object):
             'destination_object_name': 'str',
             'destination_object_if_match_e_tag': 'str',
             'destination_object_if_none_match_e_tag': 'str',
-            'destination_object_metadata': 'dict(str, str)'
+            'destination_object_metadata': 'dict(str, str)',
+            'destination_object_storage_tier': 'str'
         }
 
         self.attribute_map = {
@@ -88,7 +106,8 @@ class CopyObjectDetails(object):
             'destination_object_name': 'destinationObjectName',
             'destination_object_if_match_e_tag': 'destinationObjectIfMatchETag',
             'destination_object_if_none_match_e_tag': 'destinationObjectIfNoneMatchETag',
-            'destination_object_metadata': 'destinationObjectMetadata'
+            'destination_object_metadata': 'destinationObjectMetadata',
+            'destination_object_storage_tier': 'destinationObjectStorageTier'
         }
 
         self._source_object_name = None
@@ -101,6 +120,7 @@ class CopyObjectDetails(object):
         self._destination_object_if_match_e_tag = None
         self._destination_object_if_none_match_e_tag = None
         self._destination_object_metadata = None
+        self._destination_object_storage_tier = None
 
     @property
     def source_object_name(self):
@@ -252,7 +272,7 @@ class CopyObjectDetails(object):
     def destination_object_name(self):
         """
         **[Required]** Gets the destination_object_name of this CopyObjectDetails.
-        The name of the destination object resulting from the copy operation.
+        The name of the destination object resulting from the copy operation. Avoid entering confidential information.
 
 
         :return: The destination_object_name of this CopyObjectDetails.
@@ -264,7 +284,7 @@ class CopyObjectDetails(object):
     def destination_object_name(self, destination_object_name):
         """
         Sets the destination_object_name of this CopyObjectDetails.
-        The name of the destination object resulting from the copy operation.
+        The name of the destination object resulting from the copy operation. Avoid entering confidential information.
 
 
         :param destination_object_name: The destination_object_name of this CopyObjectDetails.
@@ -355,6 +375,40 @@ class CopyObjectDetails(object):
         :type: dict(str, str)
         """
         self._destination_object_metadata = destination_object_metadata
+
+    @property
+    def destination_object_storage_tier(self):
+        """
+        Gets the destination_object_storage_tier of this CopyObjectDetails.
+        The storage tier that the object should be stored in. If not specified, the object will be stored in
+        the same storage tier as the bucket.
+
+        Allowed values for this property are: "Standard", "InfrequentAccess", "Archive"
+
+
+        :return: The destination_object_storage_tier of this CopyObjectDetails.
+        :rtype: str
+        """
+        return self._destination_object_storage_tier
+
+    @destination_object_storage_tier.setter
+    def destination_object_storage_tier(self, destination_object_storage_tier):
+        """
+        Sets the destination_object_storage_tier of this CopyObjectDetails.
+        The storage tier that the object should be stored in. If not specified, the object will be stored in
+        the same storage tier as the bucket.
+
+
+        :param destination_object_storage_tier: The destination_object_storage_tier of this CopyObjectDetails.
+        :type: str
+        """
+        allowed_values = ["Standard", "InfrequentAccess", "Archive"]
+        if not value_allowed_none_or_none_sentinel(destination_object_storage_tier, allowed_values):
+            raise ValueError(
+                "Invalid value for `destination_object_storage_tier`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._destination_object_storage_tier = destination_object_storage_tier
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/object_storage/models/create_multipart_upload_details.py
+++ b/src/oci/object_storage/models/create_multipart_upload_details.py
@@ -17,6 +17,18 @@ class CreateMultipartUploadDetails(object):
     __ https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm
     """
 
+    #: A constant which can be used with the storage_tier property of a CreateMultipartUploadDetails.
+    #: This constant has a value of "Standard"
+    STORAGE_TIER_STANDARD = "Standard"
+
+    #: A constant which can be used with the storage_tier property of a CreateMultipartUploadDetails.
+    #: This constant has a value of "InfrequentAccess"
+    STORAGE_TIER_INFREQUENT_ACCESS = "InfrequentAccess"
+
+    #: A constant which can be used with the storage_tier property of a CreateMultipartUploadDetails.
+    #: This constant has a value of "Archive"
+    STORAGE_TIER_ARCHIVE = "Archive"
+
     def __init__(self, **kwargs):
         """
         Initializes a new CreateMultipartUploadDetails object with values from keyword arguments.
@@ -46,6 +58,11 @@ class CreateMultipartUploadDetails(object):
             The value to assign to the cache_control property of this CreateMultipartUploadDetails.
         :type cache_control: str
 
+        :param storage_tier:
+            The value to assign to the storage_tier property of this CreateMultipartUploadDetails.
+            Allowed values for this property are: "Standard", "InfrequentAccess", "Archive"
+        :type storage_tier: str
+
         :param metadata:
             The value to assign to the metadata property of this CreateMultipartUploadDetails.
         :type metadata: dict(str, str)
@@ -58,6 +75,7 @@ class CreateMultipartUploadDetails(object):
             'content_encoding': 'str',
             'content_disposition': 'str',
             'cache_control': 'str',
+            'storage_tier': 'str',
             'metadata': 'dict(str, str)'
         }
 
@@ -68,6 +86,7 @@ class CreateMultipartUploadDetails(object):
             'content_encoding': 'contentEncoding',
             'content_disposition': 'contentDisposition',
             'cache_control': 'cacheControl',
+            'storage_tier': 'storageTier',
             'metadata': 'metadata'
         }
 
@@ -77,6 +96,7 @@ class CreateMultipartUploadDetails(object):
         self._content_encoding = None
         self._content_disposition = None
         self._cache_control = None
+        self._storage_tier = None
         self._metadata = None
 
     @property
@@ -256,6 +276,40 @@ class CreateMultipartUploadDetails(object):
         :type: str
         """
         self._cache_control = cache_control
+
+    @property
+    def storage_tier(self):
+        """
+        Gets the storage_tier of this CreateMultipartUploadDetails.
+        The storage tier that the object should be stored in. If not specified, the object will be stored in
+        the same storage tier as the bucket.
+
+        Allowed values for this property are: "Standard", "InfrequentAccess", "Archive"
+
+
+        :return: The storage_tier of this CreateMultipartUploadDetails.
+        :rtype: str
+        """
+        return self._storage_tier
+
+    @storage_tier.setter
+    def storage_tier(self, storage_tier):
+        """
+        Sets the storage_tier of this CreateMultipartUploadDetails.
+        The storage tier that the object should be stored in. If not specified, the object will be stored in
+        the same storage tier as the bucket.
+
+
+        :param storage_tier: The storage_tier of this CreateMultipartUploadDetails.
+        :type: str
+        """
+        allowed_values = ["Standard", "InfrequentAccess", "Archive"]
+        if not value_allowed_none_or_none_sentinel(storage_tier, allowed_values):
+            raise ValueError(
+                "Invalid value for `storage_tier`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._storage_tier = storage_tier
 
     @property
     def metadata(self):

--- a/src/oci/object_storage/models/create_preauthenticated_request_details.py
+++ b/src/oci/object_storage/models/create_preauthenticated_request_details.py
@@ -76,6 +76,7 @@ class CreatePreauthenticatedRequestDetails(object):
         """
         **[Required]** Gets the name of this CreatePreauthenticatedRequestDetails.
         A user-specified name for the pre-authenticated request. Names can be helpful in managing pre-authenticated requests.
+        Avoid entering confidential information.
 
 
         :return: The name of this CreatePreauthenticatedRequestDetails.
@@ -88,6 +89,7 @@ class CreatePreauthenticatedRequestDetails(object):
         """
         Sets the name of this CreatePreauthenticatedRequestDetails.
         A user-specified name for the pre-authenticated request. Names can be helpful in managing pre-authenticated requests.
+        Avoid entering confidential information.
 
 
         :param name: The name of this CreatePreauthenticatedRequestDetails.

--- a/src/oci/object_storage/models/create_replication_policy_details.py
+++ b/src/oci/object_storage/models/create_replication_policy_details.py
@@ -51,7 +51,7 @@ class CreateReplicationPolicyDetails(object):
     def name(self):
         """
         **[Required]** Gets the name of this CreateReplicationPolicyDetails.
-        The name of the policy.
+        The name of the policy. Avoid entering confidential information.
 
 
         :return: The name of this CreateReplicationPolicyDetails.
@@ -63,7 +63,7 @@ class CreateReplicationPolicyDetails(object):
     def name(self, name):
         """
         Sets the name of this CreateReplicationPolicyDetails.
-        The name of the policy.
+        The name of the policy. Avoid entering confidential information.
 
 
         :param name: The name of this CreateReplicationPolicyDetails.

--- a/src/oci/object_storage/models/create_retention_rule_details.py
+++ b/src/oci/object_storage/models/create_retention_rule_details.py
@@ -52,6 +52,7 @@ class CreateRetentionRuleDetails(object):
         """
         Gets the display_name of this CreateRetentionRuleDetails.
         A user-specified name for the retention rule. Names can be helpful in identifying retention rules.
+        Avoid entering confidential information.
 
 
         :return: The display_name of this CreateRetentionRuleDetails.
@@ -64,6 +65,7 @@ class CreateRetentionRuleDetails(object):
         """
         Sets the display_name of this CreateRetentionRuleDetails.
         A user-specified name for the retention rule. Names can be helpful in identifying retention rules.
+        Avoid entering confidential information.
 
 
         :param display_name: The display_name of this CreateRetentionRuleDetails.

--- a/src/oci/object_storage/models/list_objects.py
+++ b/src/oci/object_storage/models/list_objects.py
@@ -103,7 +103,7 @@ class ListObjects(object):
     def next_start_with(self):
         """
         Gets the next_start_with of this ListObjects.
-        The name of the object to use in the 'start' parameter to obtain the next page of
+        The name of the object to use in the `start` parameter to obtain the next page of
         a truncated ListObjects response. Avoid entering confidential information.
         Example: test/object1.log
 
@@ -117,7 +117,7 @@ class ListObjects(object):
     def next_start_with(self, next_start_with):
         """
         Sets the next_start_with of this ListObjects.
-        The name of the object to use in the 'start' parameter to obtain the next page of
+        The name of the object to use in the `start` parameter to obtain the next page of
         a truncated ListObjects response. Avoid entering confidential information.
         Example: test/object1.log
 

--- a/src/oci/object_storage/models/multipart_upload.py
+++ b/src/oci/object_storage/models/multipart_upload.py
@@ -24,6 +24,18 @@ class MultipartUpload(object):
     __ https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm
     """
 
+    #: A constant which can be used with the storage_tier property of a MultipartUpload.
+    #: This constant has a value of "Standard"
+    STORAGE_TIER_STANDARD = "Standard"
+
+    #: A constant which can be used with the storage_tier property of a MultipartUpload.
+    #: This constant has a value of "InfrequentAccess"
+    STORAGE_TIER_INFREQUENT_ACCESS = "InfrequentAccess"
+
+    #: A constant which can be used with the storage_tier property of a MultipartUpload.
+    #: This constant has a value of "Archive"
+    STORAGE_TIER_ARCHIVE = "Archive"
+
     def __init__(self, **kwargs):
         """
         Initializes a new MultipartUpload object with values from keyword arguments.
@@ -49,13 +61,20 @@ class MultipartUpload(object):
             The value to assign to the time_created property of this MultipartUpload.
         :type time_created: datetime
 
+        :param storage_tier:
+            The value to assign to the storage_tier property of this MultipartUpload.
+            Allowed values for this property are: "Standard", "InfrequentAccess", "Archive", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type storage_tier: str
+
         """
         self.swagger_types = {
             'namespace': 'str',
             'bucket': 'str',
             'object': 'str',
             'upload_id': 'str',
-            'time_created': 'datetime'
+            'time_created': 'datetime',
+            'storage_tier': 'str'
         }
 
         self.attribute_map = {
@@ -63,7 +82,8 @@ class MultipartUpload(object):
             'bucket': 'bucket',
             'object': 'object',
             'upload_id': 'uploadId',
-            'time_created': 'timeCreated'
+            'time_created': 'timeCreated',
+            'storage_tier': 'storageTier'
         }
 
         self._namespace = None
@@ -71,6 +91,7 @@ class MultipartUpload(object):
         self._object = None
         self._upload_id = None
         self._time_created = None
+        self._storage_tier = None
 
     @property
     def namespace(self):
@@ -195,6 +216,36 @@ class MultipartUpload(object):
         :type: datetime
         """
         self._time_created = time_created
+
+    @property
+    def storage_tier(self):
+        """
+        Gets the storage_tier of this MultipartUpload.
+        The storage tier that the object is stored in.
+
+        Allowed values for this property are: "Standard", "InfrequentAccess", "Archive", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The storage_tier of this MultipartUpload.
+        :rtype: str
+        """
+        return self._storage_tier
+
+    @storage_tier.setter
+    def storage_tier(self, storage_tier):
+        """
+        Sets the storage_tier of this MultipartUpload.
+        The storage tier that the object is stored in.
+
+
+        :param storage_tier: The storage_tier of this MultipartUpload.
+        :type: str
+        """
+        allowed_values = ["Standard", "InfrequentAccess", "Archive"]
+        if not value_allowed_none_or_none_sentinel(storage_tier, allowed_values):
+            storage_tier = 'UNKNOWN_ENUM_VALUE'
+        self._storage_tier = storage_tier
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/object_storage/models/object_lifecycle_rule.py
+++ b/src/oci/object_storage/models/object_lifecycle_rule.py
@@ -119,9 +119,10 @@ class ObjectLifecycleRule(object):
         Gets the target of this ObjectLifecycleRule.
         The target of the object lifecycle policy rule. The values of target can be either \"objects\",
         \"multipart-uploads\" or \"previous-object-versions\".
-        This field when declared as \"objects\" is used to specify ARCHIVE or DELETE rule for objects.
-        This field when declared as \"previous-object-versions\" is used to specify ARCHIVE or DELETE
-        rule for previous versions of existing objects.
+        This field when declared as \"objects\" is used to specify ARCHIVE, INFREQUENT_ACCESS
+        or DELETE rule for objects.
+        This field when declared as \"previous-object-versions\" is used to specify ARCHIVE,
+        INFREQUENT_ACCESS or DELETE rule for previous versions of existing objects.
         This field when declared as \"multipart-uploads\" is used to specify the ABORT (only) rule for
         uncommitted multipart-uploads.
 
@@ -137,9 +138,10 @@ class ObjectLifecycleRule(object):
         Sets the target of this ObjectLifecycleRule.
         The target of the object lifecycle policy rule. The values of target can be either \"objects\",
         \"multipart-uploads\" or \"previous-object-versions\".
-        This field when declared as \"objects\" is used to specify ARCHIVE or DELETE rule for objects.
-        This field when declared as \"previous-object-versions\" is used to specify ARCHIVE or DELETE
-        rule for previous versions of existing objects.
+        This field when declared as \"objects\" is used to specify ARCHIVE, INFREQUENT_ACCESS
+        or DELETE rule for objects.
+        This field when declared as \"previous-object-versions\" is used to specify ARCHIVE,
+        INFREQUENT_ACCESS or DELETE rule for previous versions of existing objects.
         This field when declared as \"multipart-uploads\" is used to specify the ABORT (only) rule for
         uncommitted multipart-uploads.
 
@@ -154,8 +156,11 @@ class ObjectLifecycleRule(object):
         """
         **[Required]** Gets the action of this ObjectLifecycleRule.
         The action of the object lifecycle policy rule.
-        Rules using the action 'ARCHIVE' move objects from Standard storage tier into the
-        `Archive Storage tier]`__.
+        Rules using the action 'ARCHIVE' move objects from Standard and InfrequentAccess storage tiers
+        into the `Archive storage tier`__.
+        Rules using the action 'INFREQUENT_ACCESS' move objects from Standard storage tier into the
+        Infrequent Access Storage tier. Objects that are already in InfrequentAccess tier or in Archive
+        tier are left untouched.
         Rules using the action 'DELETE' permanently delete objects from buckets.
         Rules using 'ABORT' abort the uncommitted multipart-uploads and permanently delete their parts from buckets.
 
@@ -172,8 +177,11 @@ class ObjectLifecycleRule(object):
         """
         Sets the action of this ObjectLifecycleRule.
         The action of the object lifecycle policy rule.
-        Rules using the action 'ARCHIVE' move objects from Standard storage tier into the
-        `Archive Storage tier]`__.
+        Rules using the action 'ARCHIVE' move objects from Standard and InfrequentAccess storage tiers
+        into the `Archive storage tier`__.
+        Rules using the action 'INFREQUENT_ACCESS' move objects from Standard storage tier into the
+        Infrequent Access Storage tier. Objects that are already in InfrequentAccess tier or in Archive
+        tier are left untouched.
         Rules using the action 'DELETE' permanently delete objects from buckets.
         Rules using 'ABORT' abort the uncommitted multipart-uploads and permanently delete their parts from buckets.
 

--- a/src/oci/object_storage/models/object_summary.py
+++ b/src/oci/object_storage/models/object_summary.py
@@ -17,6 +17,30 @@ class ObjectSummary(object):
     __ https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm
     """
 
+    #: A constant which can be used with the storage_tier property of a ObjectSummary.
+    #: This constant has a value of "Standard"
+    STORAGE_TIER_STANDARD = "Standard"
+
+    #: A constant which can be used with the storage_tier property of a ObjectSummary.
+    #: This constant has a value of "InfrequentAccess"
+    STORAGE_TIER_INFREQUENT_ACCESS = "InfrequentAccess"
+
+    #: A constant which can be used with the storage_tier property of a ObjectSummary.
+    #: This constant has a value of "Archive"
+    STORAGE_TIER_ARCHIVE = "Archive"
+
+    #: A constant which can be used with the archival_state property of a ObjectSummary.
+    #: This constant has a value of "Archived"
+    ARCHIVAL_STATE_ARCHIVED = "Archived"
+
+    #: A constant which can be used with the archival_state property of a ObjectSummary.
+    #: This constant has a value of "Restoring"
+    ARCHIVAL_STATE_RESTORING = "Restoring"
+
+    #: A constant which can be used with the archival_state property of a ObjectSummary.
+    #: This constant has a value of "Restored"
+    ARCHIVAL_STATE_RESTORED = "Restored"
+
     def __init__(self, **kwargs):
         """
         Initializes a new ObjectSummary object with values from keyword arguments.
@@ -42,6 +66,18 @@ class ObjectSummary(object):
             The value to assign to the etag property of this ObjectSummary.
         :type etag: str
 
+        :param storage_tier:
+            The value to assign to the storage_tier property of this ObjectSummary.
+            Allowed values for this property are: "Standard", "InfrequentAccess", "Archive", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type storage_tier: str
+
+        :param archival_state:
+            The value to assign to the archival_state property of this ObjectSummary.
+            Allowed values for this property are: "Archived", "Restoring", "Restored", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type archival_state: str
+
         :param time_modified:
             The value to assign to the time_modified property of this ObjectSummary.
         :type time_modified: datetime
@@ -53,6 +89,8 @@ class ObjectSummary(object):
             'md5': 'str',
             'time_created': 'datetime',
             'etag': 'str',
+            'storage_tier': 'str',
+            'archival_state': 'str',
             'time_modified': 'datetime'
         }
 
@@ -62,6 +100,8 @@ class ObjectSummary(object):
             'md5': 'md5',
             'time_created': 'timeCreated',
             'etag': 'etag',
+            'storage_tier': 'storageTier',
+            'archival_state': 'archivalState',
             'time_modified': 'timeModified'
         }
 
@@ -70,6 +110,8 @@ class ObjectSummary(object):
         self._md5 = None
         self._time_created = None
         self._etag = None
+        self._storage_tier = None
+        self._archival_state = None
         self._time_modified = None
 
     @property
@@ -197,6 +239,66 @@ class ObjectSummary(object):
         :type: str
         """
         self._etag = etag
+
+    @property
+    def storage_tier(self):
+        """
+        Gets the storage_tier of this ObjectSummary.
+        The storage tier that the object is stored in.
+
+        Allowed values for this property are: "Standard", "InfrequentAccess", "Archive", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The storage_tier of this ObjectSummary.
+        :rtype: str
+        """
+        return self._storage_tier
+
+    @storage_tier.setter
+    def storage_tier(self, storage_tier):
+        """
+        Sets the storage_tier of this ObjectSummary.
+        The storage tier that the object is stored in.
+
+
+        :param storage_tier: The storage_tier of this ObjectSummary.
+        :type: str
+        """
+        allowed_values = ["Standard", "InfrequentAccess", "Archive"]
+        if not value_allowed_none_or_none_sentinel(storage_tier, allowed_values):
+            storage_tier = 'UNKNOWN_ENUM_VALUE'
+        self._storage_tier = storage_tier
+
+    @property
+    def archival_state(self):
+        """
+        Gets the archival_state of this ObjectSummary.
+        Archival state of an object. This field is set only for objects in Archive tier.
+
+        Allowed values for this property are: "Archived", "Restoring", "Restored", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The archival_state of this ObjectSummary.
+        :rtype: str
+        """
+        return self._archival_state
+
+    @archival_state.setter
+    def archival_state(self, archival_state):
+        """
+        Sets the archival_state of this ObjectSummary.
+        Archival state of an object. This field is set only for objects in Archive tier.
+
+
+        :param archival_state: The archival_state of this ObjectSummary.
+        :type: str
+        """
+        allowed_values = ["Archived", "Restoring", "Restored"]
+        if not value_allowed_none_or_none_sentinel(archival_state, allowed_values):
+            archival_state = 'UNKNOWN_ENUM_VALUE'
+        self._archival_state = archival_state
 
     @property
     def time_modified(self):

--- a/src/oci/object_storage/models/object_version_summary.py
+++ b/src/oci/object_storage/models/object_version_summary.py
@@ -17,6 +17,30 @@ class ObjectVersionSummary(object):
     __ https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm
     """
 
+    #: A constant which can be used with the storage_tier property of a ObjectVersionSummary.
+    #: This constant has a value of "Standard"
+    STORAGE_TIER_STANDARD = "Standard"
+
+    #: A constant which can be used with the storage_tier property of a ObjectVersionSummary.
+    #: This constant has a value of "InfrequentAccess"
+    STORAGE_TIER_INFREQUENT_ACCESS = "InfrequentAccess"
+
+    #: A constant which can be used with the storage_tier property of a ObjectVersionSummary.
+    #: This constant has a value of "Archive"
+    STORAGE_TIER_ARCHIVE = "Archive"
+
+    #: A constant which can be used with the archival_state property of a ObjectVersionSummary.
+    #: This constant has a value of "Archived"
+    ARCHIVAL_STATE_ARCHIVED = "Archived"
+
+    #: A constant which can be used with the archival_state property of a ObjectVersionSummary.
+    #: This constant has a value of "Restoring"
+    ARCHIVAL_STATE_RESTORING = "Restoring"
+
+    #: A constant which can be used with the archival_state property of a ObjectVersionSummary.
+    #: This constant has a value of "Restored"
+    ARCHIVAL_STATE_RESTORED = "Restored"
+
     def __init__(self, **kwargs):
         """
         Initializes a new ObjectVersionSummary object with values from keyword arguments.
@@ -46,6 +70,18 @@ class ObjectVersionSummary(object):
             The value to assign to the etag property of this ObjectVersionSummary.
         :type etag: str
 
+        :param storage_tier:
+            The value to assign to the storage_tier property of this ObjectVersionSummary.
+            Allowed values for this property are: "Standard", "InfrequentAccess", "Archive", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type storage_tier: str
+
+        :param archival_state:
+            The value to assign to the archival_state property of this ObjectVersionSummary.
+            Allowed values for this property are: "Archived", "Restoring", "Restored", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type archival_state: str
+
         :param version_id:
             The value to assign to the version_id property of this ObjectVersionSummary.
         :type version_id: str
@@ -62,6 +98,8 @@ class ObjectVersionSummary(object):
             'time_created': 'datetime',
             'time_modified': 'datetime',
             'etag': 'str',
+            'storage_tier': 'str',
+            'archival_state': 'str',
             'version_id': 'str',
             'is_delete_marker': 'bool'
         }
@@ -73,6 +111,8 @@ class ObjectVersionSummary(object):
             'time_created': 'timeCreated',
             'time_modified': 'timeModified',
             'etag': 'etag',
+            'storage_tier': 'storageTier',
+            'archival_state': 'archivalState',
             'version_id': 'versionId',
             'is_delete_marker': 'isDeleteMarker'
         }
@@ -83,6 +123,8 @@ class ObjectVersionSummary(object):
         self._time_created = None
         self._time_modified = None
         self._etag = None
+        self._storage_tier = None
+        self._archival_state = None
         self._version_id = None
         self._is_delete_marker = None
 
@@ -239,6 +281,66 @@ class ObjectVersionSummary(object):
         :type: str
         """
         self._etag = etag
+
+    @property
+    def storage_tier(self):
+        """
+        Gets the storage_tier of this ObjectVersionSummary.
+        The storage tier that the object is stored in.
+
+        Allowed values for this property are: "Standard", "InfrequentAccess", "Archive", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The storage_tier of this ObjectVersionSummary.
+        :rtype: str
+        """
+        return self._storage_tier
+
+    @storage_tier.setter
+    def storage_tier(self, storage_tier):
+        """
+        Sets the storage_tier of this ObjectVersionSummary.
+        The storage tier that the object is stored in.
+
+
+        :param storage_tier: The storage_tier of this ObjectVersionSummary.
+        :type: str
+        """
+        allowed_values = ["Standard", "InfrequentAccess", "Archive"]
+        if not value_allowed_none_or_none_sentinel(storage_tier, allowed_values):
+            storage_tier = 'UNKNOWN_ENUM_VALUE'
+        self._storage_tier = storage_tier
+
+    @property
+    def archival_state(self):
+        """
+        Gets the archival_state of this ObjectVersionSummary.
+        Archival state of an object. This field is set only for objects in Archive tier.
+
+        Allowed values for this property are: "Archived", "Restoring", "Restored", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The archival_state of this ObjectVersionSummary.
+        :rtype: str
+        """
+        return self._archival_state
+
+    @archival_state.setter
+    def archival_state(self, archival_state):
+        """
+        Sets the archival_state of this ObjectVersionSummary.
+        Archival state of an object. This field is set only for objects in Archive tier.
+
+
+        :param archival_state: The archival_state of this ObjectVersionSummary.
+        :type: str
+        """
+        allowed_values = ["Archived", "Restoring", "Restored"]
+        if not value_allowed_none_or_none_sentinel(archival_state, allowed_values):
+            archival_state = 'UNKNOWN_ENUM_VALUE'
+        self._archival_state = archival_state
 
     @property
     def version_id(self):

--- a/src/oci/object_storage/models/rename_object_details.py
+++ b/src/oci/object_storage/models/rename_object_details.py
@@ -93,7 +93,7 @@ class RenameObjectDetails(object):
     def new_name(self):
         """
         **[Required]** Gets the new_name of this RenameObjectDetails.
-        The new name of the source object.
+        The new name of the source object. Avoid entering confidential information.
 
 
         :return: The new_name of this RenameObjectDetails.
@@ -105,7 +105,7 @@ class RenameObjectDetails(object):
     def new_name(self, new_name):
         """
         Sets the new_name of this RenameObjectDetails.
-        The new name of the source object.
+        The new name of the source object. Avoid entering confidential information.
 
 
         :param new_name: The new_name of this RenameObjectDetails.

--- a/src/oci/object_storage/models/retention_rule_details.py
+++ b/src/oci/object_storage/models/retention_rule_details.py
@@ -52,6 +52,7 @@ class RetentionRuleDetails(object):
         """
         Gets the display_name of this RetentionRuleDetails.
         A user-specified name for the retention rule. Names can be helpful in identifying retention rules.
+        Avoid entering confidential information.
 
 
         :return: The display_name of this RetentionRuleDetails.
@@ -64,6 +65,7 @@ class RetentionRuleDetails(object):
         """
         Sets the display_name of this RetentionRuleDetails.
         A user-specified name for the retention rule. Names can be helpful in identifying retention rules.
+        Avoid entering confidential information.
 
 
         :param display_name: The display_name of this RetentionRuleDetails.

--- a/src/oci/object_storage/models/update_object_storage_tier_details.py
+++ b/src/oci/object_storage/models/update_object_storage_tier_details.py
@@ -1,0 +1,157 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateObjectStorageTierDetails(object):
+    """
+    To change the storage tier of an object, we specify the object name and the desired
+    storage tier in the body. Objects can be moved between Standard and InfrequentAccess
+    tiers and from Standard or InfrequentAccess tier to Archive tier. If a version id is
+    specified, only the specified version of the object is moved to a different storage
+    tier, else the current version is used.
+    """
+
+    #: A constant which can be used with the storage_tier property of a UpdateObjectStorageTierDetails.
+    #: This constant has a value of "Standard"
+    STORAGE_TIER_STANDARD = "Standard"
+
+    #: A constant which can be used with the storage_tier property of a UpdateObjectStorageTierDetails.
+    #: This constant has a value of "InfrequentAccess"
+    STORAGE_TIER_INFREQUENT_ACCESS = "InfrequentAccess"
+
+    #: A constant which can be used with the storage_tier property of a UpdateObjectStorageTierDetails.
+    #: This constant has a value of "Archive"
+    STORAGE_TIER_ARCHIVE = "Archive"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateObjectStorageTierDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param object_name:
+            The value to assign to the object_name property of this UpdateObjectStorageTierDetails.
+        :type object_name: str
+
+        :param storage_tier:
+            The value to assign to the storage_tier property of this UpdateObjectStorageTierDetails.
+            Allowed values for this property are: "Standard", "InfrequentAccess", "Archive"
+        :type storage_tier: str
+
+        :param version_id:
+            The value to assign to the version_id property of this UpdateObjectStorageTierDetails.
+        :type version_id: str
+
+        """
+        self.swagger_types = {
+            'object_name': 'str',
+            'storage_tier': 'str',
+            'version_id': 'str'
+        }
+
+        self.attribute_map = {
+            'object_name': 'objectName',
+            'storage_tier': 'storageTier',
+            'version_id': 'versionId'
+        }
+
+        self._object_name = None
+        self._storage_tier = None
+        self._version_id = None
+
+    @property
+    def object_name(self):
+        """
+        **[Required]** Gets the object_name of this UpdateObjectStorageTierDetails.
+        An object for which the storage tier needs to be changed.
+
+
+        :return: The object_name of this UpdateObjectStorageTierDetails.
+        :rtype: str
+        """
+        return self._object_name
+
+    @object_name.setter
+    def object_name(self, object_name):
+        """
+        Sets the object_name of this UpdateObjectStorageTierDetails.
+        An object for which the storage tier needs to be changed.
+
+
+        :param object_name: The object_name of this UpdateObjectStorageTierDetails.
+        :type: str
+        """
+        self._object_name = object_name
+
+    @property
+    def storage_tier(self):
+        """
+        **[Required]** Gets the storage_tier of this UpdateObjectStorageTierDetails.
+        The storage tier that the object should be moved to.
+
+        Allowed values for this property are: "Standard", "InfrequentAccess", "Archive"
+
+
+        :return: The storage_tier of this UpdateObjectStorageTierDetails.
+        :rtype: str
+        """
+        return self._storage_tier
+
+    @storage_tier.setter
+    def storage_tier(self, storage_tier):
+        """
+        Sets the storage_tier of this UpdateObjectStorageTierDetails.
+        The storage tier that the object should be moved to.
+
+
+        :param storage_tier: The storage_tier of this UpdateObjectStorageTierDetails.
+        :type: str
+        """
+        allowed_values = ["Standard", "InfrequentAccess", "Archive"]
+        if not value_allowed_none_or_none_sentinel(storage_tier, allowed_values):
+            raise ValueError(
+                "Invalid value for `storage_tier`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._storage_tier = storage_tier
+
+    @property
+    def version_id(self):
+        """
+        Gets the version_id of this UpdateObjectStorageTierDetails.
+        The versionId of the object. Current object version is used by default.
+
+
+        :return: The version_id of this UpdateObjectStorageTierDetails.
+        :rtype: str
+        """
+        return self._version_id
+
+    @version_id.setter
+    def version_id(self, version_id):
+        """
+        Sets the version_id of this UpdateObjectStorageTierDetails.
+        The versionId of the object. Current object version is used by default.
+
+
+        :param version_id: The version_id of this UpdateObjectStorageTierDetails.
+        :type: str
+        """
+        self._version_id = version_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/object_storage/models/update_retention_rule_details.py
+++ b/src/oci/object_storage/models/update_retention_rule_details.py
@@ -52,6 +52,7 @@ class UpdateRetentionRuleDetails(object):
         """
         Gets the display_name of this UpdateRetentionRuleDetails.
         A user-specified name for the retention rule. Names can be helpful in identifying retention rules.
+        Avoid entering confidential information.
 
 
         :return: The display_name of this UpdateRetentionRuleDetails.
@@ -64,6 +65,7 @@ class UpdateRetentionRuleDetails(object):
         """
         Sets the display_name of this UpdateRetentionRuleDetails.
         A user-specified name for the retention rule. Names can be helpful in identifying retention rules.
+        Avoid entering confidential information.
 
 
         :param display_name: The display_name of this UpdateRetentionRuleDetails.

--- a/src/oci/object_storage/object_storage_client.py
+++ b/src/oci/object_storage/object_storage_client.py
@@ -276,13 +276,13 @@ class ObjectStorageClient(object):
             The part numbers and entity tags (ETags) for the parts you want to commit.
 
         :param str if_match: (optional)
-            The entity tag (ETag) to match. For creating and committing a multipart upload to an object, this is the entity tag of the target object.
-            For uploading a part, this is the entity tag of the target part.
+            The entity tag (ETag) to match with the ETag of an existing resource. If the specified ETag matches the ETag of
+            the existing resource, GET and HEAD requests will return the resource and PUT and POST requests will upload
+            the resource.
 
         :param str if_none_match: (optional)
-            The entity tag (ETag) to avoid matching. The only valid value is '*', which indicates that the request should fail if the object
-            already exists. For creating and committing a multipart upload, this is the entity tag of the target object. For uploading a
-            part, this is the entity tag of the target part.
+            The entity tag (ETag) to avoid matching. The only valid value is '*', which indicates that the request should
+            fail if the resource already exists.
 
         :param str opc_client_request_id: (optional)
             The client request ID for tracing.
@@ -598,13 +598,13 @@ class ObjectStorageClient(object):
             Request object for creating a multipart upload.
 
         :param str if_match: (optional)
-            The entity tag (ETag) to match. For creating and committing a multipart upload to an object, this is the entity tag of the target object.
-            For uploading a part, this is the entity tag of the target part.
+            The entity tag (ETag) to match with the ETag of an existing resource. If the specified ETag matches the ETag of
+            the existing resource, GET and HEAD requests will return the resource and PUT and POST requests will upload
+            the resource.
 
         :param str if_none_match: (optional)
-            The entity tag (ETag) to avoid matching. The only valid value is '*', which indicates that the request should fail if the object
-            already exists. For creating and committing a multipart upload, this is the entity tag of the target object. For uploading a
-            part, this is the entity tag of the target part.
+            The entity tag (ETag) to avoid matching. The only valid value is '*', which indicates that the request should
+            fail if the resource already exists.
 
         :param str opc_client_request_id: (optional)
             The client request ID for tracing.
@@ -978,8 +978,9 @@ class ObjectStorageClient(object):
             Example: `my-new-bucket1`
 
         :param str if_match: (optional)
-            The entity tag (ETag) to match. For creating and committing a multipart upload to an object, this is the entity tag of the target object.
-            For uploading a part, this is the entity tag of the target part.
+            The entity tag (ETag) to match with the ETag of an existing resource. If the specified ETag matches the ETag of
+            the existing resource, GET and HEAD requests will return the resource and PUT and POST requests will upload
+            the resource.
 
         :param str opc_client_request_id: (optional)
             The client request ID for tracing.
@@ -1066,8 +1067,9 @@ class ObjectStorageClient(object):
             Example: `test/object1.log`
 
         :param str if_match: (optional)
-            The entity tag (ETag) to match. For creating and committing a multipart upload to an object, this is the entity tag of the target object.
-            For uploading a part, this is the entity tag of the target part.
+            The entity tag (ETag) to match with the ETag of an existing resource. If the specified ETag matches the ETag of
+            the existing resource, GET and HEAD requests will return the resource and PUT and POST requests will upload
+            the resource.
 
         :param str opc_client_request_id: (optional)
             The client request ID for tracing.
@@ -1165,8 +1167,9 @@ class ObjectStorageClient(object):
             The client request ID for tracing.
 
         :param str if_match: (optional)
-            The entity tag (ETag) to match. For creating and committing a multipart upload to an object, this is the entity tag of the target object.
-            For uploading a part, this is the entity tag of the target part.
+            The entity tag (ETag) to match with the ETag of an existing resource. If the specified ETag matches the ETag of
+            the existing resource, GET and HEAD requests will return the resource and PUT and POST requests will upload
+            the resource.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -1414,8 +1417,9 @@ class ObjectStorageClient(object):
             The ID of the retention rule.
 
         :param str if_match: (optional)
-            The entity tag (ETag) to match. For creating and committing a multipart upload to an object, this is the entity tag of the target object.
-            For uploading a part, this is the entity tag of the target part.
+            The entity tag (ETag) to match with the ETag of an existing resource. If the specified ETag matches the ETag of
+            the existing resource, GET and HEAD requests will return the resource and PUT and POST requests will upload
+            the resource.
 
         :param str opc_client_request_id: (optional)
             The client request ID for tracing.
@@ -1499,13 +1503,13 @@ class ObjectStorageClient(object):
             Example: `my-new-bucket1`
 
         :param str if_match: (optional)
-            The entity tag (ETag) to match. For creating and committing a multipart upload to an object, this is the entity tag of the target object.
-            For uploading a part, this is the entity tag of the target part.
+            The entity tag (ETag) to match with the ETag of an existing resource. If the specified ETag matches the ETag of
+            the existing resource, GET and HEAD requests will return the resource and PUT and POST requests will upload
+            the resource.
 
         :param str if_none_match: (optional)
-            The entity tag (ETag) to avoid matching. The only valid value is '*', which indicates that the request should fail if the object
-            already exists. For creating and committing a multipart upload, this is the entity tag of the target object. For uploading a
-            part, this is the entity tag of the target part.
+            The entity tag (ETag) to avoid matching. The only valid value is '*', which indicates that the request should
+            fail if the resource already exists.
 
         :param str opc_client_request_id: (optional)
             The client request ID for tracing.
@@ -1786,13 +1790,13 @@ class ObjectStorageClient(object):
             VersionId used to identify a particular version of the object
 
         :param str if_match: (optional)
-            The entity tag (ETag) to match. For creating and committing a multipart upload to an object, this is the entity tag of the target object.
-            For uploading a part, this is the entity tag of the target part.
+            The entity tag (ETag) to match with the ETag of an existing resource. If the specified ETag matches the ETag of
+            the existing resource, GET and HEAD requests will return the resource and PUT and POST requests will upload
+            the resource.
 
         :param str if_none_match: (optional)
-            The entity tag (ETag) to avoid matching. The only valid value is '*', which indicates that the request should fail if the object
-            already exists. For creating and committing a multipart upload, this is the entity tag of the target object. For uploading a
-            part, this is the entity tag of the target part.
+            The entity tag (ETag) to avoid matching. The only valid value is '*', which indicates that the request should
+            fail if the resource already exists.
 
         :param str opc_client_request_id: (optional)
             The client request ID for tracing.
@@ -2360,13 +2364,13 @@ class ObjectStorageClient(object):
             Example: `my-new-bucket1`
 
         :param str if_match: (optional)
-            The entity tag (ETag) to match. For creating and committing a multipart upload to an object, this is the entity tag of the target object.
-            For uploading a part, this is the entity tag of the target part.
+            The entity tag (ETag) to match with the ETag of an existing resource. If the specified ETag matches the ETag of
+            the existing resource, GET and HEAD requests will return the resource and PUT and POST requests will upload
+            the resource.
 
         :param str if_none_match: (optional)
-            The entity tag (ETag) to avoid matching. The only valid value is '*', which indicates that the request should fail if the object
-            already exists. For creating and committing a multipart upload, this is the entity tag of the target object. For uploading a
-            part, this is the entity tag of the target part.
+            The entity tag (ETag) to avoid matching. The only valid value is '*', which indicates that the request should
+            fail if the resource already exists.
 
         :param str opc_client_request_id: (optional)
             The client request ID for tracing.
@@ -2458,13 +2462,13 @@ class ObjectStorageClient(object):
             VersionId used to identify a particular version of the object
 
         :param str if_match: (optional)
-            The entity tag (ETag) to match. For creating and committing a multipart upload to an object, this is the entity tag of the target object.
-            For uploading a part, this is the entity tag of the target part.
+            The entity tag (ETag) to match with the ETag of an existing resource. If the specified ETag matches the ETag of
+            the existing resource, GET and HEAD requests will return the resource and PUT and POST requests will upload
+            the resource.
 
         :param str if_none_match: (optional)
-            The entity tag (ETag) to avoid matching. The only valid value is '*', which indicates that the request should fail if the object
-            already exists. For creating and committing a multipart upload, this is the entity tag of the target object. For uploading a
-            part, this is the entity tag of the target part.
+            The entity tag (ETag) to avoid matching. The only valid value is '*', which indicates that the request should
+            fail if the resource already exists.
 
         :param str opc_client_request_id: (optional)
             The client request ID for tracing.
@@ -2576,6 +2580,9 @@ class ObjectStorageClient(object):
         Gets a list of all BucketSummary items in a compartment. A BucketSummary contains only summary fields for the bucket
         and does not contain fields like the user-defined metadata.
 
+        ListBuckets returns a BucketSummary containing at most 1000 buckets. To paginate through more buckets, use the returned
+        `opc-next-page` value with the `page` request parameter.
+
         To use this and other API operations, you must be authorized in an IAM policy. If you are not authorized,
         talk to an administrator. If you are an administrator who needs to write policies to give users access, see
         `Getting Started with Policies`__.
@@ -2590,10 +2597,17 @@ class ObjectStorageClient(object):
             The ID of the compartment in which to list buckets.
 
         :param int limit: (optional)
-            The maximum number of items to return.
+            For list pagination. The maximum number of results per page, or items to return in a paginated
+            \"List\" call. For important details about how pagination works, see
+            `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param str page: (optional)
-            The page at which to start retrieving results.
+            For list pagination. The value of the `opc-next-page` response header from the previous \"List\" call. For important
+            details about how pagination works, see `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param list[str] fields: (optional)
             Bucket summary in list of buckets includes the 'namespace', 'name', 'compartmentId', 'createdBy', 'timeCreated',
@@ -2710,10 +2724,17 @@ class ObjectStorageClient(object):
             The upload ID for a multipart upload.
 
         :param int limit: (optional)
-            The maximum number of items to return.
+            For list pagination. The maximum number of results per page, or items to return in a paginated
+            \"List\" call. For important details about how pagination works, see
+            `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param str page: (optional)
-            The page at which to start retrieving results.
+            For list pagination. The value of the `opc-next-page` response header from the previous \"List\" call. For important
+            details about how pagination works, see `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param str opc_client_request_id: (optional)
             The client request ID for tracing.
@@ -2808,10 +2829,17 @@ class ObjectStorageClient(object):
             Example: `my-new-bucket1`
 
         :param int limit: (optional)
-            The maximum number of items to return.
+            For list pagination. The maximum number of results per page, or items to return in a paginated
+            \"List\" call. For important details about how pagination works, see
+            `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param str page: (optional)
-            The page at which to start retrieving results.
+            For list pagination. The value of the `opc-next-page` response header from the previous \"List\" call. For important
+            details about how pagination works, see `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param str opc_client_request_id: (optional)
             The client request ID for tracing.
@@ -2895,6 +2923,9 @@ class ObjectStorageClient(object):
         """
         Lists the object versions in a bucket.
 
+        ListObjectVersions returns an ObjectVersionCollection containing at most 1000 object versions. To paginate through
+        more object versions, use the returned `opc-next-page` value with the `page` request parameter.
+
         To use this and other API operations, you must be authorized in an IAM policy. If you are not authorized,
         talk to an administrator. If you are an administrator who needs to write policies to give users access, see
         `Getting Started with Policies`__.
@@ -2919,7 +2950,11 @@ class ObjectStorageClient(object):
             Object names returned by a list query must be strictly less than this parameter.
 
         :param int limit: (optional)
-            The maximum number of items to return.
+            For list pagination. The maximum number of results per page, or items to return in a paginated
+            \"List\" call. For important details about how pagination works, see
+            `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param str delimiter: (optional)
             When this parameter is set, only objects whose names do not contain the delimiter character
@@ -2929,13 +2964,13 @@ class ObjectStorageClient(object):
             Note that only '/' is a supported delimiter character at this time.
 
         :param str fields: (optional)
-            Object summary in list of objects includes the 'name' field. This parameter can also include 'size'
-            (object size in bytes), 'etag', 'md5', 'timeCreated' (object creation date and time) and 'timeModified'
-            (object modification date and time).
-            Value of this parameter should be a comma-separated, case-insensitive list of those field names.
-            For example 'name,etag,timeCreated,md5,timeModified'
+            Object summary by default includes only the 'name' field. Use this parameter to also
+            include 'size' (object size in bytes), 'etag', 'md5', 'timeCreated' (object creation date and time),
+            'timeModified' (object modification date and time), 'storageTier' and 'archivalState' fields.
+            Specify the value of this parameter as a comma-separated, case-insensitive list of those field names.
+            For example 'name,etag,timeCreated,md5,timeModified,storageTier,archivalState'.
 
-            Allowed values are: "name", "size", "etag", "timeCreated", "md5", "timeModified"
+            Allowed values are: "name", "size", "etag", "timeCreated", "md5", "timeModified", "storageTier", "archivalState"
 
         :param str opc_client_request_id: (optional)
             The client request ID for tracing.
@@ -2944,7 +2979,10 @@ class ObjectStorageClient(object):
             Object names returned by a list query must be greater than this parameter.
 
         :param str page: (optional)
-            The page at which to start retrieving results.
+            For list pagination. The value of the `opc-next-page` response header from the previous \"List\" call. For important
+            details about how pagination works, see `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -3035,7 +3073,12 @@ class ObjectStorageClient(object):
 
     def list_objects(self, namespace_name, bucket_name, **kwargs):
         """
-        Lists the objects in a bucket.
+        Lists the objects in a bucket. By default, ListObjects returns object names only. See the `fields`
+        parameter for other fields that you can optionally include in ListObjects response.
+
+        ListObjects returns at most 1000 objects. To paginate through more objects, use the returned 'nextStartWith'
+        value with the 'start' parameter. To filter which objects ListObjects returns, use the 'start' and 'end'
+        parameters.
 
         To use this and other API operations, you must be authorized in an IAM policy. If you are not authorized,
         talk to an administrator. If you are an administrator who needs to write policies to give users access, see
@@ -3061,7 +3104,11 @@ class ObjectStorageClient(object):
             Object names returned by a list query must be strictly less than this parameter.
 
         :param int limit: (optional)
-            The maximum number of items to return.
+            For list pagination. The maximum number of results per page, or items to return in a paginated
+            \"List\" call. For important details about how pagination works, see
+            `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param str delimiter: (optional)
             When this parameter is set, only objects whose names do not contain the delimiter character
@@ -3071,13 +3118,13 @@ class ObjectStorageClient(object):
             Note that only '/' is a supported delimiter character at this time.
 
         :param str fields: (optional)
-            Object summary in list of objects includes the 'name' field. This parameter can also include 'size'
-            (object size in bytes), 'etag', 'md5', 'timeCreated' (object creation date and time) and 'timeModified'
-            (object modification date and time).
-            Value of this parameter should be a comma-separated, case-insensitive list of those field names.
-            For example 'name,etag,timeCreated,md5,timeModified'
+            Object summary by default includes only the 'name' field. Use this parameter to also
+            include 'size' (object size in bytes), 'etag', 'md5', 'timeCreated' (object creation date and time),
+            'timeModified' (object modification date and time), 'storageTier' and 'archivalState' fields.
+            Specify the value of this parameter as a comma-separated, case-insensitive list of those field names.
+            For example 'name,etag,timeCreated,md5,timeModified,storageTier,archivalState'.
 
-            Allowed values are: "name", "size", "etag", "timeCreated", "md5", "timeModified"
+            Allowed values are: "name", "size", "etag", "timeCreated", "md5", "timeModified", "storageTier", "archivalState"
 
         :param str opc_client_request_id: (optional)
             The client request ID for tracing.
@@ -3186,10 +3233,17 @@ class ObjectStorageClient(object):
             User-specified object name prefixes can be used to query and return a list of pre-authenticated requests.
 
         :param int limit: (optional)
-            The maximum number of items to return.
+            For list pagination. The maximum number of results per page, or items to return in a paginated
+            \"List\" call. For important details about how pagination works, see
+            `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param str page: (optional)
-            The page at which to start retrieving results.
+            For list pagination. The value of the `opc-next-page` response header from the previous \"List\" call. For important
+            details about how pagination works, see `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param str opc_client_request_id: (optional)
             The client request ID for tracing.
@@ -3287,10 +3341,17 @@ class ObjectStorageClient(object):
             The client request ID for tracing.
 
         :param str page: (optional)
-            The page at which to start retrieving results.
+            For list pagination. The value of the `opc-next-page` response header from the previous \"List\" call. For important
+            details about how pagination works, see `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param int limit: (optional)
-            The maximum number of items to return.
+            For list pagination. The maximum number of results per page, or items to return in a paginated
+            \"List\" call. For important details about how pagination works, see
+            `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -3383,10 +3444,17 @@ class ObjectStorageClient(object):
             The client request ID for tracing.
 
         :param str page: (optional)
-            The page at which to start retrieving results.
+            For list pagination. The value of the `opc-next-page` response header from the previous \"List\" call. For important
+            details about how pagination works, see `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param int limit: (optional)
-            The maximum number of items to return.
+            For list pagination. The maximum number of results per page, or items to return in a paginated
+            \"List\" call. For important details about how pagination works, see
+            `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -3477,7 +3545,10 @@ class ObjectStorageClient(object):
             Example: `my-new-bucket1`
 
         :param str page: (optional)
-            The page at which to start retrieving results.
+            For list pagination. The value of the `opc-next-page` response header from the previous \"List\" call. For important
+            details about how pagination works, see `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -3558,10 +3629,17 @@ class ObjectStorageClient(object):
             The ID of the asynchronous request.
 
         :param str page: (optional)
-            The page at which to start retrieving results.
+            For list pagination. The value of the `opc-next-page` response header from the previous \"List\" call. For important
+            details about how pagination works, see `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param int limit: (optional)
-            The maximum number of items to return.
+            For list pagination. The maximum number of results per page, or items to return in a paginated
+            \"List\" call. For important details about how pagination works, see
+            `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param str opc_client_request_id: (optional)
             The client request ID for tracing.
@@ -3649,10 +3727,17 @@ class ObjectStorageClient(object):
             The ID of the asynchronous request.
 
         :param str page: (optional)
-            The page at which to start retrieving results.
+            For list pagination. The value of the `opc-next-page` response header from the previous \"List\" call. For important
+            details about how pagination works, see `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param int limit: (optional)
-            The maximum number of items to return.
+            For list pagination. The maximum number of results per page, or items to return in a paginated
+            \"List\" call. For important details about how pagination works, see
+            `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param str opc_client_request_id: (optional)
             The client request ID for tracing.
@@ -3743,10 +3828,17 @@ class ObjectStorageClient(object):
             The client request ID for tracing.
 
         :param str page: (optional)
-            The page at which to start retrieving results.
+            For list pagination. The value of the `opc-next-page` response header from the previous \"List\" call. For important
+            details about how pagination works, see `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param int limit: (optional)
-            The maximum number of items to return.
+            For list pagination. The maximum number of results per page, or items to return in a paginated
+            \"List\" call. For important details about how pagination works, see
+            `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -3925,13 +4017,13 @@ class ObjectStorageClient(object):
             The content length of the body.
 
         :param str if_match: (optional)
-            The entity tag (ETag) to match. For creating and committing a multipart upload to an object, this is the entity tag of the target object.
-            For uploading a part, this is the entity tag of the target part.
+            The entity tag (ETag) to match with the ETag of an existing resource. If the specified ETag matches the ETag of
+            the existing resource, GET and HEAD requests will return the resource and PUT and POST requests will upload
+            the resource.
 
         :param str if_none_match: (optional)
-            The entity tag (ETag) to avoid matching. The only valid value is '*', which indicates that the request should fail if the object
-            already exists. For creating and committing a multipart upload, this is the entity tag of the target object. For uploading a
-            part, this is the entity tag of the target part.
+            The entity tag (ETag) to avoid matching. The only valid value is '*', which indicates that the request should
+            fail if the resource already exists.
 
         :param str opc_client_request_id: (optional)
             The client request ID for tracing.
@@ -3998,6 +4090,12 @@ class ObjectStorageClient(object):
 
             __ https://docs.cloud.oracle.com/Content/Object/Tasks/usingyourencryptionkeys.htm
 
+        :param str storage_tier: (optional)
+            The storage tier that the object should be stored in. If not specified, the object will be stored in
+            the same storage tier as the bucket.
+
+            Allowed values are: "Standard", "InfrequentAccess", "Archive"
+
         :param dict(str, str) opc_meta: (optional)
             Optional user-defined metadata key and value.
 
@@ -4037,6 +4135,7 @@ class ObjectStorageClient(object):
             "opc_sse_customer_algorithm",
             "opc_sse_customer_key",
             "opc_sse_customer_key_sha256",
+            "storage_tier",
             "opc_meta"
         ]
         extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
@@ -4072,6 +4171,7 @@ class ObjectStorageClient(object):
             "opc-sse-customer-algorithm": kwargs.get("opc_sse_customer_algorithm", missing),
             "opc-sse-customer-key": kwargs.get("opc_sse_customer_key", missing),
             "opc-sse-customer-key-sha256": kwargs.get("opc_sse_customer_key_sha256", missing),
+            "storage-tier": kwargs.get("storage_tier", missing),
 
         }
         for key, value in six.iteritems(kwargs.get("opc_meta", {})):
@@ -4137,13 +4237,13 @@ class ObjectStorageClient(object):
             The client request ID for tracing.
 
         :param str if_match: (optional)
-            The entity tag (ETag) to match. For creating and committing a multipart upload to an object, this is the entity tag of the target object.
-            For uploading a part, this is the entity tag of the target part.
+            The entity tag (ETag) to match with the ETag of an existing resource. If the specified ETag matches the ETag of
+            the existing resource, GET and HEAD requests will return the resource and PUT and POST requests will upload
+            the resource.
 
         :param str if_none_match: (optional)
-            The entity tag (ETag) to avoid matching. The only valid value is '*', which indicates that the request should fail if the object
-            already exists. For creating and committing a multipart upload, this is the entity tag of the target object. For uploading a
-            part, this is the entity tag of the target part.
+            The entity tag (ETag) to avoid matching. The only valid value is '*', which indicates that the request should
+            fail if the resource already exists.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -4433,7 +4533,7 @@ class ObjectStorageClient(object):
             Example: `my-new-bucket1`
 
         :param oci.object_storage.models.RenameObjectDetails rename_object_details: (required)
-            The sourceName and newName of rename operation.
+            The sourceName and newName of rename operation. Avoid entering confidential information.
 
         :param str opc_client_request_id: (optional)
             The client request ID for tracing.
@@ -4609,8 +4709,9 @@ class ObjectStorageClient(object):
             Request object for updating a bucket.
 
         :param str if_match: (optional)
-            The entity tag (ETag) to match. For creating and committing a multipart upload to an object, this is the entity tag of the target object.
-            For uploading a part, this is the entity tag of the target part.
+            The entity tag (ETag) to match with the ETag of an existing resource. If the specified ETag matches the ETag of
+            the existing resource, GET and HEAD requests will return the resource and PUT and POST requests will upload
+            the resource.
 
         :param str opc_client_request_id: (optional)
             The client request ID for tracing.
@@ -4770,6 +4871,89 @@ class ObjectStorageClient(object):
                 body=update_namespace_metadata_details,
                 response_type="NamespaceMetadata")
 
+    def update_object_storage_tier(self, namespace_name, bucket_name, update_object_storage_tier_details, **kwargs):
+        """
+        Changes the storage tier of the object specified by the objectName parameter.
+
+
+        :param str namespace_name: (required)
+            The Object Storage namespace used for the request.
+
+        :param str bucket_name: (required)
+            The name of the bucket. Avoid entering confidential information.
+            Example: `my-new-bucket1`
+
+        :param oci.object_storage.models.UpdateObjectStorageTierDetails update_object_storage_tier_details: (required)
+            The object name and the desired storage tier.
+
+        :param str opc_client_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/objectstorage/update_object_storage_tier.py.html>`__ to see an example of how to use update_object_storage_tier API.
+        """
+        resource_path = "/n/{namespaceName}/b/{bucketName}/actions/updateObjectStorageTier"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_client_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "update_object_storage_tier got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "namespaceName": namespace_name,
+            "bucketName": bucket_name
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-client-request-id": kwargs.get("opc_client_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_object_storage_tier_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_object_storage_tier_details)
+
     def update_retention_rule(self, namespace_name, bucket_name, retention_rule_id, update_retention_rule_details, **kwargs):
         """
         Updates the specified retention rule. Rule changes take effect typically within 30 seconds.
@@ -4789,8 +4973,9 @@ class ObjectStorageClient(object):
             Request object for updating the retention rule.
 
         :param str if_match: (optional)
-            The entity tag (ETag) to match. For creating and committing a multipart upload to an object, this is the entity tag of the target object.
-            For uploading a part, this is the entity tag of the target part.
+            The entity tag (ETag) to match with the ETag of an existing resource. If the specified ETag matches the ETag of
+            the existing resource, GET and HEAD requests will return the resource and PUT and POST requests will upload
+            the resource.
 
         :param str opc_client_request_id: (optional)
             The client request ID for tracing.
@@ -4897,13 +5082,13 @@ class ObjectStorageClient(object):
             The client request ID for tracing.
 
         :param str if_match: (optional)
-            The entity tag (ETag) to match. For creating and committing a multipart upload to an object, this is the entity tag of the target object.
-            For uploading a part, this is the entity tag of the target part.
+            The entity tag (ETag) to match with the ETag of an existing resource. If the specified ETag matches the ETag of
+            the existing resource, GET and HEAD requests will return the resource and PUT and POST requests will upload
+            the resource.
 
         :param str if_none_match: (optional)
-            The entity tag (ETag) to avoid matching. The only valid value is '*', which indicates that the request should fail if the object
-            already exists. For creating and committing a multipart upload, this is the entity tag of the target object. For uploading a
-            part, this is the entity tag of the target part.
+            The entity tag (ETag) to avoid matching. The only valid value is '*', which indicates that the request should
+            fail if the resource already exists.
 
         :param str expect: (optional)
             100-continue

--- a/src/oci/object_storage/transfer/internal/multipart_object_assembler.py
+++ b/src/oci/object_storage/transfer/internal/multipart_object_assembler.py
@@ -98,6 +98,12 @@ class MultipartObjectAssembler:
 
         :param str opc_sse_customer_key_sha256 (optional):
             The base64-encoded SHA256 hash of the encryption key.
+
+        :param str storage_tier: (optional)
+            The storage tier that the object should be stored in. If not specified, the object will be stored in
+            the same storage tier as the bucket.
+
+            Allowed values are: "Standard", "InfrequentAccess", "Archive"
         """
         self.object_storage_client = object_storage_client
 
@@ -122,7 +128,9 @@ class MultipartObjectAssembler:
         self.metadata = None
         if 'metadata' in kwargs:
             self.metadata = kwargs['metadata']
-
+        self.storage_tier = None
+        if 'storage_tier' in kwargs:
+            self.storage_tier = kwargs['storage_tier']
         self.parallel_process_count = DEFAULT_PARALLEL_PROCESS_COUNT
         if 'parallel_process_count' in kwargs:
             if kwargs['parallel_process_count'] == 0:
@@ -361,7 +369,8 @@ class MultipartObjectAssembler:
             self.metadata = processed_metadata
 
             request.metadata = self.metadata
-
+        if self.storage_tier:
+            request.storage_tier = self.storage_tier
         client_request_id = None
         if 'opc_client_request_id' in kwargs:
             client_request_id = kwargs['opc_client_request_id']

--- a/src/oci/object_storage/transfer/upload_manager.py
+++ b/src/oci/object_storage/transfer/upload_manager.py
@@ -99,6 +99,12 @@ class UploadManager:
         :param dict metadata (optional):
             A dictionary of string to string values to associate with the object to upload
 
+        :param str storage_tier: (optional)
+            The storage tier that the object should be stored in. If not specified, the object will be stored in
+            the same storage tier as the bucket.
+
+            Allowed values are: "Standard", "InfrequentAccess", "Archive"
+
         :return:
             The response from multipart commit operation or the put operation.  In both cases this will be a :class:`~oci.response.Response` object with data of type None.
             For a multipart upload (non-empty stream data) the :class:`~oci.response.Response` will contain the :code:`opc-multipart-md5` header and for a non-multipart upload
@@ -208,6 +214,12 @@ class UploadManager:
 
         :param dict metadata (optional):
             A dictionary of string to string values to associate with the object to upload
+
+        :param str storage_tier: (optional)
+            The storage tier that the object should be stored in. If not specified, the object will be stored in
+            the same storage tier as the bucket.
+
+            Allowed values are: "Standard", "InfrequentAccess", "Archive"
 
         :return:
             The response from multipart commit operation or the put operation.  In both cases this will be a :class:`~oci.response.Response` object with data of type None.

--- a/src/oci/resource_manager/models/__init__.py
+++ b/src/oci/resource_manager/models/__init__.py
@@ -9,6 +9,7 @@ from .apply_job_operation_details_summary import ApplyJobOperationDetailsSummary
 from .apply_job_plan_resolution import ApplyJobPlanResolution
 from .change_configuration_source_provider_compartment_details import ChangeConfigurationSourceProviderCompartmentDetails
 from .change_stack_compartment_details import ChangeStackCompartmentDetails
+from .change_template_compartment_details import ChangeTemplateCompartmentDetails
 from .compartment_config_source import CompartmentConfigSource
 from .config_source import ConfigSource
 from .config_source_record import ConfigSourceRecord
@@ -28,6 +29,10 @@ from .create_job_details import CreateJobDetails
 from .create_job_operation_details import CreateJobOperationDetails
 from .create_plan_job_operation_details import CreatePlanJobOperationDetails
 from .create_stack_details import CreateStackDetails
+from .create_stack_template_config_source_details import CreateStackTemplateConfigSourceDetails
+from .create_template_config_source_details import CreateTemplateConfigSourceDetails
+from .create_template_details import CreateTemplateDetails
+from .create_template_zip_upload_config_source_details import CreateTemplateZipUploadConfigSourceDetails
 from .create_zip_upload_config_source_details import CreateZipUploadConfigSourceDetails
 from .destroy_job_operation_details import DestroyJobOperationDetails
 from .destroy_job_operation_details_summary import DestroyJobOperationDetailsSummary
@@ -54,6 +59,13 @@ from .stack import Stack
 from .stack_resource_drift_collection import StackResourceDriftCollection
 from .stack_resource_drift_summary import StackResourceDriftSummary
 from .stack_summary import StackSummary
+from .template import Template
+from .template_category_summary import TemplateCategorySummary
+from .template_category_summary_collection import TemplateCategorySummaryCollection
+from .template_config_source import TemplateConfigSource
+from .template_summary import TemplateSummary
+from .template_summary_collection import TemplateSummaryCollection
+from .template_zip_upload_config_source import TemplateZipUploadConfigSource
 from .terraform_version_collection import TerraformVersionCollection
 from .terraform_version_summary import TerraformVersionSummary
 from .update_config_source_details import UpdateConfigSourceDetails
@@ -63,6 +75,9 @@ from .update_github_access_token_configuration_source_provider_details import Up
 from .update_gitlab_access_token_configuration_source_provider_details import UpdateGitlabAccessTokenConfigurationSourceProviderDetails
 from .update_job_details import UpdateJobDetails
 from .update_stack_details import UpdateStackDetails
+from .update_template_config_source_details import UpdateTemplateConfigSourceDetails
+from .update_template_details import UpdateTemplateDetails
+from .update_template_zip_upload_config_source_details import UpdateTemplateZipUploadConfigSourceDetails
 from .update_zip_upload_config_source_details import UpdateZipUploadConfigSourceDetails
 from .work_request import WorkRequest
 from .work_request_error import WorkRequestError
@@ -79,6 +94,7 @@ resource_manager_type_mapping = {
     "ApplyJobPlanResolution": ApplyJobPlanResolution,
     "ChangeConfigurationSourceProviderCompartmentDetails": ChangeConfigurationSourceProviderCompartmentDetails,
     "ChangeStackCompartmentDetails": ChangeStackCompartmentDetails,
+    "ChangeTemplateCompartmentDetails": ChangeTemplateCompartmentDetails,
     "CompartmentConfigSource": CompartmentConfigSource,
     "ConfigSource": ConfigSource,
     "ConfigSourceRecord": ConfigSourceRecord,
@@ -98,6 +114,10 @@ resource_manager_type_mapping = {
     "CreateJobOperationDetails": CreateJobOperationDetails,
     "CreatePlanJobOperationDetails": CreatePlanJobOperationDetails,
     "CreateStackDetails": CreateStackDetails,
+    "CreateStackTemplateConfigSourceDetails": CreateStackTemplateConfigSourceDetails,
+    "CreateTemplateConfigSourceDetails": CreateTemplateConfigSourceDetails,
+    "CreateTemplateDetails": CreateTemplateDetails,
+    "CreateTemplateZipUploadConfigSourceDetails": CreateTemplateZipUploadConfigSourceDetails,
     "CreateZipUploadConfigSourceDetails": CreateZipUploadConfigSourceDetails,
     "DestroyJobOperationDetails": DestroyJobOperationDetails,
     "DestroyJobOperationDetailsSummary": DestroyJobOperationDetailsSummary,
@@ -124,6 +144,13 @@ resource_manager_type_mapping = {
     "StackResourceDriftCollection": StackResourceDriftCollection,
     "StackResourceDriftSummary": StackResourceDriftSummary,
     "StackSummary": StackSummary,
+    "Template": Template,
+    "TemplateCategorySummary": TemplateCategorySummary,
+    "TemplateCategorySummaryCollection": TemplateCategorySummaryCollection,
+    "TemplateConfigSource": TemplateConfigSource,
+    "TemplateSummary": TemplateSummary,
+    "TemplateSummaryCollection": TemplateSummaryCollection,
+    "TemplateZipUploadConfigSource": TemplateZipUploadConfigSource,
     "TerraformVersionCollection": TerraformVersionCollection,
     "TerraformVersionSummary": TerraformVersionSummary,
     "UpdateConfigSourceDetails": UpdateConfigSourceDetails,
@@ -133,6 +160,9 @@ resource_manager_type_mapping = {
     "UpdateGitlabAccessTokenConfigurationSourceProviderDetails": UpdateGitlabAccessTokenConfigurationSourceProviderDetails,
     "UpdateJobDetails": UpdateJobDetails,
     "UpdateStackDetails": UpdateStackDetails,
+    "UpdateTemplateConfigSourceDetails": UpdateTemplateConfigSourceDetails,
+    "UpdateTemplateDetails": UpdateTemplateDetails,
+    "UpdateTemplateZipUploadConfigSourceDetails": UpdateTemplateZipUploadConfigSourceDetails,
     "UpdateZipUploadConfigSourceDetails": UpdateZipUploadConfigSourceDetails,
     "WorkRequest": WorkRequest,
     "WorkRequestError": WorkRequestError,

--- a/src/oci/resource_manager/models/change_template_compartment_details.py
+++ b/src/oci/resource_manager/models/change_template_compartment_details.py
@@ -1,0 +1,76 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ChangeTemplateCompartmentDetails(object):
+    """
+    The details for moving a template to a different compartment.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ChangeTemplateCompartmentDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ChangeTemplateCompartmentDetails.
+        :type compartment_id: str
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId'
+        }
+
+        self._compartment_id = None
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this ChangeTemplateCompartmentDetails.
+        The `OCID`__ of the compartment
+        to move the configuration source provider to.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this ChangeTemplateCompartmentDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this ChangeTemplateCompartmentDetails.
+        The `OCID`__ of the compartment
+        to move the configuration source provider to.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this ChangeTemplateCompartmentDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/resource_manager/models/create_config_source_details.py
+++ b/src/oci/resource_manager/models/create_config_source_details.py
@@ -21,6 +21,7 @@ class CreateConfigSourceDetails(object):
         * :class:`~oci.resource_manager.models.CreateZipUploadConfigSourceDetails`
         * :class:`~oci.resource_manager.models.CreateGitConfigSourceDetails`
         * :class:`~oci.resource_manager.models.CreateCompartmentConfigSourceDetails`
+        * :class:`~oci.resource_manager.models.CreateStackTemplateConfigSourceDetails`
 
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
@@ -62,6 +63,9 @@ class CreateConfigSourceDetails(object):
 
         if type == 'COMPARTMENT_CONFIG_SOURCE':
             return 'CreateCompartmentConfigSourceDetails'
+
+        if type == 'TEMPLATE_CONFIG_SOURCE':
+            return 'CreateStackTemplateConfigSourceDetails'
         else:
             return 'CreateConfigSourceDetails'
 

--- a/src/oci/resource_manager/models/create_stack_template_config_source_details.py
+++ b/src/oci/resource_manager/models/create_stack_template_config_source_details.py
@@ -1,0 +1,82 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .create_config_source_details import CreateConfigSourceDetails
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateStackTemplateConfigSourceDetails(CreateConfigSourceDetails):
+    """
+    The template to use as the source of the Terraform configuration.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateStackTemplateConfigSourceDetails object with values from keyword arguments. The default value of the :py:attr:`~oci.resource_manager.models.CreateStackTemplateConfigSourceDetails.config_source_type` attribute
+        of this class is ``TEMPLATE_CONFIG_SOURCE`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param config_source_type:
+            The value to assign to the config_source_type property of this CreateStackTemplateConfigSourceDetails.
+        :type config_source_type: str
+
+        :param working_directory:
+            The value to assign to the working_directory property of this CreateStackTemplateConfigSourceDetails.
+        :type working_directory: str
+
+        :param template_id:
+            The value to assign to the template_id property of this CreateStackTemplateConfigSourceDetails.
+        :type template_id: str
+
+        """
+        self.swagger_types = {
+            'config_source_type': 'str',
+            'working_directory': 'str',
+            'template_id': 'str'
+        }
+
+        self.attribute_map = {
+            'config_source_type': 'configSourceType',
+            'working_directory': 'workingDirectory',
+            'template_id': 'templateId'
+        }
+
+        self._config_source_type = None
+        self._working_directory = None
+        self._template_id = None
+        self._config_source_type = 'TEMPLATE_CONFIG_SOURCE'
+
+    @property
+    def template_id(self):
+        """
+        **[Required]** Gets the template_id of this CreateStackTemplateConfigSourceDetails.
+
+        :return: The template_id of this CreateStackTemplateConfigSourceDetails.
+        :rtype: str
+        """
+        return self._template_id
+
+    @template_id.setter
+    def template_id(self, template_id):
+        """
+        Sets the template_id of this CreateStackTemplateConfigSourceDetails.
+
+        :param template_id: The template_id of this CreateStackTemplateConfigSourceDetails.
+        :type: str
+        """
+        self._template_id = template_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/resource_manager/models/create_template_config_source_details.py
+++ b/src/oci/resource_manager/models/create_template_config_source_details.py
@@ -1,0 +1,87 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateTemplateConfigSourceDetails(object):
+    """
+    Property details for the configuration source used for the template.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateTemplateConfigSourceDetails object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
+        to a service operations then you should favor using a subclass over the base class:
+
+        * :class:`~oci.resource_manager.models.CreateTemplateZipUploadConfigSourceDetails`
+
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param template_config_source_type:
+            The value to assign to the template_config_source_type property of this CreateTemplateConfigSourceDetails.
+        :type template_config_source_type: str
+
+        """
+        self.swagger_types = {
+            'template_config_source_type': 'str'
+        }
+
+        self.attribute_map = {
+            'template_config_source_type': 'templateConfigSourceType'
+        }
+
+        self._template_config_source_type = None
+
+    @staticmethod
+    def get_subtype(object_dictionary):
+        """
+        Given the hash representation of a subtype of this class,
+        use the info in the hash to return the class of the subtype.
+        """
+        type = object_dictionary['templateConfigSourceType']
+
+        if type == 'ZIP_UPLOAD':
+            return 'CreateTemplateZipUploadConfigSourceDetails'
+        else:
+            return 'CreateTemplateConfigSourceDetails'
+
+    @property
+    def template_config_source_type(self):
+        """
+        **[Required]** Gets the template_config_source_type of this CreateTemplateConfigSourceDetails.
+        Specifies the `configSourceType` for uploading the Terraform configuration.
+
+
+        :return: The template_config_source_type of this CreateTemplateConfigSourceDetails.
+        :rtype: str
+        """
+        return self._template_config_source_type
+
+    @template_config_source_type.setter
+    def template_config_source_type(self, template_config_source_type):
+        """
+        Sets the template_config_source_type of this CreateTemplateConfigSourceDetails.
+        Specifies the `configSourceType` for uploading the Terraform configuration.
+
+
+        :param template_config_source_type: The template_config_source_type of this CreateTemplateConfigSourceDetails.
+        :type: str
+        """
+        self._template_config_source_type = template_config_source_type
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/resource_manager/models/create_template_details.py
+++ b/src/oci/resource_manager/models/create_template_details.py
@@ -1,0 +1,303 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateTemplateDetails(object):
+    """
+    The configuration details for creating a template.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateTemplateDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this CreateTemplateDetails.
+        :type compartment_id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this CreateTemplateDetails.
+        :type display_name: str
+
+        :param description:
+            The value to assign to the description property of this CreateTemplateDetails.
+        :type description: str
+
+        :param long_description:
+            The value to assign to the long_description property of this CreateTemplateDetails.
+        :type long_description: str
+
+        :param logo_file_base64_encoded:
+            The value to assign to the logo_file_base64_encoded property of this CreateTemplateDetails.
+        :type logo_file_base64_encoded: str
+
+        :param template_config_source:
+            The value to assign to the template_config_source property of this CreateTemplateDetails.
+        :type template_config_source: oci.resource_manager.models.CreateTemplateConfigSourceDetails
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this CreateTemplateDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this CreateTemplateDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str',
+            'display_name': 'str',
+            'description': 'str',
+            'long_description': 'str',
+            'logo_file_base64_encoded': 'str',
+            'template_config_source': 'CreateTemplateConfigSourceDetails',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId',
+            'display_name': 'displayName',
+            'description': 'description',
+            'long_description': 'longDescription',
+            'logo_file_base64_encoded': 'logoFileBase64Encoded',
+            'template_config_source': 'templateConfigSource',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._compartment_id = None
+        self._display_name = None
+        self._description = None
+        self._long_description = None
+        self._logo_file_base64_encoded = None
+        self._template_config_source = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this CreateTemplateDetails.
+        The `OCID`__ of the compartment containing this template.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this CreateTemplateDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this CreateTemplateDetails.
+        The `OCID`__ of the compartment containing this template.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this CreateTemplateDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this CreateTemplateDetails.
+        The template's display name. Avoid entering confidential information.
+
+
+        :return: The display_name of this CreateTemplateDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this CreateTemplateDetails.
+        The template's display name. Avoid entering confidential information.
+
+
+        :param display_name: The display_name of this CreateTemplateDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def description(self):
+        """
+        **[Required]** Gets the description of this CreateTemplateDetails.
+        Description of the template. Avoid entering confidential information.
+
+
+        :return: The description of this CreateTemplateDetails.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this CreateTemplateDetails.
+        Description of the template. Avoid entering confidential information.
+
+
+        :param description: The description of this CreateTemplateDetails.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def long_description(self):
+        """
+        Gets the long_description of this CreateTemplateDetails.
+        Detailed description of the template. This description is displayed in the Console page listing templates when the template is expanded. Avoid entering confidential information.
+
+
+        :return: The long_description of this CreateTemplateDetails.
+        :rtype: str
+        """
+        return self._long_description
+
+    @long_description.setter
+    def long_description(self, long_description):
+        """
+        Sets the long_description of this CreateTemplateDetails.
+        Detailed description of the template. This description is displayed in the Console page listing templates when the template is expanded. Avoid entering confidential information.
+
+
+        :param long_description: The long_description of this CreateTemplateDetails.
+        :type: str
+        """
+        self._long_description = long_description
+
+    @property
+    def logo_file_base64_encoded(self):
+        """
+        Gets the logo_file_base64_encoded of this CreateTemplateDetails.
+        Base64-encoded logo for the template.
+
+
+        :return: The logo_file_base64_encoded of this CreateTemplateDetails.
+        :rtype: str
+        """
+        return self._logo_file_base64_encoded
+
+    @logo_file_base64_encoded.setter
+    def logo_file_base64_encoded(self, logo_file_base64_encoded):
+        """
+        Sets the logo_file_base64_encoded of this CreateTemplateDetails.
+        Base64-encoded logo for the template.
+
+
+        :param logo_file_base64_encoded: The logo_file_base64_encoded of this CreateTemplateDetails.
+        :type: str
+        """
+        self._logo_file_base64_encoded = logo_file_base64_encoded
+
+    @property
+    def template_config_source(self):
+        """
+        **[Required]** Gets the template_config_source of this CreateTemplateDetails.
+
+        :return: The template_config_source of this CreateTemplateDetails.
+        :rtype: oci.resource_manager.models.CreateTemplateConfigSourceDetails
+        """
+        return self._template_config_source
+
+    @template_config_source.setter
+    def template_config_source(self, template_config_source):
+        """
+        Sets the template_config_source of this CreateTemplateDetails.
+
+        :param template_config_source: The template_config_source of this CreateTemplateDetails.
+        :type: oci.resource_manager.models.CreateTemplateConfigSourceDetails
+        """
+        self._template_config_source = template_config_source
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this CreateTemplateDetails.
+        Free-form tags associated with the resource. Each tag is a key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this CreateTemplateDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this CreateTemplateDetails.
+        Free-form tags associated with the resource. Each tag is a key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this CreateTemplateDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this CreateTemplateDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this CreateTemplateDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this CreateTemplateDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this CreateTemplateDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/resource_manager/models/create_template_zip_upload_config_source_details.py
+++ b/src/oci/resource_manager/models/create_template_zip_upload_config_source_details.py
@@ -1,0 +1,75 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .create_template_config_source_details import CreateTemplateConfigSourceDetails
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateTemplateZipUploadConfigSourceDetails(CreateTemplateConfigSourceDetails):
+    """
+    Property details for uploading the zip file for template.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateTemplateZipUploadConfigSourceDetails object with values from keyword arguments. The default value of the :py:attr:`~oci.resource_manager.models.CreateTemplateZipUploadConfigSourceDetails.template_config_source_type` attribute
+        of this class is ``ZIP_UPLOAD`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param template_config_source_type:
+            The value to assign to the template_config_source_type property of this CreateTemplateZipUploadConfigSourceDetails.
+        :type template_config_source_type: str
+
+        :param zip_file_base64_encoded:
+            The value to assign to the zip_file_base64_encoded property of this CreateTemplateZipUploadConfigSourceDetails.
+        :type zip_file_base64_encoded: str
+
+        """
+        self.swagger_types = {
+            'template_config_source_type': 'str',
+            'zip_file_base64_encoded': 'str'
+        }
+
+        self.attribute_map = {
+            'template_config_source_type': 'templateConfigSourceType',
+            'zip_file_base64_encoded': 'zipFileBase64Encoded'
+        }
+
+        self._template_config_source_type = None
+        self._zip_file_base64_encoded = None
+        self._template_config_source_type = 'ZIP_UPLOAD'
+
+    @property
+    def zip_file_base64_encoded(self):
+        """
+        **[Required]** Gets the zip_file_base64_encoded of this CreateTemplateZipUploadConfigSourceDetails.
+
+        :return: The zip_file_base64_encoded of this CreateTemplateZipUploadConfigSourceDetails.
+        :rtype: str
+        """
+        return self._zip_file_base64_encoded
+
+    @zip_file_base64_encoded.setter
+    def zip_file_base64_encoded(self, zip_file_base64_encoded):
+        """
+        Sets the zip_file_base64_encoded of this CreateTemplateZipUploadConfigSourceDetails.
+
+        :param zip_file_base64_encoded: The zip_file_base64_encoded of this CreateTemplateZipUploadConfigSourceDetails.
+        :type: str
+        """
+        self._zip_file_base64_encoded = zip_file_base64_encoded
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/resource_manager/models/template.py
+++ b/src/oci/resource_manager/models/template.py
@@ -1,0 +1,416 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class Template(object):
+    """
+    The properties that define a template. A template is a pre-built Terraform configuration that provisions a set of resources used in a common scenario.
+    """
+
+    #: A constant which can be used with the lifecycle_state property of a Template.
+    #: This constant has a value of "ACTIVE"
+    LIFECYCLE_STATE_ACTIVE = "ACTIVE"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new Template object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this Template.
+        :type id: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this Template.
+        :type compartment_id: str
+
+        :param category_id:
+            The value to assign to the category_id property of this Template.
+        :type category_id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this Template.
+        :type display_name: str
+
+        :param description:
+            The value to assign to the description property of this Template.
+        :type description: str
+
+        :param long_description:
+            The value to assign to the long_description property of this Template.
+        :type long_description: str
+
+        :param time_created:
+            The value to assign to the time_created property of this Template.
+        :type time_created: datetime
+
+        :param template_config_source:
+            The value to assign to the template_config_source property of this Template.
+        :type template_config_source: oci.resource_manager.models.TemplateConfigSource
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this Template.
+            Allowed values for this property are: "ACTIVE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this Template.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this Template.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'compartment_id': 'str',
+            'category_id': 'str',
+            'display_name': 'str',
+            'description': 'str',
+            'long_description': 'str',
+            'time_created': 'datetime',
+            'template_config_source': 'TemplateConfigSource',
+            'lifecycle_state': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'compartment_id': 'compartmentId',
+            'category_id': 'categoryId',
+            'display_name': 'displayName',
+            'description': 'description',
+            'long_description': 'longDescription',
+            'time_created': 'timeCreated',
+            'template_config_source': 'templateConfigSource',
+            'lifecycle_state': 'lifecycleState',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._id = None
+        self._compartment_id = None
+        self._category_id = None
+        self._display_name = None
+        self._description = None
+        self._long_description = None
+        self._time_created = None
+        self._template_config_source = None
+        self._lifecycle_state = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this Template.
+        Unique identifier (`OCID`__) for the template.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :return: The id of this Template.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this Template.
+        Unique identifier (`OCID`__) for the template.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :param id: The id of this Template.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def compartment_id(self):
+        """
+        Gets the compartment_id of this Template.
+        The `OCID`__ of the compartment containing this template.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this Template.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this Template.
+        The `OCID`__ of the compartment containing this template.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this Template.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def category_id(self):
+        """
+        Gets the category_id of this Template.
+        Unique identifier for the category where the template is located.
+
+
+        :return: The category_id of this Template.
+        :rtype: str
+        """
+        return self._category_id
+
+    @category_id.setter
+    def category_id(self, category_id):
+        """
+        Sets the category_id of this Template.
+        Unique identifier for the category where the template is located.
+
+
+        :param category_id: The category_id of this Template.
+        :type: str
+        """
+        self._category_id = category_id
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this Template.
+        Human-readable name of the template.
+
+
+        :return: The display_name of this Template.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this Template.
+        Human-readable name of the template.
+
+
+        :param display_name: The display_name of this Template.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def description(self):
+        """
+        Gets the description of this Template.
+        Brief description of the template.
+
+
+        :return: The description of this Template.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this Template.
+        Brief description of the template.
+
+
+        :param description: The description of this Template.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def long_description(self):
+        """
+        Gets the long_description of this Template.
+        Detailed description of the template. This description is displayed in the Console page listing templates when the template is expanded. Avoid entering confidential information.
+
+
+        :return: The long_description of this Template.
+        :rtype: str
+        """
+        return self._long_description
+
+    @long_description.setter
+    def long_description(self, long_description):
+        """
+        Sets the long_description of this Template.
+        Detailed description of the template. This description is displayed in the Console page listing templates when the template is expanded. Avoid entering confidential information.
+
+
+        :param long_description: The long_description of this Template.
+        :type: str
+        """
+        self._long_description = long_description
+
+    @property
+    def time_created(self):
+        """
+        Gets the time_created of this Template.
+        The date and time at which the template was created.
+        Format is defined by RFC3339.
+        Example: `2020-11-25T21:10:29.600Z`
+
+
+        :return: The time_created of this Template.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this Template.
+        The date and time at which the template was created.
+        Format is defined by RFC3339.
+        Example: `2020-11-25T21:10:29.600Z`
+
+
+        :param time_created: The time_created of this Template.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def template_config_source(self):
+        """
+        Gets the template_config_source of this Template.
+
+        :return: The template_config_source of this Template.
+        :rtype: oci.resource_manager.models.TemplateConfigSource
+        """
+        return self._template_config_source
+
+    @template_config_source.setter
+    def template_config_source(self, template_config_source):
+        """
+        Sets the template_config_source of this Template.
+
+        :param template_config_source: The template_config_source of this Template.
+        :type: oci.resource_manager.models.TemplateConfigSource
+        """
+        self._template_config_source = template_config_source
+
+    @property
+    def lifecycle_state(self):
+        """
+        Gets the lifecycle_state of this Template.
+        The current lifecycle state of the template.
+
+        Allowed values for this property are: "ACTIVE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this Template.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this Template.
+        The current lifecycle state of the template.
+
+
+        :param lifecycle_state: The lifecycle_state of this Template.
+        :type: str
+        """
+        allowed_values = ["ACTIVE"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this Template.
+        Free-form tags associated with the resource. Each tag is a key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this Template.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this Template.
+        Free-form tags associated with the resource. Each tag is a key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this Template.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this Template.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this Template.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this Template.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this Template.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/resource_manager/models/template_category_summary.py
+++ b/src/oci/resource_manager/models/template_category_summary.py
@@ -1,0 +1,101 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class TemplateCategorySummary(object):
+    """
+    Summary information for the template category.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new TemplateCategorySummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this TemplateCategorySummary.
+        :type id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this TemplateCategorySummary.
+        :type display_name: str
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'display_name': 'str'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'display_name': 'displayName'
+        }
+
+        self._id = None
+        self._display_name = None
+
+    @property
+    def id(self):
+        """
+        Gets the id of this TemplateCategorySummary.
+        Unique identifier for the template category.
+
+
+        :return: The id of this TemplateCategorySummary.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this TemplateCategorySummary.
+        Unique identifier for the template category.
+
+
+        :param id: The id of this TemplateCategorySummary.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this TemplateCategorySummary.
+        The name of the template category.
+
+
+        :return: The display_name of this TemplateCategorySummary.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this TemplateCategorySummary.
+        The name of the template category.
+
+
+        :param display_name: The display_name of this TemplateCategorySummary.
+        :type: str
+        """
+        self._display_name = display_name
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/resource_manager/models/template_category_summary_collection.py
+++ b/src/oci/resource_manager/models/template_category_summary_collection.py
@@ -1,0 +1,70 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class TemplateCategorySummaryCollection(object):
+    """
+    Results of a `ListTemplateCategories` operation.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new TemplateCategorySummaryCollection object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param items:
+            The value to assign to the items property of this TemplateCategorySummaryCollection.
+        :type items: list[oci.resource_manager.models.TemplateCategorySummary]
+
+        """
+        self.swagger_types = {
+            'items': 'list[TemplateCategorySummary]'
+        }
+
+        self.attribute_map = {
+            'items': 'items'
+        }
+
+        self._items = None
+
+    @property
+    def items(self):
+        """
+        **[Required]** Gets the items of this TemplateCategorySummaryCollection.
+        A list of template categories.
+
+
+        :return: The items of this TemplateCategorySummaryCollection.
+        :rtype: list[oci.resource_manager.models.TemplateCategorySummary]
+        """
+        return self._items
+
+    @items.setter
+    def items(self, items):
+        """
+        Sets the items of this TemplateCategorySummaryCollection.
+        A list of template categories.
+
+
+        :param items: The items of this TemplateCategorySummaryCollection.
+        :type: list[oci.resource_manager.models.TemplateCategorySummary]
+        """
+        self._items = items
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/resource_manager/models/template_config_source.py
+++ b/src/oci/resource_manager/models/template_config_source.py
@@ -1,0 +1,99 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class TemplateConfigSource(object):
+    """
+    Information about the Template.
+    """
+
+    #: A constant which can be used with the template_config_source_type property of a TemplateConfigSource.
+    #: This constant has a value of "ZIP_UPLOAD"
+    TEMPLATE_CONFIG_SOURCE_TYPE_ZIP_UPLOAD = "ZIP_UPLOAD"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new TemplateConfigSource object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
+        to a service operations then you should favor using a subclass over the base class:
+
+        * :class:`~oci.resource_manager.models.TemplateZipUploadConfigSource`
+
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param template_config_source_type:
+            The value to assign to the template_config_source_type property of this TemplateConfigSource.
+            Allowed values for this property are: "ZIP_UPLOAD", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type template_config_source_type: str
+
+        """
+        self.swagger_types = {
+            'template_config_source_type': 'str'
+        }
+
+        self.attribute_map = {
+            'template_config_source_type': 'templateConfigSourceType'
+        }
+
+        self._template_config_source_type = None
+
+    @staticmethod
+    def get_subtype(object_dictionary):
+        """
+        Given the hash representation of a subtype of this class,
+        use the info in the hash to return the class of the subtype.
+        """
+        type = object_dictionary['templateConfigSourceType']
+
+        if type == 'ZIP_UPLOAD':
+            return 'TemplateZipUploadConfigSource'
+        else:
+            return 'TemplateConfigSource'
+
+    @property
+    def template_config_source_type(self):
+        """
+        **[Required]** Gets the template_config_source_type of this TemplateConfigSource.
+        The type of configuration source to use for the template configuration.
+
+        Allowed values for this property are: "ZIP_UPLOAD", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The template_config_source_type of this TemplateConfigSource.
+        :rtype: str
+        """
+        return self._template_config_source_type
+
+    @template_config_source_type.setter
+    def template_config_source_type(self, template_config_source_type):
+        """
+        Sets the template_config_source_type of this TemplateConfigSource.
+        The type of configuration source to use for the template configuration.
+
+
+        :param template_config_source_type: The template_config_source_type of this TemplateConfigSource.
+        :type: str
+        """
+        allowed_values = ["ZIP_UPLOAD"]
+        if not value_allowed_none_or_none_sentinel(template_config_source_type, allowed_values):
+            template_config_source_type = 'UNKNOWN_ENUM_VALUE'
+        self._template_config_source_type = template_config_source_type
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/resource_manager/models/template_summary.py
+++ b/src/oci/resource_manager/models/template_summary.py
@@ -1,0 +1,237 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class TemplateSummary(object):
+    """
+    Summary information for a template.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new TemplateSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this TemplateSummary.
+        :type id: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this TemplateSummary.
+        :type compartment_id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this TemplateSummary.
+        :type display_name: str
+
+        :param description:
+            The value to assign to the description property of this TemplateSummary.
+        :type description: str
+
+        :param time_created:
+            The value to assign to the time_created property of this TemplateSummary.
+        :type time_created: datetime
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this TemplateSummary.
+        :type lifecycle_state: str
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'compartment_id': 'str',
+            'display_name': 'str',
+            'description': 'str',
+            'time_created': 'datetime',
+            'lifecycle_state': 'str'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'compartment_id': 'compartmentId',
+            'display_name': 'displayName',
+            'description': 'description',
+            'time_created': 'timeCreated',
+            'lifecycle_state': 'lifecycleState'
+        }
+
+        self._id = None
+        self._compartment_id = None
+        self._display_name = None
+        self._description = None
+        self._time_created = None
+        self._lifecycle_state = None
+
+    @property
+    def id(self):
+        """
+        Gets the id of this TemplateSummary.
+        Unique identifier of the specified template.
+
+
+        :return: The id of this TemplateSummary.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this TemplateSummary.
+        Unique identifier of the specified template.
+
+
+        :param id: The id of this TemplateSummary.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def compartment_id(self):
+        """
+        Gets the compartment_id of this TemplateSummary.
+        The `OCID`__ of the compartment containing this template.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this TemplateSummary.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this TemplateSummary.
+        The `OCID`__ of the compartment containing this template.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this TemplateSummary.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this TemplateSummary.
+        Human-readable display name for the template.
+
+
+        :return: The display_name of this TemplateSummary.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this TemplateSummary.
+        Human-readable display name for the template.
+
+
+        :param display_name: The display_name of this TemplateSummary.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def description(self):
+        """
+        Gets the description of this TemplateSummary.
+        Brief description of the template.
+
+
+        :return: The description of this TemplateSummary.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this TemplateSummary.
+        Brief description of the template.
+
+
+        :param description: The description of this TemplateSummary.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def time_created(self):
+        """
+        Gets the time_created of this TemplateSummary.
+        The date and time at which the template was created.
+        Format is defined by RFC3339.
+        Example: `2020-11-25T21:10:29.600Z`
+
+
+        :return: The time_created of this TemplateSummary.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this TemplateSummary.
+        The date and time at which the template was created.
+        Format is defined by RFC3339.
+        Example: `2020-11-25T21:10:29.600Z`
+
+
+        :param time_created: The time_created of this TemplateSummary.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def lifecycle_state(self):
+        """
+        Gets the lifecycle_state of this TemplateSummary.
+        The current lifecycle state of the template.
+        Allowable values:
+        - ACTIVE
+
+
+        :return: The lifecycle_state of this TemplateSummary.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this TemplateSummary.
+        The current lifecycle state of the template.
+        Allowable values:
+        - ACTIVE
+
+
+        :param lifecycle_state: The lifecycle_state of this TemplateSummary.
+        :type: str
+        """
+        self._lifecycle_state = lifecycle_state
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/resource_manager/models/template_summary_collection.py
+++ b/src/oci/resource_manager/models/template_summary_collection.py
@@ -1,0 +1,70 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class TemplateSummaryCollection(object):
+    """
+    Results of a `ListTemplates` operation.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new TemplateSummaryCollection object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param items:
+            The value to assign to the items property of this TemplateSummaryCollection.
+        :type items: list[oci.resource_manager.models.TemplateSummary]
+
+        """
+        self.swagger_types = {
+            'items': 'list[TemplateSummary]'
+        }
+
+        self.attribute_map = {
+            'items': 'items'
+        }
+
+        self._items = None
+
+    @property
+    def items(self):
+        """
+        **[Required]** Gets the items of this TemplateSummaryCollection.
+        A list of template summaries.
+
+
+        :return: The items of this TemplateSummaryCollection.
+        :rtype: list[oci.resource_manager.models.TemplateSummary]
+        """
+        return self._items
+
+    @items.setter
+    def items(self, items):
+        """
+        Sets the items of this TemplateSummaryCollection.
+        A list of template summaries.
+
+
+        :param items: The items of this TemplateSummaryCollection.
+        :type: list[oci.resource_manager.models.TemplateSummary]
+        """
+        self._items = items
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/resource_manager/models/template_zip_upload_config_source.py
+++ b/src/oci/resource_manager/models/template_zip_upload_config_source.py
@@ -1,0 +1,49 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .template_config_source import TemplateConfigSource
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class TemplateZipUploadConfigSource(TemplateConfigSource):
+    """
+    Metadata about the user-provided Terraform configuration.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new TemplateZipUploadConfigSource object with values from keyword arguments. The default value of the :py:attr:`~oci.resource_manager.models.TemplateZipUploadConfigSource.template_config_source_type` attribute
+        of this class is ``ZIP_UPLOAD`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param template_config_source_type:
+            The value to assign to the template_config_source_type property of this TemplateZipUploadConfigSource.
+            Allowed values for this property are: "ZIP_UPLOAD"
+        :type template_config_source_type: str
+
+        """
+        self.swagger_types = {
+            'template_config_source_type': 'str'
+        }
+
+        self.attribute_map = {
+            'template_config_source_type': 'templateConfigSourceType'
+        }
+
+        self._template_config_source_type = None
+        self._template_config_source_type = 'ZIP_UPLOAD'
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/resource_manager/models/update_template_config_source_details.py
+++ b/src/oci/resource_manager/models/update_template_config_source_details.py
@@ -1,0 +1,87 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateTemplateConfigSourceDetails(object):
+    """
+    Updates the property details for the configuration source for the template.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateTemplateConfigSourceDetails object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
+        to a service operations then you should favor using a subclass over the base class:
+
+        * :class:`~oci.resource_manager.models.UpdateTemplateZipUploadConfigSourceDetails`
+
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param template_config_source_type:
+            The value to assign to the template_config_source_type property of this UpdateTemplateConfigSourceDetails.
+        :type template_config_source_type: str
+
+        """
+        self.swagger_types = {
+            'template_config_source_type': 'str'
+        }
+
+        self.attribute_map = {
+            'template_config_source_type': 'templateConfigSourceType'
+        }
+
+        self._template_config_source_type = None
+
+    @staticmethod
+    def get_subtype(object_dictionary):
+        """
+        Given the hash representation of a subtype of this class,
+        use the info in the hash to return the class of the subtype.
+        """
+        type = object_dictionary['templateConfigSourceType']
+
+        if type == 'ZIP_UPLOAD':
+            return 'UpdateTemplateZipUploadConfigSourceDetails'
+        else:
+            return 'UpdateTemplateConfigSourceDetails'
+
+    @property
+    def template_config_source_type(self):
+        """
+        **[Required]** Gets the template_config_source_type of this UpdateTemplateConfigSourceDetails.
+        Specifies the `configSourceType` for uploading the Terraform configuration.
+
+
+        :return: The template_config_source_type of this UpdateTemplateConfigSourceDetails.
+        :rtype: str
+        """
+        return self._template_config_source_type
+
+    @template_config_source_type.setter
+    def template_config_source_type(self, template_config_source_type):
+        """
+        Sets the template_config_source_type of this UpdateTemplateConfigSourceDetails.
+        Specifies the `configSourceType` for uploading the Terraform configuration.
+
+
+        :param template_config_source_type: The template_config_source_type of this UpdateTemplateConfigSourceDetails.
+        :type: str
+        """
+        self._template_config_source_type = template_config_source_type
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/resource_manager/models/update_template_details.py
+++ b/src/oci/resource_manager/models/update_template_details.py
@@ -1,0 +1,268 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateTemplateDetails(object):
+    """
+    Updates the specified template.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateTemplateDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this UpdateTemplateDetails.
+        :type display_name: str
+
+        :param description:
+            The value to assign to the description property of this UpdateTemplateDetails.
+        :type description: str
+
+        :param long_description:
+            The value to assign to the long_description property of this UpdateTemplateDetails.
+        :type long_description: str
+
+        :param logo_file_base64_encoded:
+            The value to assign to the logo_file_base64_encoded property of this UpdateTemplateDetails.
+        :type logo_file_base64_encoded: str
+
+        :param template_config_source:
+            The value to assign to the template_config_source property of this UpdateTemplateDetails.
+        :type template_config_source: oci.resource_manager.models.UpdateTemplateConfigSourceDetails
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this UpdateTemplateDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this UpdateTemplateDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'description': 'str',
+            'long_description': 'str',
+            'logo_file_base64_encoded': 'str',
+            'template_config_source': 'UpdateTemplateConfigSourceDetails',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'description': 'description',
+            'long_description': 'longDescription',
+            'logo_file_base64_encoded': 'logoFileBase64Encoded',
+            'template_config_source': 'templateConfigSource',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._display_name = None
+        self._description = None
+        self._long_description = None
+        self._logo_file_base64_encoded = None
+        self._template_config_source = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this UpdateTemplateDetails.
+        The template's display name. Avoid entering confidential information.
+
+
+        :return: The display_name of this UpdateTemplateDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this UpdateTemplateDetails.
+        The template's display name. Avoid entering confidential information.
+
+
+        :param display_name: The display_name of this UpdateTemplateDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def description(self):
+        """
+        Gets the description of this UpdateTemplateDetails.
+        Description of the template. Avoid entering confidential information.
+
+
+        :return: The description of this UpdateTemplateDetails.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this UpdateTemplateDetails.
+        Description of the template. Avoid entering confidential information.
+
+
+        :param description: The description of this UpdateTemplateDetails.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def long_description(self):
+        """
+        Gets the long_description of this UpdateTemplateDetails.
+        Detailed description of the template. This description is displayed in the Console page listing templates when the template is expanded. Avoid entering confidential information.
+
+
+        :return: The long_description of this UpdateTemplateDetails.
+        :rtype: str
+        """
+        return self._long_description
+
+    @long_description.setter
+    def long_description(self, long_description):
+        """
+        Sets the long_description of this UpdateTemplateDetails.
+        Detailed description of the template. This description is displayed in the Console page listing templates when the template is expanded. Avoid entering confidential information.
+
+
+        :param long_description: The long_description of this UpdateTemplateDetails.
+        :type: str
+        """
+        self._long_description = long_description
+
+    @property
+    def logo_file_base64_encoded(self):
+        """
+        Gets the logo_file_base64_encoded of this UpdateTemplateDetails.
+        Base64-encoded logo for the template.
+
+
+        :return: The logo_file_base64_encoded of this UpdateTemplateDetails.
+        :rtype: str
+        """
+        return self._logo_file_base64_encoded
+
+    @logo_file_base64_encoded.setter
+    def logo_file_base64_encoded(self, logo_file_base64_encoded):
+        """
+        Sets the logo_file_base64_encoded of this UpdateTemplateDetails.
+        Base64-encoded logo for the template.
+
+
+        :param logo_file_base64_encoded: The logo_file_base64_encoded of this UpdateTemplateDetails.
+        :type: str
+        """
+        self._logo_file_base64_encoded = logo_file_base64_encoded
+
+    @property
+    def template_config_source(self):
+        """
+        Gets the template_config_source of this UpdateTemplateDetails.
+
+        :return: The template_config_source of this UpdateTemplateDetails.
+        :rtype: oci.resource_manager.models.UpdateTemplateConfigSourceDetails
+        """
+        return self._template_config_source
+
+    @template_config_source.setter
+    def template_config_source(self, template_config_source):
+        """
+        Sets the template_config_source of this UpdateTemplateDetails.
+
+        :param template_config_source: The template_config_source of this UpdateTemplateDetails.
+        :type: oci.resource_manager.models.UpdateTemplateConfigSourceDetails
+        """
+        self._template_config_source = template_config_source
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this UpdateTemplateDetails.
+        Free-form tags associated with the resource. Each tag is a key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this UpdateTemplateDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this UpdateTemplateDetails.
+        Free-form tags associated with the resource. Each tag is a key-value pair with no predefined name, type, or namespace.
+        For more information, see `Resource Tags`__.
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this UpdateTemplateDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this UpdateTemplateDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this UpdateTemplateDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this UpdateTemplateDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this UpdateTemplateDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/resource_manager/models/update_template_zip_upload_config_source_details.py
+++ b/src/oci/resource_manager/models/update_template_zip_upload_config_source_details.py
@@ -1,0 +1,75 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .update_template_config_source_details import UpdateTemplateConfigSourceDetails
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateTemplateZipUploadConfigSourceDetails(UpdateTemplateConfigSourceDetails):
+    """
+    Updates property details for the configuration .zip file.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateTemplateZipUploadConfigSourceDetails object with values from keyword arguments. The default value of the :py:attr:`~oci.resource_manager.models.UpdateTemplateZipUploadConfigSourceDetails.template_config_source_type` attribute
+        of this class is ``ZIP_UPLOAD`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param template_config_source_type:
+            The value to assign to the template_config_source_type property of this UpdateTemplateZipUploadConfigSourceDetails.
+        :type template_config_source_type: str
+
+        :param zip_file_base64_encoded:
+            The value to assign to the zip_file_base64_encoded property of this UpdateTemplateZipUploadConfigSourceDetails.
+        :type zip_file_base64_encoded: str
+
+        """
+        self.swagger_types = {
+            'template_config_source_type': 'str',
+            'zip_file_base64_encoded': 'str'
+        }
+
+        self.attribute_map = {
+            'template_config_source_type': 'templateConfigSourceType',
+            'zip_file_base64_encoded': 'zipFileBase64Encoded'
+        }
+
+        self._template_config_source_type = None
+        self._zip_file_base64_encoded = None
+        self._template_config_source_type = 'ZIP_UPLOAD'
+
+    @property
+    def zip_file_base64_encoded(self):
+        """
+        Gets the zip_file_base64_encoded of this UpdateTemplateZipUploadConfigSourceDetails.
+
+        :return: The zip_file_base64_encoded of this UpdateTemplateZipUploadConfigSourceDetails.
+        :rtype: str
+        """
+        return self._zip_file_base64_encoded
+
+    @zip_file_base64_encoded.setter
+    def zip_file_base64_encoded(self, zip_file_base64_encoded):
+        """
+        Sets the zip_file_base64_encoded of this UpdateTemplateZipUploadConfigSourceDetails.
+
+        :param zip_file_base64_encoded: The zip_file_base64_encoded of this UpdateTemplateZipUploadConfigSourceDetails.
+        :type: str
+        """
+        self._zip_file_base64_encoded = zip_file_base64_encoded
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/resource_manager/resource_manager_client.py
+++ b/src/oci/resource_manager/resource_manager_client.py
@@ -375,6 +375,109 @@ class ResourceManagerClient(object):
                 header_params=header_params,
                 body=change_stack_compartment_details)
 
+    def change_template_compartment(self, template_id, change_template_compartment_details, **kwargs):
+        """
+        Moves a template into a different compartment within the same tenancy.
+        For information about moving resources between compartments, see
+        `Moving Resources to a Different Compartment`__.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes
+
+
+        :param str template_id: (required)
+            The `OCID`__ of the template.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+        :param oci.resource_manager.models.ChangeTemplateCompartmentDetails change_template_compartment_details: (required)
+            The details for moving a template to a different compartment.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the `PUT` or `DELETE` call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous `GET` or `POST` response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+            particular request, please provide the request ID.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of retrying the same action. Retry tokens expire after
+            24 hours, but can be invalidated before then due to conflicting operations. For example,
+            if a resource has been deleted and purged from the system, then a retry of the original
+            creation request may be rejected.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/resourcemanager/change_template_compartment.py.html>`__ to see an example of how to use change_template_compartment API.
+        """
+        resource_path = "/templates/{templateId}/actions/changeCompartment"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "change_template_compartment got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "templateId": template_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_template_compartment_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_template_compartment_details)
+
     def create_configuration_source_provider(self, create_configuration_source_provider_details, **kwargs):
         """
         Creates a configuration source provider in the specified compartment.
@@ -617,6 +720,88 @@ class ResourceManagerClient(object):
                 body=create_stack_details,
                 response_type="Stack")
 
+    def create_template(self, create_template_details, **kwargs):
+        """
+        Creates a custom template in the specified compartment.
+
+
+        :param oci.resource_manager.models.CreateTemplateDetails create_template_details: (required)
+            The configuration details for creating a template.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+            particular request, please provide the request ID.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of retrying the same action. Retry tokens expire after
+            24 hours, but can be invalidated before then due to conflicting operations. For example,
+            if a resource has been deleted and purged from the system, then a retry of the original
+            creation request may be rejected.
+
+        :param str oci_splat_generated_ocids: (optional)
+            This is to enable limit/quota support through splat
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.resource_manager.models.Template`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/resourcemanager/create_template.py.html>`__ to see an example of how to use create_template API.
+        """
+        resource_path = "/templates"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "opc_retry_token",
+            "oci_splat_generated_ocids"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "create_template got unknown kwargs: {!r}".format(extra_kwargs))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "oci-splat-generated-ocids": kwargs.get("oci_splat_generated_ocids", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_template_details,
+                response_type="Template")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_template_details,
+                response_type="Template")
+
     def delete_configuration_source_provider(self, configuration_source_provider_id, **kwargs):
         """
         Deletes the specified configuration source provider.
@@ -749,6 +934,89 @@ class ResourceManagerClient(object):
 
         path_params = {
             "stackId": stack_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
+    def delete_template(self, template_id, **kwargs):
+        """
+        Deletes the specified template.
+
+
+        :param str template_id: (required)
+            The `OCID`__ of the template.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+            particular request, please provide the request ID.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the `PUT` or `DELETE` call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous `GET` or `POST` response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/resourcemanager/delete_template.py.html>`__ to see an example of how to use delete_template API.
+        """
+        resource_path = "/templates/{templateId}"
+        method = "DELETE"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "if_match"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "delete_template got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "templateId": template_id
         }
 
         path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
@@ -1657,6 +1925,242 @@ class ResourceManagerClient(object):
                 header_params=header_params,
                 response_type="stream")
 
+    def get_template(self, template_id, **kwargs):
+        """
+        Gets the specified template.
+
+
+        :param str template_id: (required)
+            The `OCID`__ of the template.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+            particular request, please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.resource_manager.models.Template`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/resourcemanager/get_template.py.html>`__ to see an example of how to use get_template API.
+        """
+        resource_path = "/templates/{templateId}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_template got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "templateId": template_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="Template")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="Template")
+
+    def get_template_logo(self, template_id, **kwargs):
+        """
+        Returns the Terraform logo file in .logo format for the specified template.
+        Returns an error if no logo file is found.
+
+
+        :param str template_id: (required)
+            The `OCID`__ of the template.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+            particular request, please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type stream
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/resourcemanager/get_template_logo.py.html>`__ to see an example of how to use get_template_logo API.
+        """
+        resource_path = "/templates/{templateId}/logo"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_template_logo got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "templateId": template_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "image/png",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="stream")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="stream")
+
+    def get_template_tf_config(self, template_id, **kwargs):
+        """
+        Returns the Terraform configuration file in .zip format for the specified template.
+        Returns an error if no zip file is found.
+
+
+        :param str template_id: (required)
+            The `OCID`__ of the template.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+            particular request, please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type stream
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/resourcemanager/get_template_tf_config.py.html>`__ to see an example of how to use get_template_tf_config API.
+        """
+        resource_path = "/templates/{templateId}/tfConfig"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_template_tf_config got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "templateId": template_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/zip",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="stream")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="stream")
+
     def get_work_request(self, work_request_id, **kwargs):
         """
         Return the given work request.
@@ -2401,6 +2905,204 @@ class ResourceManagerClient(object):
                 header_params=header_params,
                 response_type="list[StackSummary]")
 
+    def list_template_categories(self, **kwargs):
+        """
+        Lists template categories.
+
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+            particular request, please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.resource_manager.models.TemplateCategorySummaryCollection`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/resourcemanager/list_template_categories.py.html>`__ to see an example of how to use list_template_categories API.
+        """
+        resource_path = "/templateCategories"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_template_categories got unknown kwargs: {!r}".format(extra_kwargs))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                response_type="TemplateCategorySummaryCollection")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                response_type="TemplateCategorySummaryCollection")
+
+    def list_templates(self, **kwargs):
+        """
+        Lists templates according to the specified filter.
+
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+            particular request, please provide the request ID.
+
+        :param str compartment_id: (optional)
+            A filter to return only resources that exist in the compartment, identified by `OCID`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+        :param str template_category_id: (optional)
+            Unique identifier of the template category.
+
+        :param str template_id: (optional)
+            The `OCID`__ of the template.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+        :param str display_name: (optional)
+            A filter to return only resources that match the specified display name.
+
+        :param str sort_by: (optional)
+            The field to use when sorting returned resources.
+            By default, `TIMECREATED` is ordered descending.
+            By default, `DISPLAYNAME` is ordered ascending. Note that you can sort only on one field.
+
+            Allowed values are: "TIMECREATED", "DISPLAYNAME"
+
+        :param str sort_order: (optional)
+            The sort order to use when sorting returned resources. Ascending (`ASC`) or descending (`DESC`).
+
+            Allowed values are: "ASC", "DESC"
+
+        :param int limit: (optional)
+            The number of items returned in a paginated `List` call. For information about pagination, see
+            `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+
+        :param str page: (optional)
+            The value of the `opc-next-page` response header from the preceding `List` call.
+            For information about pagination, see `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.resource_manager.models.TemplateSummaryCollection`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/resourcemanager/list_templates.py.html>`__ to see an example of how to use list_templates API.
+        """
+        resource_path = "/templates"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "compartment_id",
+            "template_category_id",
+            "template_id",
+            "display_name",
+            "sort_by",
+            "sort_order",
+            "limit",
+            "page"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_templates got unknown kwargs: {!r}".format(extra_kwargs))
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["TIMECREATED", "DISPLAYNAME"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        query_params = {
+            "compartmentId": kwargs.get("compartment_id", missing),
+            "templateCategoryId": kwargs.get("template_category_id", missing),
+            "templateId": kwargs.get("template_id", missing),
+            "displayName": kwargs.get("display_name", missing),
+            "sortBy": kwargs.get("sort_by", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="TemplateSummaryCollection")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="TemplateSummaryCollection")
+
     def list_terraform_versions(self, **kwargs):
         """
         Returns a list of supported Terraform versions for use with stacks.
@@ -3094,3 +3796,93 @@ class ResourceManagerClient(object):
                 header_params=header_params,
                 body=update_stack_details,
                 response_type="Stack")
+
+    def update_template(self, template_id, update_template_details, **kwargs):
+        """
+        Updates the specified template.
+
+
+        :param str template_id: (required)
+            The `OCID`__ of the template.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+        :param oci.resource_manager.models.UpdateTemplateDetails update_template_details: (required)
+            The details for updating a template.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+            particular request, please provide the request ID.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the `PUT` or `DELETE` call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous `GET` or `POST` response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.resource_manager.models.Template`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/resourcemanager/update_template.py.html>`__ to see an example of how to use update_template API.
+        """
+        resource_path = "/templates/{templateId}"
+        method = "PUT"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "if_match"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "update_template got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "templateId": template_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_template_details,
+                response_type="Template")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_template_details,
+                response_type="Template")

--- a/src/oci/resource_manager/resource_manager_client_composite_operations.py
+++ b/src/oci/resource_manager/resource_manager_client_composite_operations.py
@@ -229,6 +229,44 @@ class ResourceManagerClientCompositeOperations(object):
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
+    def create_template_and_wait_for_state(self, create_template_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.resource_manager.ResourceManagerClient.create_template` and waits for the :py:class:`~oci.resource_manager.models.Template` acted upon
+        to enter the given state(s).
+
+        :param oci.resource_manager.models.CreateTemplateDetails create_template_details: (required)
+            The configuration details for creating a template.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.resource_manager.models.Template.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.resource_manager.ResourceManagerClient.create_template`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.create_template(create_template_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_template(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def delete_configuration_source_provider_and_wait_for_state(self, configuration_source_provider_id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.resource_manager.ResourceManagerClient.delete_configuration_source_provider` and waits for the :py:class:`~oci.resource_manager.models.ConfigurationSourceProvider` acted upon
@@ -302,6 +340,55 @@ class ResourceManagerClientCompositeOperations(object):
         operation_result = None
         try:
             operation_result = self.client.delete_stack(stack_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                initial_get_result,
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                succeed_on_not_found=True,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def delete_template_and_wait_for_state(self, template_id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.resource_manager.ResourceManagerClient.delete_template` and waits for the :py:class:`~oci.resource_manager.models.Template` acted upon
+        to enter the given state(s).
+
+        :param str template_id: (required)
+            The `OCID`__ of the template.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.resource_manager.models.Template.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.resource_manager.ResourceManagerClient.delete_template`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        initial_get_result = self.client.get_template(template_id)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_template(template_id, **operation_kwargs)
         except oci.exceptions.ServiceError as e:
             if e.status == 404:
                 return WAIT_RESOURCE_NOT_FOUND
@@ -487,6 +574,49 @@ class ResourceManagerClientCompositeOperations(object):
             waiter_result = oci.wait_until(
                 self.client,
                 self.client.get_stack(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def update_template_and_wait_for_state(self, template_id, update_template_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.resource_manager.ResourceManagerClient.update_template` and waits for the :py:class:`~oci.resource_manager.models.Template` acted upon
+        to enter the given state(s).
+
+        :param str template_id: (required)
+            The `OCID`__ of the template.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+        :param oci.resource_manager.models.UpdateTemplateDetails update_template_details: (required)
+            The details for updating a template.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.resource_manager.models.Template.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.resource_manager.ResourceManagerClient.update_template`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_template(template_id, update_template_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_template(wait_for_resource_id),
                 evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
                 **waiter_kwargs
             )

--- a/src/oci/version.py
+++ b/src/oci/version.py
@@ -2,4 +2,4 @@
 # Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
 # This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 
-__version__ = "2.29.0"
+__version__ = "2.30.0"


### PR DESCRIPTION
## Added

* Support for checking if a contact for Exadata infrastructure is valid in My Oracle Support in the Database service

* Support for checking if Exadata infrastructure is in a degraded state in the Database service

* Support for updating the operating system on a VM cluster in the Database service

* Support for external databases in the Database service

* Support for uploading objects to the infrequent access storage tier in the Object Storage service

* Support for changing the storage tier of existing objects in the Object Storage service

* Support for private templates in the Resource Manager service

* Support for multiple encryption domains on IPSec tunnels in the Networking service

##Breaking

* Attribute `vnic_id` in response model `Ipv6` changed from required to optional in the Networking service
