### PR TITLE
Releasing version 2.31.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 ====================
+2.31.1 - 2021-02-16
+====================
+
+Added
+-----
+* Support for scan DNS names and zone ids on database system, cloud VM cluster, and autonomous Exadata infrastructure responses in the Database service
+* Support for specifying ACL rules to limit ingress into public load balancers in the Integration service
+* Support for Cloud at Customer as a source type in the Application Migration service
+* Support for selective migration of specific resources in the Application Migration service
+
+====================
 2.31.0 - 2021-02-09
 ====================
 

--- a/docs/api/application_migration.rst
+++ b/docs/api/application_migration.rst
@@ -31,10 +31,13 @@ Application Migration
     oci.application_migration.models.Migration
     oci.application_migration.models.MigrationSummary
     oci.application_migration.models.OacDiscoveryDetails
+    oci.application_migration.models.OccAuthorizationDetails
+    oci.application_migration.models.OccSourceDetails
     oci.application_migration.models.OcicAuthorizationDetails
     oci.application_migration.models.OcicSourceDetails
     oci.application_migration.models.OicDiscoveryDetails
     oci.application_migration.models.PcsDiscoveryDetails
+    oci.application_migration.models.ResourceField
     oci.application_migration.models.SoacsDiscoveryDetails
     oci.application_migration.models.Source
     oci.application_migration.models.SourceApplication

--- a/docs/api/application_migration/models/oci.application_migration.models.OccAuthorizationDetails.rst
+++ b/docs/api/application_migration/models/oci.application_migration.models.OccAuthorizationDetails.rst
@@ -1,0 +1,11 @@
+OccAuthorizationDetails
+=======================
+
+.. currentmodule:: oci.application_migration.models
+
+.. autoclass:: OccAuthorizationDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/application_migration/models/oci.application_migration.models.OccSourceDetails.rst
+++ b/docs/api/application_migration/models/oci.application_migration.models.OccSourceDetails.rst
@@ -1,0 +1,11 @@
+OccSourceDetails
+================
+
+.. currentmodule:: oci.application_migration.models
+
+.. autoclass:: OccSourceDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/application_migration/models/oci.application_migration.models.ResourceField.rst
+++ b/docs/api/application_migration/models/oci.application_migration.models.ResourceField.rst
@@ -1,0 +1,11 @@
+ResourceField
+=============
+
+.. currentmodule:: oci.application_migration.models
+
+.. autoclass:: ResourceField
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/integration.rst
+++ b/docs/api/integration.rst
@@ -19,13 +19,17 @@ Integration
     :template: autosummary/model_class.rst
 
     oci.integration.models.ChangeIntegrationInstanceCompartmentDetails
+    oci.integration.models.ChangeIntegrationInstanceNetworkEndpointDetails
     oci.integration.models.CreateCustomEndpointDetails
     oci.integration.models.CreateIntegrationInstanceDetails
     oci.integration.models.CustomEndpointDetails
     oci.integration.models.IntegrationInstance
     oci.integration.models.IntegrationInstanceSummary
+    oci.integration.models.NetworkEndpointDetails
+    oci.integration.models.PublicEndpointDetails
     oci.integration.models.UpdateCustomEndpointDetails
     oci.integration.models.UpdateIntegrationInstanceDetails
+    oci.integration.models.VirtualCloudNetwork
     oci.integration.models.WorkRequest
     oci.integration.models.WorkRequestError
     oci.integration.models.WorkRequestLogEntry

--- a/docs/api/integration/models/oci.integration.models.ChangeIntegrationInstanceNetworkEndpointDetails.rst
+++ b/docs/api/integration/models/oci.integration.models.ChangeIntegrationInstanceNetworkEndpointDetails.rst
@@ -1,0 +1,11 @@
+ChangeIntegrationInstanceNetworkEndpointDetails
+===============================================
+
+.. currentmodule:: oci.integration.models
+
+.. autoclass:: ChangeIntegrationInstanceNetworkEndpointDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/integration/models/oci.integration.models.NetworkEndpointDetails.rst
+++ b/docs/api/integration/models/oci.integration.models.NetworkEndpointDetails.rst
@@ -1,0 +1,11 @@
+NetworkEndpointDetails
+======================
+
+.. currentmodule:: oci.integration.models
+
+.. autoclass:: NetworkEndpointDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/integration/models/oci.integration.models.PublicEndpointDetails.rst
+++ b/docs/api/integration/models/oci.integration.models.PublicEndpointDetails.rst
@@ -1,0 +1,11 @@
+PublicEndpointDetails
+=====================
+
+.. currentmodule:: oci.integration.models
+
+.. autoclass:: PublicEndpointDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/integration/models/oci.integration.models.VirtualCloudNetwork.rst
+++ b/docs/api/integration/models/oci.integration.models.VirtualCloudNetwork.rst
@@ -1,0 +1,11 @@
+VirtualCloudNetwork
+===================
+
+.. currentmodule:: oci.integration.models
+
+.. autoclass:: VirtualCloudNetwork
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/src/oci/application_migration/models/__init__.py
+++ b/src/oci/application_migration/models/__init__.py
@@ -17,10 +17,13 @@ from .jcs_discovery_details import JcsDiscoveryDetails
 from .migration import Migration
 from .migration_summary import MigrationSummary
 from .oac_discovery_details import OacDiscoveryDetails
+from .occ_authorization_details import OccAuthorizationDetails
+from .occ_source_details import OccSourceDetails
 from .ocic_authorization_details import OcicAuthorizationDetails
 from .ocic_source_details import OcicSourceDetails
 from .oic_discovery_details import OicDiscoveryDetails
 from .pcs_discovery_details import PcsDiscoveryDetails
+from .resource_field import ResourceField
 from .soacs_discovery_details import SoacsDiscoveryDetails
 from .source import Source
 from .source_application import SourceApplication
@@ -50,10 +53,13 @@ application_migration_type_mapping = {
     "Migration": Migration,
     "MigrationSummary": MigrationSummary,
     "OacDiscoveryDetails": OacDiscoveryDetails,
+    "OccAuthorizationDetails": OccAuthorizationDetails,
+    "OccSourceDetails": OccSourceDetails,
     "OcicAuthorizationDetails": OcicAuthorizationDetails,
     "OcicSourceDetails": OcicSourceDetails,
     "OicDiscoveryDetails": OicDiscoveryDetails,
     "PcsDiscoveryDetails": PcsDiscoveryDetails,
+    "ResourceField": ResourceField,
     "SoacsDiscoveryDetails": SoacsDiscoveryDetails,
     "Source": Source,
     "SourceApplication": SourceApplication,

--- a/src/oci/application_migration/models/authorization_details.py
+++ b/src/oci/application_migration/models/authorization_details.py
@@ -22,11 +22,16 @@ class AuthorizationDetails(object):
     #: This constant has a value of "INTERNAL_COMPUTE"
     TYPE_INTERNAL_COMPUTE = "INTERNAL_COMPUTE"
 
+    #: A constant which can be used with the type property of a AuthorizationDetails.
+    #: This constant has a value of "OCC"
+    TYPE_OCC = "OCC"
+
     def __init__(self, **kwargs):
         """
         Initializes a new AuthorizationDetails object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
         to a service operations then you should favor using a subclass over the base class:
 
+        * :class:`~oci.application_migration.models.OccAuthorizationDetails`
         * :class:`~oci.application_migration.models.InternalAuthorizationDetails`
         * :class:`~oci.application_migration.models.OcicAuthorizationDetails`
 
@@ -34,7 +39,7 @@ class AuthorizationDetails(object):
 
         :param type:
             The value to assign to the type property of this AuthorizationDetails.
-            Allowed values for this property are: "OCIC", "INTERNAL_COMPUTE"
+            Allowed values for this property are: "OCIC", "INTERNAL_COMPUTE", "OCC"
         :type type: str
 
         """
@@ -56,6 +61,9 @@ class AuthorizationDetails(object):
         """
         type = object_dictionary['type']
 
+        if type == 'OCC':
+            return 'OccAuthorizationDetails'
+
         if type == 'INTERNAL_COMPUTE':
             return 'InternalAuthorizationDetails'
 
@@ -70,7 +78,7 @@ class AuthorizationDetails(object):
         **[Required]** Gets the type of this AuthorizationDetails.
         Type of the source environment from which you are migrating applications to Oracle Cloud Infrastructure.
 
-        Allowed values for this property are: "OCIC", "INTERNAL_COMPUTE"
+        Allowed values for this property are: "OCIC", "INTERNAL_COMPUTE", "OCC"
 
 
         :return: The type of this AuthorizationDetails.
@@ -88,7 +96,7 @@ class AuthorizationDetails(object):
         :param type: The type of this AuthorizationDetails.
         :type: str
         """
-        allowed_values = ["OCIC", "INTERNAL_COMPUTE"]
+        allowed_values = ["OCIC", "INTERNAL_COMPUTE", "OCC"]
         if not value_allowed_none_or_none_sentinel(type, allowed_values):
             raise ValueError(
                 "Invalid value for `type`, must be None or one of {0}"

--- a/src/oci/application_migration/models/configuration_field.py
+++ b/src/oci/application_migration/models/configuration_field.py
@@ -40,6 +40,10 @@ class ConfigurationField(object):
             The value to assign to the description property of this ConfigurationField.
         :type description: str
 
+        :param resource_list:
+            The value to assign to the resource_list property of this ConfigurationField.
+        :type resource_list: list[oci.application_migration.models.ResourceField]
+
         :param is_required:
             The value to assign to the is_required property of this ConfigurationField.
         :type is_required: bool
@@ -55,6 +59,7 @@ class ConfigurationField(object):
             'type': 'str',
             'value': 'str',
             'description': 'str',
+            'resource_list': 'list[ResourceField]',
             'is_required': 'bool',
             'is_mutable': 'bool'
         }
@@ -65,6 +70,7 @@ class ConfigurationField(object):
             'type': 'type',
             'value': 'value',
             'description': 'description',
+            'resource_list': 'resourceList',
             'is_required': 'isRequired',
             'is_mutable': 'isMutable'
         }
@@ -74,6 +80,7 @@ class ConfigurationField(object):
         self._type = None
         self._value = None
         self._description = None
+        self._resource_list = None
         self._is_required = None
         self._is_mutable = None
 
@@ -196,6 +203,30 @@ class ConfigurationField(object):
         :type: str
         """
         self._description = description
+
+    @property
+    def resource_list(self):
+        """
+        Gets the resource_list of this ConfigurationField.
+        A list of resources associated with a specific configuration object.
+
+
+        :return: The resource_list of this ConfigurationField.
+        :rtype: list[oci.application_migration.models.ResourceField]
+        """
+        return self._resource_list
+
+    @resource_list.setter
+    def resource_list(self, resource_list):
+        """
+        Sets the resource_list of this ConfigurationField.
+        A list of resources associated with a specific configuration object.
+
+
+        :param resource_list: The resource_list of this ConfigurationField.
+        :type: list[oci.application_migration.models.ResourceField]
+        """
+        self._resource_list = resource_list
 
     @property
     def is_required(self):

--- a/src/oci/application_migration/models/create_migration_details.py
+++ b/src/oci/application_migration/models/create_migration_details.py
@@ -64,6 +64,10 @@ class CreateMigrationDetails(object):
             Allowed values for this property are: "DATABASE_SYSTEM", "NOT_SET"
         :type pre_created_target_database_type: str
 
+        :param is_selective_migration:
+            The value to assign to the is_selective_migration property of this CreateMigrationDetails.
+        :type is_selective_migration: bool
+
         :param service_config:
             The value to assign to the service_config property of this CreateMigrationDetails.
         :type service_config: dict(str, ConfigurationField)
@@ -89,6 +93,7 @@ class CreateMigrationDetails(object):
             'application_name': 'str',
             'discovery_details': 'DiscoveryDetails',
             'pre_created_target_database_type': 'str',
+            'is_selective_migration': 'bool',
             'service_config': 'dict(str, ConfigurationField)',
             'application_config': 'dict(str, ConfigurationField)',
             'freeform_tags': 'dict(str, str)',
@@ -103,6 +108,7 @@ class CreateMigrationDetails(object):
             'application_name': 'applicationName',
             'discovery_details': 'discoveryDetails',
             'pre_created_target_database_type': 'preCreatedTargetDatabaseType',
+            'is_selective_migration': 'isSelectiveMigration',
             'service_config': 'serviceConfig',
             'application_config': 'applicationConfig',
             'freeform_tags': 'freeformTags',
@@ -116,6 +122,7 @@ class CreateMigrationDetails(object):
         self._application_name = None
         self._discovery_details = None
         self._pre_created_target_database_type = None
+        self._is_selective_migration = None
         self._service_config = None
         self._application_config = None
         self._freeform_tags = None
@@ -302,6 +309,30 @@ class CreateMigrationDetails(object):
                 .format(allowed_values)
             )
         self._pre_created_target_database_type = pre_created_target_database_type
+
+    @property
+    def is_selective_migration(self):
+        """
+        Gets the is_selective_migration of this CreateMigrationDetails.
+        If set to `true`, Application Migration migrates the application resources selectively depending on the source.
+
+
+        :return: The is_selective_migration of this CreateMigrationDetails.
+        :rtype: bool
+        """
+        return self._is_selective_migration
+
+    @is_selective_migration.setter
+    def is_selective_migration(self, is_selective_migration):
+        """
+        Sets the is_selective_migration of this CreateMigrationDetails.
+        If set to `true`, Application Migration migrates the application resources selectively depending on the source.
+
+
+        :param is_selective_migration: The is_selective_migration of this CreateMigrationDetails.
+        :type: bool
+        """
+        self._is_selective_migration = is_selective_migration
 
     @property
     def service_config(self):

--- a/src/oci/application_migration/models/internal_authorization_details.py
+++ b/src/oci/application_migration/models/internal_authorization_details.py
@@ -21,7 +21,7 @@ class InternalAuthorizationDetails(AuthorizationDetails):
 
         :param type:
             The value to assign to the type property of this InternalAuthorizationDetails.
-            Allowed values for this property are: "OCIC", "INTERNAL_COMPUTE"
+            Allowed values for this property are: "OCIC", "INTERNAL_COMPUTE", "OCC"
         :type type: str
 
         :param username:

--- a/src/oci/application_migration/models/internal_source_details.py
+++ b/src/oci/application_migration/models/internal_source_details.py
@@ -21,7 +21,7 @@ class InternalSourceDetails(SourceDetails):
 
         :param type:
             The value to assign to the type property of this InternalSourceDetails.
-            Allowed values for this property are: "OCIC", "INTERNAL_COMPUTE"
+            Allowed values for this property are: "OCIC", "INTERNAL_COMPUTE", "OCC"
         :type type: str
 
         :param account_name:

--- a/src/oci/application_migration/models/migration.py
+++ b/src/oci/application_migration/models/migration.py
@@ -155,6 +155,10 @@ class Migration(object):
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type pre_created_target_database_type: str
 
+        :param is_selective_migration:
+            The value to assign to the is_selective_migration property of this Migration.
+        :type is_selective_migration: bool
+
         :param service_config:
             The value to assign to the service_config property of this Migration.
         :type service_config: dict(str, ConfigurationField)
@@ -198,6 +202,7 @@ class Migration(object):
             'application_name': 'str',
             'application_type': 'str',
             'pre_created_target_database_type': 'str',
+            'is_selective_migration': 'bool',
             'service_config': 'dict(str, ConfigurationField)',
             'application_config': 'dict(str, ConfigurationField)',
             'lifecycle_state': 'str',
@@ -217,6 +222,7 @@ class Migration(object):
             'application_name': 'applicationName',
             'application_type': 'applicationType',
             'pre_created_target_database_type': 'preCreatedTargetDatabaseType',
+            'is_selective_migration': 'isSelectiveMigration',
             'service_config': 'serviceConfig',
             'application_config': 'applicationConfig',
             'lifecycle_state': 'lifecycleState',
@@ -235,6 +241,7 @@ class Migration(object):
         self._application_name = None
         self._application_type = None
         self._pre_created_target_database_type = None
+        self._is_selective_migration = None
         self._service_config = None
         self._application_config = None
         self._lifecycle_state = None
@@ -484,6 +491,30 @@ class Migration(object):
         if not value_allowed_none_or_none_sentinel(pre_created_target_database_type, allowed_values):
             pre_created_target_database_type = 'UNKNOWN_ENUM_VALUE'
         self._pre_created_target_database_type = pre_created_target_database_type
+
+    @property
+    def is_selective_migration(self):
+        """
+        Gets the is_selective_migration of this Migration.
+        If set to `true`, Application Migration migrates the application resources selectively depending on the source.
+
+
+        :return: The is_selective_migration of this Migration.
+        :rtype: bool
+        """
+        return self._is_selective_migration
+
+    @is_selective_migration.setter
+    def is_selective_migration(self, is_selective_migration):
+        """
+        Sets the is_selective_migration of this Migration.
+        If set to `true`, Application Migration migrates the application resources selectively depending on the source.
+
+
+        :param is_selective_migration: The is_selective_migration of this Migration.
+        :type: bool
+        """
+        self._is_selective_migration = is_selective_migration
 
     @property
     def service_config(self):

--- a/src/oci/application_migration/models/occ_authorization_details.py
+++ b/src/oci/application_migration/models/occ_authorization_details.py
@@ -8,28 +8,28 @@ from oci.decorators import init_model_state_from_kwargs
 
 
 @init_model_state_from_kwargs
-class OcicAuthorizationDetails(AuthorizationDetails):
+class OccAuthorizationDetails(AuthorizationDetails):
     """
-    Credentials to access Oracle Cloud Infrastructure - Classic, which is the source environment from which you want to migrate the application.
+    Credentials to access Oracle Cloud @ Customer, which is the source environment from which you want to migrate the application.
     """
 
     def __init__(self, **kwargs):
         """
-        Initializes a new OcicAuthorizationDetails object with values from keyword arguments. The default value of the :py:attr:`~oci.application_migration.models.OcicAuthorizationDetails.type` attribute
-        of this class is ``OCIC`` and it should not be changed.
+        Initializes a new OccAuthorizationDetails object with values from keyword arguments. The default value of the :py:attr:`~oci.application_migration.models.OccAuthorizationDetails.type` attribute
+        of this class is ``OCC`` and it should not be changed.
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
         :param type:
-            The value to assign to the type property of this OcicAuthorizationDetails.
+            The value to assign to the type property of this OccAuthorizationDetails.
             Allowed values for this property are: "OCIC", "INTERNAL_COMPUTE", "OCC"
         :type type: str
 
         :param username:
-            The value to assign to the username property of this OcicAuthorizationDetails.
+            The value to assign to the username property of this OccAuthorizationDetails.
         :type username: str
 
         :param password:
-            The value to assign to the password property of this OcicAuthorizationDetails.
+            The value to assign to the password property of this OccAuthorizationDetails.
         :type password: str
 
         """
@@ -48,16 +48,16 @@ class OcicAuthorizationDetails(AuthorizationDetails):
         self._type = None
         self._username = None
         self._password = None
-        self._type = 'OCIC'
+        self._type = 'OCC'
 
     @property
     def username(self):
         """
-        **[Required]** Gets the username of this OcicAuthorizationDetails.
-        User with Compute Operations role in Oracle Cloud Infrastructure - Classic.
+        **[Required]** Gets the username of this OccAuthorizationDetails.
+        User with Compute Operations role in Oracle Cloud @ Customer.
 
 
-        :return: The username of this OcicAuthorizationDetails.
+        :return: The username of this OccAuthorizationDetails.
         :rtype: str
         """
         return self._username
@@ -65,11 +65,11 @@ class OcicAuthorizationDetails(AuthorizationDetails):
     @username.setter
     def username(self, username):
         """
-        Sets the username of this OcicAuthorizationDetails.
-        User with Compute Operations role in Oracle Cloud Infrastructure - Classic.
+        Sets the username of this OccAuthorizationDetails.
+        User with Compute Operations role in Oracle Cloud @ Customer.
 
 
-        :param username: The username of this OcicAuthorizationDetails.
+        :param username: The username of this OccAuthorizationDetails.
         :type: str
         """
         self._username = username
@@ -77,11 +77,11 @@ class OcicAuthorizationDetails(AuthorizationDetails):
     @property
     def password(self):
         """
-        **[Required]** Gets the password of this OcicAuthorizationDetails.
+        **[Required]** Gets the password of this OccAuthorizationDetails.
         Password for this user.
 
 
-        :return: The password of this OcicAuthorizationDetails.
+        :return: The password of this OccAuthorizationDetails.
         :rtype: str
         """
         return self._password
@@ -89,11 +89,11 @@ class OcicAuthorizationDetails(AuthorizationDetails):
     @password.setter
     def password(self, password):
         """
-        Sets the password of this OcicAuthorizationDetails.
+        Sets the password of this OccAuthorizationDetails.
         Password for this user.
 
 
-        :param password: The password of this OcicAuthorizationDetails.
+        :param password: The password of this OccAuthorizationDetails.
         :type: str
         """
         self._password = password

--- a/src/oci/application_migration/models/occ_source_details.py
+++ b/src/oci/application_migration/models/occ_source_details.py
@@ -1,0 +1,84 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .source_details import SourceDetails
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class OccSourceDetails(SourceDetails):
+    """
+    Details about the Oracle Cloud @ Customer account, the source environment from which you want to migrate the application.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new OccSourceDetails object with values from keyword arguments. The default value of the :py:attr:`~oci.application_migration.models.OccSourceDetails.type` attribute
+        of this class is ``OCC`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param type:
+            The value to assign to the type property of this OccSourceDetails.
+            Allowed values for this property are: "OCIC", "INTERNAL_COMPUTE", "OCC"
+        :type type: str
+
+        :param compute_account:
+            The value to assign to the compute_account property of this OccSourceDetails.
+        :type compute_account: str
+
+        """
+        self.swagger_types = {
+            'type': 'str',
+            'compute_account': 'str'
+        }
+
+        self.attribute_map = {
+            'type': 'type',
+            'compute_account': 'computeAccount'
+        }
+
+        self._type = None
+        self._compute_account = None
+        self._type = 'OCC'
+
+    @property
+    def compute_account(self):
+        """
+        **[Required]** Gets the compute_account of this OccSourceDetails.
+        If you are using a Oracle Cloud @ Customer account with Identity Cloud Service (IDCS), enter the service instance ID.
+        For example, if Compute-567890123 is the account name of your Oracle Cloud @ Customer Compute service entitlement,
+        then enter 567890123.
+
+
+        :return: The compute_account of this OccSourceDetails.
+        :rtype: str
+        """
+        return self._compute_account
+
+    @compute_account.setter
+    def compute_account(self, compute_account):
+        """
+        Sets the compute_account of this OccSourceDetails.
+        If you are using a Oracle Cloud @ Customer account with Identity Cloud Service (IDCS), enter the service instance ID.
+        For example, if Compute-567890123 is the account name of your Oracle Cloud @ Customer Compute service entitlement,
+        then enter 567890123.
+
+
+        :param compute_account: The compute_account of this OccSourceDetails.
+        :type: str
+        """
+        self._compute_account = compute_account
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/application_migration/models/ocic_source_details.py
+++ b/src/oci/application_migration/models/ocic_source_details.py
@@ -21,7 +21,7 @@ class OcicSourceDetails(SourceDetails):
 
         :param type:
             The value to assign to the type property of this OcicSourceDetails.
-            Allowed values for this property are: "OCIC", "INTERNAL_COMPUTE"
+            Allowed values for this property are: "OCIC", "INTERNAL_COMPUTE", "OCC"
         :type type: str
 
         :param region:

--- a/src/oci/application_migration/models/resource_field.py
+++ b/src/oci/application_migration/models/resource_field.py
@@ -1,0 +1,163 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ResourceField(object):
+    """
+    Resource object that can be used to pass details about any list of resources associated with Migrations. The List of resources are added to ConfigurationField to add the capability to pass lists of resources of any type and group.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ResourceField object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param name:
+            The value to assign to the name property of this ResourceField.
+        :type name: str
+
+        :param group:
+            The value to assign to the group property of this ResourceField.
+        :type group: str
+
+        :param type:
+            The value to assign to the type property of this ResourceField.
+        :type type: str
+
+        :param value:
+            The value to assign to the value property of this ResourceField.
+        :type value: str
+
+        """
+        self.swagger_types = {
+            'name': 'str',
+            'group': 'str',
+            'type': 'str',
+            'value': 'str'
+        }
+
+        self.attribute_map = {
+            'name': 'name',
+            'group': 'group',
+            'type': 'type',
+            'value': 'value'
+        }
+
+        self._name = None
+        self._group = None
+        self._type = None
+        self._value = None
+
+    @property
+    def name(self):
+        """
+        Gets the name of this ResourceField.
+        The display name of the resource field.
+
+
+        :return: The name of this ResourceField.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this ResourceField.
+        The display name of the resource field.
+
+
+        :param name: The name of this ResourceField.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def group(self):
+        """
+        Gets the group of this ResourceField.
+        The name of the group to which this field belongs to.
+
+
+        :return: The group of this ResourceField.
+        :rtype: str
+        """
+        return self._group
+
+    @group.setter
+    def group(self, group):
+        """
+        Sets the group of this ResourceField.
+        The name of the group to which this field belongs to.
+
+
+        :param group: The group of this ResourceField.
+        :type: str
+        """
+        self._group = group
+
+    @property
+    def type(self):
+        """
+        **[Required]** Gets the type of this ResourceField.
+        The type of the resource field.
+
+
+        :return: The type of this ResourceField.
+        :rtype: str
+        """
+        return self._type
+
+    @type.setter
+    def type(self, type):
+        """
+        Sets the type of this ResourceField.
+        The type of the resource field.
+
+
+        :param type: The type of this ResourceField.
+        :type: str
+        """
+        self._type = type
+
+    @property
+    def value(self):
+        """
+        **[Required]** Gets the value of this ResourceField.
+        The value of the field.
+
+
+        :return: The value of this ResourceField.
+        :rtype: str
+        """
+        return self._value
+
+    @value.setter
+    def value(self, value):
+        """
+        Sets the value of this ResourceField.
+        The value of the field.
+
+
+        :param value: The value of this ResourceField.
+        :type: str
+        """
+        self._value = value
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/application_migration/models/source_details.py
+++ b/src/oci/application_migration/models/source_details.py
@@ -17,6 +17,8 @@ class SourceDetails(object):
 
     Specify `INTERNAL_COMPUTE` if you have a traditional Oracle Cloud Infrastructure - Classic account and you want to migrate Oracle
     Process Cloud Service or Oracle Integration Cloud Service applications.
+
+    Specify `OCC` if you have an Oracle Cloud @ Customer account.
     """
 
     #: A constant which can be used with the type property of a SourceDetails.
@@ -27,11 +29,16 @@ class SourceDetails(object):
     #: This constant has a value of "INTERNAL_COMPUTE"
     TYPE_INTERNAL_COMPUTE = "INTERNAL_COMPUTE"
 
+    #: A constant which can be used with the type property of a SourceDetails.
+    #: This constant has a value of "OCC"
+    TYPE_OCC = "OCC"
+
     def __init__(self, **kwargs):
         """
         Initializes a new SourceDetails object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
         to a service operations then you should favor using a subclass over the base class:
 
+        * :class:`~oci.application_migration.models.OccSourceDetails`
         * :class:`~oci.application_migration.models.InternalSourceDetails`
         * :class:`~oci.application_migration.models.OcicSourceDetails`
 
@@ -39,7 +46,7 @@ class SourceDetails(object):
 
         :param type:
             The value to assign to the type property of this SourceDetails.
-            Allowed values for this property are: "OCIC", "INTERNAL_COMPUTE", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "OCIC", "INTERNAL_COMPUTE", "OCC", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type type: str
 
@@ -62,6 +69,9 @@ class SourceDetails(object):
         """
         type = object_dictionary['type']
 
+        if type == 'OCC':
+            return 'OccSourceDetails'
+
         if type == 'INTERNAL_COMPUTE':
             return 'InternalSourceDetails'
 
@@ -76,7 +86,7 @@ class SourceDetails(object):
         **[Required]** Gets the type of this SourceDetails.
         The type of source environment.
 
-        Allowed values for this property are: "OCIC", "INTERNAL_COMPUTE", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "OCIC", "INTERNAL_COMPUTE", "OCC", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -95,7 +105,7 @@ class SourceDetails(object):
         :param type: The type of this SourceDetails.
         :type: str
         """
-        allowed_values = ["OCIC", "INTERNAL_COMPUTE"]
+        allowed_values = ["OCIC", "INTERNAL_COMPUTE", "OCC"]
         if not value_allowed_none_or_none_sentinel(type, allowed_values):
             type = 'UNKNOWN_ENUM_VALUE'
         self._type = type

--- a/src/oci/application_migration/models/source_summary.py
+++ b/src/oci/application_migration/models/source_summary.py
@@ -21,6 +21,10 @@ class SourceSummary(object):
     #: This constant has a value of "INTERNAL_COMPUTE"
     TYPE_INTERNAL_COMPUTE = "INTERNAL_COMPUTE"
 
+    #: A constant which can be used with the type property of a SourceSummary.
+    #: This constant has a value of "OCC"
+    TYPE_OCC = "OCC"
+
     #: A constant which can be used with the lifecycle_state property of a SourceSummary.
     #: This constant has a value of "CREATING"
     LIFECYCLE_STATE_CREATING = "CREATING"
@@ -56,7 +60,7 @@ class SourceSummary(object):
 
         :param type:
             The value to assign to the type property of this SourceSummary.
-            Allowed values for this property are: "OCIC", "INTERNAL_COMPUTE", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "OCIC", "INTERNAL_COMPUTE", "OCC", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type type: str
 
@@ -166,7 +170,7 @@ class SourceSummary(object):
         Gets the type of this SourceSummary.
         The type of source environment.
 
-        Allowed values for this property are: "OCIC", "INTERNAL_COMPUTE", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "OCIC", "INTERNAL_COMPUTE", "OCC", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -185,7 +189,7 @@ class SourceSummary(object):
         :param type: The type of this SourceSummary.
         :type: str
         """
-        allowed_values = ["OCIC", "INTERNAL_COMPUTE"]
+        allowed_values = ["OCIC", "INTERNAL_COMPUTE", "OCC"]
         if not value_allowed_none_or_none_sentinel(type, allowed_values):
             type = 'UNKNOWN_ENUM_VALUE'
         self._type = type

--- a/src/oci/application_migration/models/update_migration_details.py
+++ b/src/oci/application_migration/models/update_migration_details.py
@@ -34,6 +34,10 @@ class UpdateMigrationDetails(object):
             The value to assign to the discovery_details property of this UpdateMigrationDetails.
         :type discovery_details: oci.application_migration.models.DiscoveryDetails
 
+        :param is_selective_migration:
+            The value to assign to the is_selective_migration property of this UpdateMigrationDetails.
+        :type is_selective_migration: bool
+
         :param service_config:
             The value to assign to the service_config property of this UpdateMigrationDetails.
         :type service_config: dict(str, ConfigurationField)
@@ -55,6 +59,7 @@ class UpdateMigrationDetails(object):
             'display_name': 'str',
             'description': 'str',
             'discovery_details': 'DiscoveryDetails',
+            'is_selective_migration': 'bool',
             'service_config': 'dict(str, ConfigurationField)',
             'application_config': 'dict(str, ConfigurationField)',
             'freeform_tags': 'dict(str, str)',
@@ -65,6 +70,7 @@ class UpdateMigrationDetails(object):
             'display_name': 'displayName',
             'description': 'description',
             'discovery_details': 'discoveryDetails',
+            'is_selective_migration': 'isSelectiveMigration',
             'service_config': 'serviceConfig',
             'application_config': 'applicationConfig',
             'freeform_tags': 'freeformTags',
@@ -74,6 +80,7 @@ class UpdateMigrationDetails(object):
         self._display_name = None
         self._description = None
         self._discovery_details = None
+        self._is_selective_migration = None
         self._service_config = None
         self._application_config = None
         self._freeform_tags = None
@@ -146,6 +153,30 @@ class UpdateMigrationDetails(object):
         :type: oci.application_migration.models.DiscoveryDetails
         """
         self._discovery_details = discovery_details
+
+    @property
+    def is_selective_migration(self):
+        """
+        Gets the is_selective_migration of this UpdateMigrationDetails.
+        If set to `true`, Application Migration migrates the application resources selectively depending on the source.
+
+
+        :return: The is_selective_migration of this UpdateMigrationDetails.
+        :rtype: bool
+        """
+        return self._is_selective_migration
+
+    @is_selective_migration.setter
+    def is_selective_migration(self, is_selective_migration):
+        """
+        Sets the is_selective_migration of this UpdateMigrationDetails.
+        If set to `true`, Application Migration migrates the application resources selectively depending on the source.
+
+
+        :param is_selective_migration: The is_selective_migration of this UpdateMigrationDetails.
+        :type: bool
+        """
+        self._is_selective_migration = is_selective_migration
 
     @property
     def service_config(self):

--- a/src/oci/database/models/autonomous_exadata_infrastructure.py
+++ b/src/oci/database/models/autonomous_exadata_infrastructure.py
@@ -130,6 +130,14 @@ class AutonomousExadataInfrastructure(object):
             The value to assign to the defined_tags property of this AutonomousExadataInfrastructure.
         :type defined_tags: dict(str, dict(str, object))
 
+        :param scan_dns_name:
+            The value to assign to the scan_dns_name property of this AutonomousExadataInfrastructure.
+        :type scan_dns_name: str
+
+        :param zone_id:
+            The value to assign to the zone_id property of this AutonomousExadataInfrastructure.
+        :type zone_id: str
+
         """
         self.swagger_types = {
             'id': 'str',
@@ -149,7 +157,9 @@ class AutonomousExadataInfrastructure(object):
             'last_maintenance_run_id': 'str',
             'next_maintenance_run_id': 'str',
             'freeform_tags': 'dict(str, str)',
-            'defined_tags': 'dict(str, dict(str, object))'
+            'defined_tags': 'dict(str, dict(str, object))',
+            'scan_dns_name': 'str',
+            'zone_id': 'str'
         }
 
         self.attribute_map = {
@@ -170,7 +180,9 @@ class AutonomousExadataInfrastructure(object):
             'last_maintenance_run_id': 'lastMaintenanceRunId',
             'next_maintenance_run_id': 'nextMaintenanceRunId',
             'freeform_tags': 'freeformTags',
-            'defined_tags': 'definedTags'
+            'defined_tags': 'definedTags',
+            'scan_dns_name': 'scanDnsName',
+            'zone_id': 'zoneId'
         }
 
         self._id = None
@@ -191,6 +203,8 @@ class AutonomousExadataInfrastructure(object):
         self._next_maintenance_run_id = None
         self._freeform_tags = None
         self._defined_tags = None
+        self._scan_dns_name = None
+        self._zone_id = None
 
     @property
     def id(self):
@@ -679,6 +693,54 @@ class AutonomousExadataInfrastructure(object):
         :type: dict(str, dict(str, object))
         """
         self._defined_tags = defined_tags
+
+    @property
+    def scan_dns_name(self):
+        """
+        Gets the scan_dns_name of this AutonomousExadataInfrastructure.
+        The FQDN of the DNS record for the SCAN IP addresses that are associated with the Autonomous Exadata Infrastructure.
+
+
+        :return: The scan_dns_name of this AutonomousExadataInfrastructure.
+        :rtype: str
+        """
+        return self._scan_dns_name
+
+    @scan_dns_name.setter
+    def scan_dns_name(self, scan_dns_name):
+        """
+        Sets the scan_dns_name of this AutonomousExadataInfrastructure.
+        The FQDN of the DNS record for the SCAN IP addresses that are associated with the Autonomous Exadata Infrastructure.
+
+
+        :param scan_dns_name: The scan_dns_name of this AutonomousExadataInfrastructure.
+        :type: str
+        """
+        self._scan_dns_name = scan_dns_name
+
+    @property
+    def zone_id(self):
+        """
+        Gets the zone_id of this AutonomousExadataInfrastructure.
+        The OCID of the zone the Autonomous Exadata Infrastructure is associated with.
+
+
+        :return: The zone_id of this AutonomousExadataInfrastructure.
+        :rtype: str
+        """
+        return self._zone_id
+
+    @zone_id.setter
+    def zone_id(self, zone_id):
+        """
+        Sets the zone_id of this AutonomousExadataInfrastructure.
+        The OCID of the zone the Autonomous Exadata Infrastructure is associated with.
+
+
+        :param zone_id: The zone_id of this AutonomousExadataInfrastructure.
+        :type: str
+        """
+        self._zone_id = zone_id
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/database/models/autonomous_exadata_infrastructure_summary.py
+++ b/src/oci/database/models/autonomous_exadata_infrastructure_summary.py
@@ -148,6 +148,14 @@ class AutonomousExadataInfrastructureSummary(object):
             The value to assign to the defined_tags property of this AutonomousExadataInfrastructureSummary.
         :type defined_tags: dict(str, dict(str, object))
 
+        :param scan_dns_name:
+            The value to assign to the scan_dns_name property of this AutonomousExadataInfrastructureSummary.
+        :type scan_dns_name: str
+
+        :param zone_id:
+            The value to assign to the zone_id property of this AutonomousExadataInfrastructureSummary.
+        :type zone_id: str
+
         """
         self.swagger_types = {
             'id': 'str',
@@ -167,7 +175,9 @@ class AutonomousExadataInfrastructureSummary(object):
             'last_maintenance_run_id': 'str',
             'next_maintenance_run_id': 'str',
             'freeform_tags': 'dict(str, str)',
-            'defined_tags': 'dict(str, dict(str, object))'
+            'defined_tags': 'dict(str, dict(str, object))',
+            'scan_dns_name': 'str',
+            'zone_id': 'str'
         }
 
         self.attribute_map = {
@@ -188,7 +198,9 @@ class AutonomousExadataInfrastructureSummary(object):
             'last_maintenance_run_id': 'lastMaintenanceRunId',
             'next_maintenance_run_id': 'nextMaintenanceRunId',
             'freeform_tags': 'freeformTags',
-            'defined_tags': 'definedTags'
+            'defined_tags': 'definedTags',
+            'scan_dns_name': 'scanDnsName',
+            'zone_id': 'zoneId'
         }
 
         self._id = None
@@ -209,6 +221,8 @@ class AutonomousExadataInfrastructureSummary(object):
         self._next_maintenance_run_id = None
         self._freeform_tags = None
         self._defined_tags = None
+        self._scan_dns_name = None
+        self._zone_id = None
 
     @property
     def id(self):
@@ -697,6 +711,54 @@ class AutonomousExadataInfrastructureSummary(object):
         :type: dict(str, dict(str, object))
         """
         self._defined_tags = defined_tags
+
+    @property
+    def scan_dns_name(self):
+        """
+        Gets the scan_dns_name of this AutonomousExadataInfrastructureSummary.
+        The FQDN of the DNS record for the SCAN IP addresses that are associated with the Autonomous Exadata Infrastructure.
+
+
+        :return: The scan_dns_name of this AutonomousExadataInfrastructureSummary.
+        :rtype: str
+        """
+        return self._scan_dns_name
+
+    @scan_dns_name.setter
+    def scan_dns_name(self, scan_dns_name):
+        """
+        Sets the scan_dns_name of this AutonomousExadataInfrastructureSummary.
+        The FQDN of the DNS record for the SCAN IP addresses that are associated with the Autonomous Exadata Infrastructure.
+
+
+        :param scan_dns_name: The scan_dns_name of this AutonomousExadataInfrastructureSummary.
+        :type: str
+        """
+        self._scan_dns_name = scan_dns_name
+
+    @property
+    def zone_id(self):
+        """
+        Gets the zone_id of this AutonomousExadataInfrastructureSummary.
+        The OCID of the zone the Autonomous Exadata Infrastructure is associated with.
+
+
+        :return: The zone_id of this AutonomousExadataInfrastructureSummary.
+        :rtype: str
+        """
+        return self._zone_id
+
+    @zone_id.setter
+    def zone_id(self, zone_id):
+        """
+        Sets the zone_id of this AutonomousExadataInfrastructureSummary.
+        The OCID of the zone the Autonomous Exadata Infrastructure is associated with.
+
+
+        :param zone_id: The zone_id of this AutonomousExadataInfrastructureSummary.
+        :type: str
+        """
+        self._zone_id = zone_id
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/database/models/cloud_vm_cluster.py
+++ b/src/oci/database/models/cloud_vm_cluster.py
@@ -212,6 +212,14 @@ class CloudVmCluster(object):
             The value to assign to the defined_tags property of this CloudVmCluster.
         :type defined_tags: dict(str, dict(str, object))
 
+        :param scan_dns_name:
+            The value to assign to the scan_dns_name property of this CloudVmCluster.
+        :type scan_dns_name: str
+
+        :param zone_id:
+            The value to assign to the zone_id property of this CloudVmCluster.
+        :type zone_id: str
+
         """
         self.swagger_types = {
             'iorm_config_cache': 'ExadataIormConfig',
@@ -249,7 +257,9 @@ class CloudVmCluster(object):
             'vip_ids': 'list[str]',
             'scan_dns_record_id': 'str',
             'freeform_tags': 'dict(str, str)',
-            'defined_tags': 'dict(str, dict(str, object))'
+            'defined_tags': 'dict(str, dict(str, object))',
+            'scan_dns_name': 'str',
+            'zone_id': 'str'
         }
 
         self.attribute_map = {
@@ -288,7 +298,9 @@ class CloudVmCluster(object):
             'vip_ids': 'vipIds',
             'scan_dns_record_id': 'scanDnsRecordId',
             'freeform_tags': 'freeformTags',
-            'defined_tags': 'definedTags'
+            'defined_tags': 'definedTags',
+            'scan_dns_name': 'scanDnsName',
+            'zone_id': 'zoneId'
         }
 
         self._iorm_config_cache = None
@@ -327,6 +339,8 @@ class CloudVmCluster(object):
         self._scan_dns_record_id = None
         self._freeform_tags = None
         self._defined_tags = None
+        self._scan_dns_name = None
+        self._zone_id = None
 
     @property
     def iorm_config_cache(self):
@@ -1321,6 +1335,54 @@ class CloudVmCluster(object):
         :type: dict(str, dict(str, object))
         """
         self._defined_tags = defined_tags
+
+    @property
+    def scan_dns_name(self):
+        """
+        Gets the scan_dns_name of this CloudVmCluster.
+        The FQDN of the DNS record for the SCAN IP addresses that are associated with the cloud VM cluster.
+
+
+        :return: The scan_dns_name of this CloudVmCluster.
+        :rtype: str
+        """
+        return self._scan_dns_name
+
+    @scan_dns_name.setter
+    def scan_dns_name(self, scan_dns_name):
+        """
+        Sets the scan_dns_name of this CloudVmCluster.
+        The FQDN of the DNS record for the SCAN IP addresses that are associated with the cloud VM cluster.
+
+
+        :param scan_dns_name: The scan_dns_name of this CloudVmCluster.
+        :type: str
+        """
+        self._scan_dns_name = scan_dns_name
+
+    @property
+    def zone_id(self):
+        """
+        Gets the zone_id of this CloudVmCluster.
+        The OCID of the zone the cloud VM cluster is associated with.
+
+
+        :return: The zone_id of this CloudVmCluster.
+        :rtype: str
+        """
+        return self._zone_id
+
+    @zone_id.setter
+    def zone_id(self, zone_id):
+        """
+        Sets the zone_id of this CloudVmCluster.
+        The OCID of the zone the cloud VM cluster is associated with.
+
+
+        :param zone_id: The zone_id of this CloudVmCluster.
+        :type: str
+        """
+        self._zone_id = zone_id
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/database/models/cloud_vm_cluster_summary.py
+++ b/src/oci/database/models/cloud_vm_cluster_summary.py
@@ -208,6 +208,14 @@ class CloudVmClusterSummary(object):
             The value to assign to the defined_tags property of this CloudVmClusterSummary.
         :type defined_tags: dict(str, dict(str, object))
 
+        :param scan_dns_name:
+            The value to assign to the scan_dns_name property of this CloudVmClusterSummary.
+        :type scan_dns_name: str
+
+        :param zone_id:
+            The value to assign to the zone_id property of this CloudVmClusterSummary.
+        :type zone_id: str
+
         """
         self.swagger_types = {
             'id': 'str',
@@ -244,7 +252,9 @@ class CloudVmClusterSummary(object):
             'vip_ids': 'list[str]',
             'scan_dns_record_id': 'str',
             'freeform_tags': 'dict(str, str)',
-            'defined_tags': 'dict(str, dict(str, object))'
+            'defined_tags': 'dict(str, dict(str, object))',
+            'scan_dns_name': 'str',
+            'zone_id': 'str'
         }
 
         self.attribute_map = {
@@ -282,7 +292,9 @@ class CloudVmClusterSummary(object):
             'vip_ids': 'vipIds',
             'scan_dns_record_id': 'scanDnsRecordId',
             'freeform_tags': 'freeformTags',
-            'defined_tags': 'definedTags'
+            'defined_tags': 'definedTags',
+            'scan_dns_name': 'scanDnsName',
+            'zone_id': 'zoneId'
         }
 
         self._id = None
@@ -320,6 +332,8 @@ class CloudVmClusterSummary(object):
         self._scan_dns_record_id = None
         self._freeform_tags = None
         self._defined_tags = None
+        self._scan_dns_name = None
+        self._zone_id = None
 
     @property
     def id(self):
@@ -1294,6 +1308,54 @@ class CloudVmClusterSummary(object):
         :type: dict(str, dict(str, object))
         """
         self._defined_tags = defined_tags
+
+    @property
+    def scan_dns_name(self):
+        """
+        Gets the scan_dns_name of this CloudVmClusterSummary.
+        The FQDN of the DNS record for the SCAN IP addresses that are associated with the cloud VM cluster.
+
+
+        :return: The scan_dns_name of this CloudVmClusterSummary.
+        :rtype: str
+        """
+        return self._scan_dns_name
+
+    @scan_dns_name.setter
+    def scan_dns_name(self, scan_dns_name):
+        """
+        Sets the scan_dns_name of this CloudVmClusterSummary.
+        The FQDN of the DNS record for the SCAN IP addresses that are associated with the cloud VM cluster.
+
+
+        :param scan_dns_name: The scan_dns_name of this CloudVmClusterSummary.
+        :type: str
+        """
+        self._scan_dns_name = scan_dns_name
+
+    @property
+    def zone_id(self):
+        """
+        Gets the zone_id of this CloudVmClusterSummary.
+        The OCID of the zone the cloud VM cluster is associated with.
+
+
+        :return: The zone_id of this CloudVmClusterSummary.
+        :rtype: str
+        """
+        return self._zone_id
+
+    @zone_id.setter
+    def zone_id(self, zone_id):
+        """
+        Sets the zone_id of this CloudVmClusterSummary.
+        The OCID of the zone the cloud VM cluster is associated with.
+
+
+        :param zone_id: The zone_id of this CloudVmClusterSummary.
+        :type: str
+        """
+        self._zone_id = zone_id
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/database/models/db_system.py
+++ b/src/oci/database/models/db_system.py
@@ -220,6 +220,14 @@ class DbSystem(object):
             The value to assign to the scan_dns_record_id property of this DbSystem.
         :type scan_dns_record_id: str
 
+        :param scan_dns_name:
+            The value to assign to the scan_dns_name property of this DbSystem.
+        :type scan_dns_name: str
+
+        :param zone_id:
+            The value to assign to the zone_id property of this DbSystem.
+        :type zone_id: str
+
         :param data_storage_size_in_gbs:
             The value to assign to the data_storage_size_in_gbs property of this DbSystem.
         :type data_storage_size_in_gbs: int
@@ -300,6 +308,8 @@ class DbSystem(object):
             'scan_ip_ids': 'list[str]',
             'vip_ids': 'list[str]',
             'scan_dns_record_id': 'str',
+            'scan_dns_name': 'str',
+            'zone_id': 'str',
             'data_storage_size_in_gbs': 'int',
             'reco_storage_size_in_gb': 'int',
             'node_count': 'int',
@@ -346,6 +356,8 @@ class DbSystem(object):
             'scan_ip_ids': 'scanIpIds',
             'vip_ids': 'vipIds',
             'scan_dns_record_id': 'scanDnsRecordId',
+            'scan_dns_name': 'scanDnsName',
+            'zone_id': 'zoneId',
             'data_storage_size_in_gbs': 'dataStorageSizeInGBs',
             'reco_storage_size_in_gb': 'recoStorageSizeInGB',
             'node_count': 'nodeCount',
@@ -391,6 +403,8 @@ class DbSystem(object):
         self._scan_ip_ids = None
         self._vip_ids = None
         self._scan_dns_record_id = None
+        self._scan_dns_name = None
+        self._zone_id = None
         self._data_storage_size_in_gbs = None
         self._reco_storage_size_in_gb = None
         self._node_count = None
@@ -1278,6 +1292,54 @@ class DbSystem(object):
         :type: str
         """
         self._scan_dns_record_id = scan_dns_record_id
+
+    @property
+    def scan_dns_name(self):
+        """
+        Gets the scan_dns_name of this DbSystem.
+        The FQDN of the DNS record for the SCAN IP addresses that are associated with the DB system.
+
+
+        :return: The scan_dns_name of this DbSystem.
+        :rtype: str
+        """
+        return self._scan_dns_name
+
+    @scan_dns_name.setter
+    def scan_dns_name(self, scan_dns_name):
+        """
+        Sets the scan_dns_name of this DbSystem.
+        The FQDN of the DNS record for the SCAN IP addresses that are associated with the DB system.
+
+
+        :param scan_dns_name: The scan_dns_name of this DbSystem.
+        :type: str
+        """
+        self._scan_dns_name = scan_dns_name
+
+    @property
+    def zone_id(self):
+        """
+        Gets the zone_id of this DbSystem.
+        The OCID of the zone the DB system is associated with.
+
+
+        :return: The zone_id of this DbSystem.
+        :rtype: str
+        """
+        return self._zone_id
+
+    @zone_id.setter
+    def zone_id(self, zone_id):
+        """
+        Sets the zone_id of this DbSystem.
+        The OCID of the zone the DB system is associated with.
+
+
+        :param zone_id: The zone_id of this DbSystem.
+        :type: str
+        """
+        self._zone_id = zone_id
 
     @property
     def data_storage_size_in_gbs(self):

--- a/src/oci/database/models/db_system_summary.py
+++ b/src/oci/database/models/db_system_summary.py
@@ -245,6 +245,14 @@ class DbSystemSummary(object):
             The value to assign to the scan_dns_record_id property of this DbSystemSummary.
         :type scan_dns_record_id: str
 
+        :param scan_dns_name:
+            The value to assign to the scan_dns_name property of this DbSystemSummary.
+        :type scan_dns_name: str
+
+        :param zone_id:
+            The value to assign to the zone_id property of this DbSystemSummary.
+        :type zone_id: str
+
         :param data_storage_size_in_gbs:
             The value to assign to the data_storage_size_in_gbs property of this DbSystemSummary.
         :type data_storage_size_in_gbs: int
@@ -324,6 +332,8 @@ class DbSystemSummary(object):
             'scan_ip_ids': 'list[str]',
             'vip_ids': 'list[str]',
             'scan_dns_record_id': 'str',
+            'scan_dns_name': 'str',
+            'zone_id': 'str',
             'data_storage_size_in_gbs': 'int',
             'reco_storage_size_in_gb': 'int',
             'node_count': 'int',
@@ -369,6 +379,8 @@ class DbSystemSummary(object):
             'scan_ip_ids': 'scanIpIds',
             'vip_ids': 'vipIds',
             'scan_dns_record_id': 'scanDnsRecordId',
+            'scan_dns_name': 'scanDnsName',
+            'zone_id': 'zoneId',
             'data_storage_size_in_gbs': 'dataStorageSizeInGBs',
             'reco_storage_size_in_gb': 'recoStorageSizeInGB',
             'node_count': 'nodeCount',
@@ -413,6 +425,8 @@ class DbSystemSummary(object):
         self._scan_ip_ids = None
         self._vip_ids = None
         self._scan_dns_record_id = None
+        self._scan_dns_name = None
+        self._zone_id = None
         self._data_storage_size_in_gbs = None
         self._reco_storage_size_in_gb = None
         self._node_count = None
@@ -1280,6 +1294,54 @@ class DbSystemSummary(object):
         :type: str
         """
         self._scan_dns_record_id = scan_dns_record_id
+
+    @property
+    def scan_dns_name(self):
+        """
+        Gets the scan_dns_name of this DbSystemSummary.
+        The FQDN of the DNS record for the SCAN IP addresses that are associated with the DB system.
+
+
+        :return: The scan_dns_name of this DbSystemSummary.
+        :rtype: str
+        """
+        return self._scan_dns_name
+
+    @scan_dns_name.setter
+    def scan_dns_name(self, scan_dns_name):
+        """
+        Sets the scan_dns_name of this DbSystemSummary.
+        The FQDN of the DNS record for the SCAN IP addresses that are associated with the DB system.
+
+
+        :param scan_dns_name: The scan_dns_name of this DbSystemSummary.
+        :type: str
+        """
+        self._scan_dns_name = scan_dns_name
+
+    @property
+    def zone_id(self):
+        """
+        Gets the zone_id of this DbSystemSummary.
+        The OCID of the zone the DB system is associated with.
+
+
+        :return: The zone_id of this DbSystemSummary.
+        :rtype: str
+        """
+        return self._zone_id
+
+    @zone_id.setter
+    def zone_id(self, zone_id):
+        """
+        Sets the zone_id of this DbSystemSummary.
+        The OCID of the zone the DB system is associated with.
+
+
+        :param zone_id: The zone_id of this DbSystemSummary.
+        :type: str
+        """
+        self._zone_id = zone_id
 
     @property
     def data_storage_size_in_gbs(self):

--- a/src/oci/integration/integration_instance_client.py
+++ b/src/oci/integration/integration_instance_client.py
@@ -184,6 +184,106 @@ class IntegrationInstanceClient(object):
                 header_params=header_params,
                 body=change_integration_instance_compartment_details)
 
+    def change_integration_instance_network_endpoint(self, integration_instance_id, change_integration_instance_network_endpoint_details, **kwargs):
+        """
+        Change an Integration instance network endpoint. The operation is long-running
+        and creates a new WorkRequest.
+
+
+        :param str integration_instance_id: (required)
+            Unique Integration Instance identifier.
+
+        :param oci.integration.models.ChangeIntegrationInstanceNetworkEndpointDetails change_integration_instance_network_endpoint_details: (required)
+            Details for the updated Integration instance network endpoint
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call
+            for a resource, set the `if-match` parameter to the value of the
+            etag from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the etag you
+            provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case
+            of a timeout or server error without risk of executing that same action
+            again. Retry tokens expire after 24 hours, but can be invalidated before
+            then due to conflicting operations. For example, if a resource has been
+            deleted and purged from the system, then a retry of the original creation
+            request might be rejected.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/integration/change_integration_instance_network_endpoint.py.html>`__ to see an example of how to use change_integration_instance_network_endpoint API.
+        """
+        resource_path = "/integrationInstances/{integrationInstanceId}/actions/changeNetworkEndpoint"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "change_integration_instance_network_endpoint got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "integrationInstanceId": integration_instance_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_integration_instance_network_endpoint_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_integration_instance_network_endpoint_details)
+
     def create_integration_instance(self, create_integration_instance_details, **kwargs):
         """
         Creates a new Integration Instance.

--- a/src/oci/integration/integration_instance_client_composite_operations.py
+++ b/src/oci/integration/integration_instance_client_composite_operations.py
@@ -64,6 +64,47 @@ class IntegrationInstanceClientCompositeOperations(object):
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
+    def change_integration_instance_network_endpoint_and_wait_for_state(self, integration_instance_id, change_integration_instance_network_endpoint_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.integration.IntegrationInstanceClient.change_integration_instance_network_endpoint` and waits for the :py:class:`~oci.integration.models.WorkRequest`
+        to enter the given state(s).
+
+        :param str integration_instance_id: (required)
+            Unique Integration Instance identifier.
+
+        :param oci.integration.models.ChangeIntegrationInstanceNetworkEndpointDetails change_integration_instance_network_endpoint_details: (required)
+            Details for the updated Integration instance network endpoint
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.integration.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.integration.IntegrationInstanceClient.change_integration_instance_network_endpoint`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.change_integration_instance_network_endpoint(integration_instance_id, change_integration_instance_network_endpoint_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def create_integration_instance_and_wait_for_state(self, create_integration_instance_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.integration.IntegrationInstanceClient.create_integration_instance` and waits for the :py:class:`~oci.integration.models.WorkRequest`

--- a/src/oci/integration/models/__init__.py
+++ b/src/oci/integration/models/__init__.py
@@ -5,13 +5,17 @@
 from __future__ import absolute_import
 
 from .change_integration_instance_compartment_details import ChangeIntegrationInstanceCompartmentDetails
+from .change_integration_instance_network_endpoint_details import ChangeIntegrationInstanceNetworkEndpointDetails
 from .create_custom_endpoint_details import CreateCustomEndpointDetails
 from .create_integration_instance_details import CreateIntegrationInstanceDetails
 from .custom_endpoint_details import CustomEndpointDetails
 from .integration_instance import IntegrationInstance
 from .integration_instance_summary import IntegrationInstanceSummary
+from .network_endpoint_details import NetworkEndpointDetails
+from .public_endpoint_details import PublicEndpointDetails
 from .update_custom_endpoint_details import UpdateCustomEndpointDetails
 from .update_integration_instance_details import UpdateIntegrationInstanceDetails
+from .virtual_cloud_network import VirtualCloudNetwork
 from .work_request import WorkRequest
 from .work_request_error import WorkRequestError
 from .work_request_log_entry import WorkRequestLogEntry
@@ -21,13 +25,17 @@ from .work_request_summary import WorkRequestSummary
 # Maps type names to classes for integration services.
 integration_type_mapping = {
     "ChangeIntegrationInstanceCompartmentDetails": ChangeIntegrationInstanceCompartmentDetails,
+    "ChangeIntegrationInstanceNetworkEndpointDetails": ChangeIntegrationInstanceNetworkEndpointDetails,
     "CreateCustomEndpointDetails": CreateCustomEndpointDetails,
     "CreateIntegrationInstanceDetails": CreateIntegrationInstanceDetails,
     "CustomEndpointDetails": CustomEndpointDetails,
     "IntegrationInstance": IntegrationInstance,
     "IntegrationInstanceSummary": IntegrationInstanceSummary,
+    "NetworkEndpointDetails": NetworkEndpointDetails,
+    "PublicEndpointDetails": PublicEndpointDetails,
     "UpdateCustomEndpointDetails": UpdateCustomEndpointDetails,
     "UpdateIntegrationInstanceDetails": UpdateIntegrationInstanceDetails,
+    "VirtualCloudNetwork": VirtualCloudNetwork,
     "WorkRequest": WorkRequest,
     "WorkRequestError": WorkRequestError,
     "WorkRequestLogEntry": WorkRequestLogEntry,

--- a/src/oci/integration/models/change_integration_instance_network_endpoint_details.py
+++ b/src/oci/integration/models/change_integration_instance_network_endpoint_details.py
@@ -1,0 +1,66 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ChangeIntegrationInstanceNetworkEndpointDetails(object):
+    """
+    Input payload to update an Integration instance endpoint details. An empty payload will clear out any existing configuration.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ChangeIntegrationInstanceNetworkEndpointDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param network_endpoint_details:
+            The value to assign to the network_endpoint_details property of this ChangeIntegrationInstanceNetworkEndpointDetails.
+        :type network_endpoint_details: oci.integration.models.NetworkEndpointDetails
+
+        """
+        self.swagger_types = {
+            'network_endpoint_details': 'NetworkEndpointDetails'
+        }
+
+        self.attribute_map = {
+            'network_endpoint_details': 'networkEndpointDetails'
+        }
+
+        self._network_endpoint_details = None
+
+    @property
+    def network_endpoint_details(self):
+        """
+        Gets the network_endpoint_details of this ChangeIntegrationInstanceNetworkEndpointDetails.
+
+        :return: The network_endpoint_details of this ChangeIntegrationInstanceNetworkEndpointDetails.
+        :rtype: oci.integration.models.NetworkEndpointDetails
+        """
+        return self._network_endpoint_details
+
+    @network_endpoint_details.setter
+    def network_endpoint_details(self, network_endpoint_details):
+        """
+        Sets the network_endpoint_details of this ChangeIntegrationInstanceNetworkEndpointDetails.
+
+        :param network_endpoint_details: The network_endpoint_details of this ChangeIntegrationInstanceNetworkEndpointDetails.
+        :type: oci.integration.models.NetworkEndpointDetails
+        """
+        self._network_endpoint_details = network_endpoint_details
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/integration/models/create_integration_instance_details.py
+++ b/src/oci/integration/models/create_integration_instance_details.py
@@ -92,6 +92,10 @@ class CreateIntegrationInstanceDetails(object):
             The value to assign to the is_file_server_enabled property of this CreateIntegrationInstanceDetails.
         :type is_file_server_enabled: bool
 
+        :param network_endpoint_details:
+            The value to assign to the network_endpoint_details property of this CreateIntegrationInstanceDetails.
+        :type network_endpoint_details: oci.integration.models.NetworkEndpointDetails
+
         """
         self.swagger_types = {
             'display_name': 'str',
@@ -106,7 +110,8 @@ class CreateIntegrationInstanceDetails(object):
             'custom_endpoint': 'CreateCustomEndpointDetails',
             'alternate_custom_endpoints': 'list[CreateCustomEndpointDetails]',
             'consumption_model': 'str',
-            'is_file_server_enabled': 'bool'
+            'is_file_server_enabled': 'bool',
+            'network_endpoint_details': 'NetworkEndpointDetails'
         }
 
         self.attribute_map = {
@@ -122,7 +127,8 @@ class CreateIntegrationInstanceDetails(object):
             'custom_endpoint': 'customEndpoint',
             'alternate_custom_endpoints': 'alternateCustomEndpoints',
             'consumption_model': 'consumptionModel',
-            'is_file_server_enabled': 'isFileServerEnabled'
+            'is_file_server_enabled': 'isFileServerEnabled',
+            'network_endpoint_details': 'networkEndpointDetails'
         }
 
         self._display_name = None
@@ -138,6 +144,7 @@ class CreateIntegrationInstanceDetails(object):
         self._alternate_custom_endpoints = None
         self._consumption_model = None
         self._is_file_server_enabled = None
+        self._network_endpoint_details = None
 
     @property
     def display_name(self):
@@ -303,7 +310,7 @@ class CreateIntegrationInstanceDetails(object):
     def idcs_at(self):
         """
         Gets the idcs_at of this CreateIntegrationInstanceDetails.
-        IDCS Authentication token. This is is required for pre-UCPIS cloud accounts, but not UCPIS, hence not a required parameter
+        IDCS Authentication token. This is required for all realms with IDCS. Its optional as its not required for non IDCS realms.
 
 
         :return: The idcs_at of this CreateIntegrationInstanceDetails.
@@ -315,7 +322,7 @@ class CreateIntegrationInstanceDetails(object):
     def idcs_at(self, idcs_at):
         """
         Sets the idcs_at of this CreateIntegrationInstanceDetails.
-        IDCS Authentication token. This is is required for pre-UCPIS cloud accounts, but not UCPIS, hence not a required parameter
+        IDCS Authentication token. This is required for all realms with IDCS. Its optional as its not required for non IDCS realms.
 
 
         :param idcs_at: The idcs_at of this CreateIntegrationInstanceDetails.
@@ -472,6 +479,26 @@ class CreateIntegrationInstanceDetails(object):
         :type: bool
         """
         self._is_file_server_enabled = is_file_server_enabled
+
+    @property
+    def network_endpoint_details(self):
+        """
+        Gets the network_endpoint_details of this CreateIntegrationInstanceDetails.
+
+        :return: The network_endpoint_details of this CreateIntegrationInstanceDetails.
+        :rtype: oci.integration.models.NetworkEndpointDetails
+        """
+        return self._network_endpoint_details
+
+    @network_endpoint_details.setter
+    def network_endpoint_details(self, network_endpoint_details):
+        """
+        Sets the network_endpoint_details of this CreateIntegrationInstanceDetails.
+
+        :param network_endpoint_details: The network_endpoint_details of this CreateIntegrationInstanceDetails.
+        :type: oci.integration.models.NetworkEndpointDetails
+        """
+        self._network_endpoint_details = network_endpoint_details
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/integration/models/integration_instance.py
+++ b/src/oci/integration/models/integration_instance.py
@@ -144,6 +144,10 @@ class IntegrationInstance(object):
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type consumption_model: str
 
+        :param network_endpoint_details:
+            The value to assign to the network_endpoint_details property of this IntegrationInstance.
+        :type network_endpoint_details: oci.integration.models.NetworkEndpointDetails
+
         """
         self.swagger_types = {
             'id': 'str',
@@ -163,7 +167,8 @@ class IntegrationInstance(object):
             'is_visual_builder_enabled': 'bool',
             'custom_endpoint': 'CustomEndpointDetails',
             'alternate_custom_endpoints': 'list[CustomEndpointDetails]',
-            'consumption_model': 'str'
+            'consumption_model': 'str',
+            'network_endpoint_details': 'NetworkEndpointDetails'
         }
 
         self.attribute_map = {
@@ -184,7 +189,8 @@ class IntegrationInstance(object):
             'is_visual_builder_enabled': 'isVisualBuilderEnabled',
             'custom_endpoint': 'customEndpoint',
             'alternate_custom_endpoints': 'alternateCustomEndpoints',
-            'consumption_model': 'consumptionModel'
+            'consumption_model': 'consumptionModel',
+            'network_endpoint_details': 'networkEndpointDetails'
         }
 
         self._id = None
@@ -205,6 +211,7 @@ class IntegrationInstance(object):
         self._custom_endpoint = None
         self._alternate_custom_endpoints = None
         self._consumption_model = None
+        self._network_endpoint_details = None
 
     @property
     def id(self):
@@ -659,6 +666,26 @@ class IntegrationInstance(object):
         if not value_allowed_none_or_none_sentinel(consumption_model, allowed_values):
             consumption_model = 'UNKNOWN_ENUM_VALUE'
         self._consumption_model = consumption_model
+
+    @property
+    def network_endpoint_details(self):
+        """
+        Gets the network_endpoint_details of this IntegrationInstance.
+
+        :return: The network_endpoint_details of this IntegrationInstance.
+        :rtype: oci.integration.models.NetworkEndpointDetails
+        """
+        return self._network_endpoint_details
+
+    @network_endpoint_details.setter
+    def network_endpoint_details(self, network_endpoint_details):
+        """
+        Sets the network_endpoint_details of this IntegrationInstance.
+
+        :param network_endpoint_details: The network_endpoint_details of this IntegrationInstance.
+        :type: oci.integration.models.NetworkEndpointDetails
+        """
+        self._network_endpoint_details = network_endpoint_details
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/integration/models/integration_instance_summary.py
+++ b/src/oci/integration/models/integration_instance_summary.py
@@ -136,6 +136,10 @@ class IntegrationInstanceSummary(object):
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type consumption_model: str
 
+        :param network_endpoint_details:
+            The value to assign to the network_endpoint_details property of this IntegrationInstanceSummary.
+        :type network_endpoint_details: oci.integration.models.NetworkEndpointDetails
+
         """
         self.swagger_types = {
             'id': 'str',
@@ -153,7 +157,8 @@ class IntegrationInstanceSummary(object):
             'is_visual_builder_enabled': 'bool',
             'custom_endpoint': 'CustomEndpointDetails',
             'alternate_custom_endpoints': 'list[CustomEndpointDetails]',
-            'consumption_model': 'str'
+            'consumption_model': 'str',
+            'network_endpoint_details': 'NetworkEndpointDetails'
         }
 
         self.attribute_map = {
@@ -172,7 +177,8 @@ class IntegrationInstanceSummary(object):
             'is_visual_builder_enabled': 'isVisualBuilderEnabled',
             'custom_endpoint': 'customEndpoint',
             'alternate_custom_endpoints': 'alternateCustomEndpoints',
-            'consumption_model': 'consumptionModel'
+            'consumption_model': 'consumptionModel',
+            'network_endpoint_details': 'networkEndpointDetails'
         }
 
         self._id = None
@@ -191,6 +197,7 @@ class IntegrationInstanceSummary(object):
         self._custom_endpoint = None
         self._alternate_custom_endpoints = None
         self._consumption_model = None
+        self._network_endpoint_details = None
 
     @property
     def id(self):
@@ -589,6 +596,26 @@ class IntegrationInstanceSummary(object):
         if not value_allowed_none_or_none_sentinel(consumption_model, allowed_values):
             consumption_model = 'UNKNOWN_ENUM_VALUE'
         self._consumption_model = consumption_model
+
+    @property
+    def network_endpoint_details(self):
+        """
+        Gets the network_endpoint_details of this IntegrationInstanceSummary.
+
+        :return: The network_endpoint_details of this IntegrationInstanceSummary.
+        :rtype: oci.integration.models.NetworkEndpointDetails
+        """
+        return self._network_endpoint_details
+
+    @network_endpoint_details.setter
+    def network_endpoint_details(self, network_endpoint_details):
+        """
+        Sets the network_endpoint_details of this IntegrationInstanceSummary.
+
+        :param network_endpoint_details: The network_endpoint_details of this IntegrationInstanceSummary.
+        :type: oci.integration.models.NetworkEndpointDetails
+        """
+        self._network_endpoint_details = network_endpoint_details
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/integration/models/network_endpoint_details.py
+++ b/src/oci/integration/models/network_endpoint_details.py
@@ -1,0 +1,99 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class NetworkEndpointDetails(object):
+    """
+    Base representation of a network endpoint.
+    """
+
+    #: A constant which can be used with the network_endpoint_type property of a NetworkEndpointDetails.
+    #: This constant has a value of "PUBLIC"
+    NETWORK_ENDPOINT_TYPE_PUBLIC = "PUBLIC"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new NetworkEndpointDetails object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
+        to a service operations then you should favor using a subclass over the base class:
+
+        * :class:`~oci.integration.models.PublicEndpointDetails`
+
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param network_endpoint_type:
+            The value to assign to the network_endpoint_type property of this NetworkEndpointDetails.
+            Allowed values for this property are: "PUBLIC", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type network_endpoint_type: str
+
+        """
+        self.swagger_types = {
+            'network_endpoint_type': 'str'
+        }
+
+        self.attribute_map = {
+            'network_endpoint_type': 'networkEndpointType'
+        }
+
+        self._network_endpoint_type = None
+
+    @staticmethod
+    def get_subtype(object_dictionary):
+        """
+        Given the hash representation of a subtype of this class,
+        use the info in the hash to return the class of the subtype.
+        """
+        type = object_dictionary['networkEndpointType']
+
+        if type == 'PUBLIC':
+            return 'PublicEndpointDetails'
+        else:
+            return 'NetworkEndpointDetails'
+
+    @property
+    def network_endpoint_type(self):
+        """
+        **[Required]** Gets the network_endpoint_type of this NetworkEndpointDetails.
+        The type of network endpoint.
+
+        Allowed values for this property are: "PUBLIC", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The network_endpoint_type of this NetworkEndpointDetails.
+        :rtype: str
+        """
+        return self._network_endpoint_type
+
+    @network_endpoint_type.setter
+    def network_endpoint_type(self, network_endpoint_type):
+        """
+        Sets the network_endpoint_type of this NetworkEndpointDetails.
+        The type of network endpoint.
+
+
+        :param network_endpoint_type: The network_endpoint_type of this NetworkEndpointDetails.
+        :type: str
+        """
+        allowed_values = ["PUBLIC"]
+        if not value_allowed_none_or_none_sentinel(network_endpoint_type, allowed_values):
+            network_endpoint_type = 'UNKNOWN_ENUM_VALUE'
+        self._network_endpoint_type = network_endpoint_type
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/integration/models/public_endpoint_details.py
+++ b/src/oci/integration/models/public_endpoint_details.py
@@ -1,0 +1,142 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .network_endpoint_details import NetworkEndpointDetails
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class PublicEndpointDetails(NetworkEndpointDetails):
+    """
+    Public endpoint configuration details.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new PublicEndpointDetails object with values from keyword arguments. The default value of the :py:attr:`~oci.integration.models.PublicEndpointDetails.network_endpoint_type` attribute
+        of this class is ``PUBLIC`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param network_endpoint_type:
+            The value to assign to the network_endpoint_type property of this PublicEndpointDetails.
+            Allowed values for this property are: "PUBLIC"
+        :type network_endpoint_type: str
+
+        :param allowlisted_http_ips:
+            The value to assign to the allowlisted_http_ips property of this PublicEndpointDetails.
+        :type allowlisted_http_ips: list[str]
+
+        :param allowlisted_http_vcns:
+            The value to assign to the allowlisted_http_vcns property of this PublicEndpointDetails.
+        :type allowlisted_http_vcns: list[oci.integration.models.VirtualCloudNetwork]
+
+        :param is_integration_vcn_allowlisted:
+            The value to assign to the is_integration_vcn_allowlisted property of this PublicEndpointDetails.
+        :type is_integration_vcn_allowlisted: bool
+
+        """
+        self.swagger_types = {
+            'network_endpoint_type': 'str',
+            'allowlisted_http_ips': 'list[str]',
+            'allowlisted_http_vcns': 'list[VirtualCloudNetwork]',
+            'is_integration_vcn_allowlisted': 'bool'
+        }
+
+        self.attribute_map = {
+            'network_endpoint_type': 'networkEndpointType',
+            'allowlisted_http_ips': 'allowlistedHttpIps',
+            'allowlisted_http_vcns': 'allowlistedHttpVcns',
+            'is_integration_vcn_allowlisted': 'isIntegrationVcnAllowlisted'
+        }
+
+        self._network_endpoint_type = None
+        self._allowlisted_http_ips = None
+        self._allowlisted_http_vcns = None
+        self._is_integration_vcn_allowlisted = None
+        self._network_endpoint_type = 'PUBLIC'
+
+    @property
+    def allowlisted_http_ips(self):
+        """
+        Gets the allowlisted_http_ips of this PublicEndpointDetails.
+        Source IP addresses or IP address ranges ingress rules.
+
+
+        :return: The allowlisted_http_ips of this PublicEndpointDetails.
+        :rtype: list[str]
+        """
+        return self._allowlisted_http_ips
+
+    @allowlisted_http_ips.setter
+    def allowlisted_http_ips(self, allowlisted_http_ips):
+        """
+        Sets the allowlisted_http_ips of this PublicEndpointDetails.
+        Source IP addresses or IP address ranges ingress rules.
+
+
+        :param allowlisted_http_ips: The allowlisted_http_ips of this PublicEndpointDetails.
+        :type: list[str]
+        """
+        self._allowlisted_http_ips = allowlisted_http_ips
+
+    @property
+    def allowlisted_http_vcns(self):
+        """
+        Gets the allowlisted_http_vcns of this PublicEndpointDetails.
+        Virtual Cloud Networks allowed to access this network endpoint.
+
+
+        :return: The allowlisted_http_vcns of this PublicEndpointDetails.
+        :rtype: list[oci.integration.models.VirtualCloudNetwork]
+        """
+        return self._allowlisted_http_vcns
+
+    @allowlisted_http_vcns.setter
+    def allowlisted_http_vcns(self, allowlisted_http_vcns):
+        """
+        Sets the allowlisted_http_vcns of this PublicEndpointDetails.
+        Virtual Cloud Networks allowed to access this network endpoint.
+
+
+        :param allowlisted_http_vcns: The allowlisted_http_vcns of this PublicEndpointDetails.
+        :type: list[oci.integration.models.VirtualCloudNetwork]
+        """
+        self._allowlisted_http_vcns = allowlisted_http_vcns
+
+    @property
+    def is_integration_vcn_allowlisted(self):
+        """
+        Gets the is_integration_vcn_allowlisted of this PublicEndpointDetails.
+        The Integration service's VCN is allow-listed to allow integrations to call back into other integrations
+
+
+        :return: The is_integration_vcn_allowlisted of this PublicEndpointDetails.
+        :rtype: bool
+        """
+        return self._is_integration_vcn_allowlisted
+
+    @is_integration_vcn_allowlisted.setter
+    def is_integration_vcn_allowlisted(self, is_integration_vcn_allowlisted):
+        """
+        Sets the is_integration_vcn_allowlisted of this PublicEndpointDetails.
+        The Integration service's VCN is allow-listed to allow integrations to call back into other integrations
+
+
+        :param is_integration_vcn_allowlisted: The is_integration_vcn_allowlisted of this PublicEndpointDetails.
+        :type: bool
+        """
+        self._is_integration_vcn_allowlisted = is_integration_vcn_allowlisted
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/integration/models/virtual_cloud_network.py
+++ b/src/oci/integration/models/virtual_cloud_network.py
@@ -1,0 +1,101 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class VirtualCloudNetwork(object):
+    """
+    Virtual Cloud Network definition.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new VirtualCloudNetwork object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this VirtualCloudNetwork.
+        :type id: str
+
+        :param allowlisted_ips:
+            The value to assign to the allowlisted_ips property of this VirtualCloudNetwork.
+        :type allowlisted_ips: list[str]
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'allowlisted_ips': 'list[str]'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'allowlisted_ips': 'allowlistedIps'
+        }
+
+        self._id = None
+        self._allowlisted_ips = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this VirtualCloudNetwork.
+        The Virtual Cloud Network OCID.
+
+
+        :return: The id of this VirtualCloudNetwork.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this VirtualCloudNetwork.
+        The Virtual Cloud Network OCID.
+
+
+        :param id: The id of this VirtualCloudNetwork.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def allowlisted_ips(self):
+        """
+        Gets the allowlisted_ips of this VirtualCloudNetwork.
+        Source IP addresses or IP address ranges ingress rules.
+
+
+        :return: The allowlisted_ips of this VirtualCloudNetwork.
+        :rtype: list[str]
+        """
+        return self._allowlisted_ips
+
+    @allowlisted_ips.setter
+    def allowlisted_ips(self, allowlisted_ips):
+        """
+        Sets the allowlisted_ips of this VirtualCloudNetwork.
+        Source IP addresses or IP address ranges ingress rules.
+
+
+        :param allowlisted_ips: The allowlisted_ips of this VirtualCloudNetwork.
+        :type: list[str]
+        """
+        self._allowlisted_ips = allowlisted_ips
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/version.py
+++ b/src/oci/version.py
@@ -2,4 +2,4 @@
 # Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
 # This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 
-__version__ = "2.31.0"
+__version__ = "2.31.1"


### PR DESCRIPTION
## Added

* Support for scan DNS names and zone ids on database system, cloud VM cluster, and autonomous Exadata infrastructure responses in the Database service

* Support for specifying ACL rules to limit ingress into public load balancers in the Integration service

* Support for Cloud at Customer as a source type in the Application Migration service

* Support for selective migration of specific resources in the Application Migration service