### PR TITLE
Releasing version 2.32.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 ====================
+2.32.0 - 2021-03-02
+====================
+
+Added
+-----
+* Support for pipelines, pipeline tasks, and favorites in the Data Integration service
+* Support for publishing tasks to OCI Data Flow in the Data Integration service
+* Support for clones in the File Storage service
+
+Breaking
+--------
+* Changed model `UniqueKey` in the Dataintegration service to not inherit from Key.
+* Changed model `PrimaryKey` in the Dataintegration service to inherit from `UniqueKey`.
+* Removed enum values `PRIMARY_KEY` and `UNIQUE_KEY` in property `model_type` from model `key` in the Dataintegration service.
+
+====================
 2.31.2 - 2021-02-23
 ====================
 

--- a/docs/api/data_integration.rst
+++ b/docs/api/data_integration.rst
@@ -21,9 +21,11 @@ Data Integration
     oci.data_integration.models.AbstractDataOperationConfig
     oci.data_integration.models.AbstractField
     oci.data_integration.models.AbstractFormatAttribute
+    oci.data_integration.models.AbstractFrequencyDetails
     oci.data_integration.models.AbstractReadAttribute
     oci.data_integration.models.AbstractWriteAttribute
     oci.data_integration.models.Aggregator
+    oci.data_integration.models.AggregatorSummary
     oci.data_integration.models.Application
     oci.data_integration.models.ApplicationDetails
     oci.data_integration.models.ApplicationSummary
@@ -35,6 +37,7 @@ Data Integration
     oci.data_integration.models.ChildReferenceDetail
     oci.data_integration.models.CompositeFieldMap
     oci.data_integration.models.CompositeType
+    oci.data_integration.models.Compression
     oci.data_integration.models.ConditionalInputLink
     oci.data_integration.models.ConfigDefinition
     oci.data_integration.models.ConfigParameterDefinition
@@ -96,17 +99,22 @@ Data Integration
     oci.data_integration.models.CreateExternalPublicationValidationDetails
     oci.data_integration.models.CreateFolderDetails
     oci.data_integration.models.CreatePatchDetails
+    oci.data_integration.models.CreatePipelineDetails
+    oci.data_integration.models.CreatePipelineValidationDetails
     oci.data_integration.models.CreateProjectDetails
     oci.data_integration.models.CreateSourceApplicationInfo
     oci.data_integration.models.CreateTaskDetails
     oci.data_integration.models.CreateTaskFromDataLoaderTask
     oci.data_integration.models.CreateTaskFromIntegrationTask
+    oci.data_integration.models.CreateTaskFromPipelineTask
     oci.data_integration.models.CreateTaskRunDetails
     oci.data_integration.models.CreateTaskValidationDetails
     oci.data_integration.models.CreateTaskValidationFromDataLoaderTask
     oci.data_integration.models.CreateTaskValidationFromIntegrationTask
+    oci.data_integration.models.CreateTaskValidationFromPipelineTask
     oci.data_integration.models.CreateWorkspaceDetails
     oci.data_integration.models.CsvFormatAttribute
+    oci.data_integration.models.DailyFrequencyDetails
     oci.data_integration.models.DataAsset
     oci.data_integration.models.DataAssetFromAdwcDetails
     oci.data_integration.models.DataAssetFromAtpDetails
@@ -156,6 +164,7 @@ Data Integration
     oci.data_integration.models.DynamicProxyField
     oci.data_integration.models.DynamicType
     oci.data_integration.models.DynamicTypeHandler
+    oci.data_integration.models.EndOperator
     oci.data_integration.models.EnrichedEntity
     oci.data_integration.models.EntityShape
     oci.data_integration.models.EntityShapeFromFile
@@ -178,9 +187,11 @@ Data Integration
     oci.data_integration.models.FolderSummary
     oci.data_integration.models.FolderSummaryCollection
     oci.data_integration.models.ForeignKey
+    oci.data_integration.models.HourlyFrequencyDetails
     oci.data_integration.models.InputField
     oci.data_integration.models.InputLink
     oci.data_integration.models.InputPort
+    oci.data_integration.models.Intersect
     oci.data_integration.models.JavaType
     oci.data_integration.models.Join
     oci.data_integration.models.Joiner
@@ -189,12 +200,17 @@ Data Integration
     oci.data_integration.models.KeyAttribute
     oci.data_integration.models.KeyRange
     oci.data_integration.models.KeyRangePartitionConfig
+    oci.data_integration.models.LastRunDetails
     oci.data_integration.models.MacroField
+    oci.data_integration.models.MergeOperator
     oci.data_integration.models.Message
+    oci.data_integration.models.Minus
+    oci.data_integration.models.MonthlyFrequencyDetails
     oci.data_integration.models.NameListRule
     oci.data_integration.models.NamePatternRule
     oci.data_integration.models.NativeShapeField
     oci.data_integration.models.ObjectMetadata
+    oci.data_integration.models.OciVaultSecretConfig
     oci.data_integration.models.Operator
     oci.data_integration.models.OracleAdwcWriteAttribute
     oci.data_integration.models.OracleAdwcWriteAttributes
@@ -217,6 +233,12 @@ Data Integration
     oci.data_integration.models.PatchObjectMetadata
     oci.data_integration.models.PatchSummary
     oci.data_integration.models.PatchSummaryCollection
+    oci.data_integration.models.Pipeline
+    oci.data_integration.models.PipelineSummary
+    oci.data_integration.models.PipelineSummaryCollection
+    oci.data_integration.models.PipelineValidation
+    oci.data_integration.models.PipelineValidationSummary
+    oci.data_integration.models.PipelineValidationSummaryCollection
     oci.data_integration.models.PrimaryKey
     oci.data_integration.models.Project
     oci.data_integration.models.ProjectDetails
@@ -228,6 +250,8 @@ Data Integration
     oci.data_integration.models.PublishedObject
     oci.data_integration.models.PublishedObjectFromDataLoaderTask
     oci.data_integration.models.PublishedObjectFromIntegrationTask
+    oci.data_integration.models.PublishedObjectFromPipelineTask
+    oci.data_integration.models.PublishedObjectFromPipelineTaskSummary
     oci.data_integration.models.PublishedObjectSummary
     oci.data_integration.models.PublishedObjectSummaryCollection
     oci.data_integration.models.PublishedObjectSummaryFromDataLoaderTask
@@ -245,10 +269,14 @@ Data Integration
     oci.data_integration.models.RootObject
     oci.data_integration.models.RuleBasedFieldMap
     oci.data_integration.models.RuleTypeConfig
+    oci.data_integration.models.Schedule
     oci.data_integration.models.Schema
+    oci.data_integration.models.SchemaDriftConfig
     oci.data_integration.models.SchemaSummary
     oci.data_integration.models.SchemaSummaryCollection
+    oci.data_integration.models.SecretConfig
     oci.data_integration.models.Select
+    oci.data_integration.models.SensitiveAttribute
     oci.data_integration.models.Shape
     oci.data_integration.models.ShapeField
     oci.data_integration.models.Sort
@@ -258,29 +286,36 @@ Data Integration
     oci.data_integration.models.SortOper
     oci.data_integration.models.Source
     oci.data_integration.models.SourceApplicationInfo
+    oci.data_integration.models.StartOperator
     oci.data_integration.models.StructuredType
     oci.data_integration.models.Target
     oci.data_integration.models.Task
     oci.data_integration.models.TaskFromDataLoaderTaskDetails
     oci.data_integration.models.TaskFromIntegrationTaskDetails
+    oci.data_integration.models.TaskFromPipelineTaskDetails
+    oci.data_integration.models.TaskOperator
     oci.data_integration.models.TaskRun
     oci.data_integration.models.TaskRunDetails
     oci.data_integration.models.TaskRunLogSummary
     oci.data_integration.models.TaskRunSummary
     oci.data_integration.models.TaskRunSummaryCollection
+    oci.data_integration.models.TaskSchedule
     oci.data_integration.models.TaskSummary
     oci.data_integration.models.TaskSummaryCollection
     oci.data_integration.models.TaskSummaryFromDataLoaderTask
     oci.data_integration.models.TaskSummaryFromIntegrationTask
+    oci.data_integration.models.TaskSummaryFromPipelineTask
     oci.data_integration.models.TaskValidation
     oci.data_integration.models.TaskValidationSummary
     oci.data_integration.models.TaskValidationSummaryCollection
+    oci.data_integration.models.Time
     oci.data_integration.models.TypeLibrary
     oci.data_integration.models.TypeListRule
     oci.data_integration.models.TypeSystem
     oci.data_integration.models.TypedNamePatternRule
     oci.data_integration.models.TypedObject
     oci.data_integration.models.UIProperties
+    oci.data_integration.models.Union
     oci.data_integration.models.UniqueKey
     oci.data_integration.models.UpdateApplicationDetails
     oci.data_integration.models.UpdateConnectionDetails
@@ -300,14 +335,17 @@ Data Integration
     oci.data_integration.models.UpdateDataFlowDetails
     oci.data_integration.models.UpdateExternalPublicationDetails
     oci.data_integration.models.UpdateFolderDetails
+    oci.data_integration.models.UpdatePipelineDetails
     oci.data_integration.models.UpdateProjectDetails
     oci.data_integration.models.UpdateReferenceDetails
     oci.data_integration.models.UpdateTaskDetails
     oci.data_integration.models.UpdateTaskFromDataLoaderTask
     oci.data_integration.models.UpdateTaskFromIntegrationTask
+    oci.data_integration.models.UpdateTaskFromPipelineTask
     oci.data_integration.models.UpdateTaskRunDetails
     oci.data_integration.models.UpdateWorkspaceDetails
     oci.data_integration.models.ValidationMessage
+    oci.data_integration.models.Variable
     oci.data_integration.models.WorkRequest
     oci.data_integration.models.WorkRequestError
     oci.data_integration.models.WorkRequestLogEntry

--- a/docs/api/data_integration/models/oci.data_integration.models.AbstractFrequencyDetails.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.AbstractFrequencyDetails.rst
@@ -1,0 +1,11 @@
+AbstractFrequencyDetails
+========================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: AbstractFrequencyDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.AggregatorSummary.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.AggregatorSummary.rst
@@ -1,0 +1,11 @@
+AggregatorSummary
+=================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: AggregatorSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.Compression.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.Compression.rst
@@ -1,0 +1,11 @@
+Compression
+===========
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: Compression
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.CreatePipelineDetails.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.CreatePipelineDetails.rst
@@ -1,0 +1,11 @@
+CreatePipelineDetails
+=====================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: CreatePipelineDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.CreatePipelineValidationDetails.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.CreatePipelineValidationDetails.rst
@@ -1,0 +1,11 @@
+CreatePipelineValidationDetails
+===============================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: CreatePipelineValidationDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.CreateTaskFromPipelineTask.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.CreateTaskFromPipelineTask.rst
@@ -1,0 +1,11 @@
+CreateTaskFromPipelineTask
+==========================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: CreateTaskFromPipelineTask
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.CreateTaskValidationFromPipelineTask.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.CreateTaskValidationFromPipelineTask.rst
@@ -1,0 +1,11 @@
+CreateTaskValidationFromPipelineTask
+====================================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: CreateTaskValidationFromPipelineTask
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.DailyFrequencyDetails.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.DailyFrequencyDetails.rst
@@ -1,0 +1,11 @@
+DailyFrequencyDetails
+=====================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: DailyFrequencyDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.EndOperator.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.EndOperator.rst
@@ -1,0 +1,11 @@
+EndOperator
+===========
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: EndOperator
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.HourlyFrequencyDetails.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.HourlyFrequencyDetails.rst
@@ -1,0 +1,11 @@
+HourlyFrequencyDetails
+======================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: HourlyFrequencyDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.Intersect.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.Intersect.rst
@@ -1,0 +1,11 @@
+Intersect
+=========
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: Intersect
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.LastRunDetails.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.LastRunDetails.rst
@@ -1,0 +1,11 @@
+LastRunDetails
+==============
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: LastRunDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.MergeOperator.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.MergeOperator.rst
@@ -1,0 +1,11 @@
+MergeOperator
+=============
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: MergeOperator
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.Minus.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.Minus.rst
@@ -1,0 +1,11 @@
+Minus
+=====
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: Minus
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.MonthlyFrequencyDetails.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.MonthlyFrequencyDetails.rst
@@ -1,0 +1,11 @@
+MonthlyFrequencyDetails
+=======================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: MonthlyFrequencyDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.OciVaultSecretConfig.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.OciVaultSecretConfig.rst
@@ -1,0 +1,11 @@
+OciVaultSecretConfig
+====================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: OciVaultSecretConfig
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.Pipeline.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.Pipeline.rst
@@ -1,0 +1,11 @@
+Pipeline
+========
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: Pipeline
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.PipelineSummary.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.PipelineSummary.rst
@@ -1,0 +1,11 @@
+PipelineSummary
+===============
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: PipelineSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.PipelineSummaryCollection.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.PipelineSummaryCollection.rst
@@ -1,0 +1,11 @@
+PipelineSummaryCollection
+=========================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: PipelineSummaryCollection
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.PipelineValidation.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.PipelineValidation.rst
@@ -1,0 +1,11 @@
+PipelineValidation
+==================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: PipelineValidation
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.PipelineValidationSummary.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.PipelineValidationSummary.rst
@@ -1,0 +1,11 @@
+PipelineValidationSummary
+=========================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: PipelineValidationSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.PipelineValidationSummaryCollection.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.PipelineValidationSummaryCollection.rst
@@ -1,0 +1,11 @@
+PipelineValidationSummaryCollection
+===================================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: PipelineValidationSummaryCollection
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.PublishedObjectFromPipelineTask.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.PublishedObjectFromPipelineTask.rst
@@ -1,0 +1,11 @@
+PublishedObjectFromPipelineTask
+===============================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: PublishedObjectFromPipelineTask
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.PublishedObjectFromPipelineTaskSummary.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.PublishedObjectFromPipelineTaskSummary.rst
@@ -1,0 +1,11 @@
+PublishedObjectFromPipelineTaskSummary
+======================================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: PublishedObjectFromPipelineTaskSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.Schedule.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.Schedule.rst
@@ -1,0 +1,11 @@
+Schedule
+========
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: Schedule
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.SchemaDriftConfig.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.SchemaDriftConfig.rst
@@ -1,0 +1,11 @@
+SchemaDriftConfig
+=================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: SchemaDriftConfig
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.SecretConfig.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.SecretConfig.rst
@@ -1,0 +1,11 @@
+SecretConfig
+============
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: SecretConfig
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.SensitiveAttribute.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.SensitiveAttribute.rst
@@ -1,0 +1,11 @@
+SensitiveAttribute
+==================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: SensitiveAttribute
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.StartOperator.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.StartOperator.rst
@@ -1,0 +1,11 @@
+StartOperator
+=============
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: StartOperator
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.TaskFromPipelineTaskDetails.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.TaskFromPipelineTaskDetails.rst
@@ -1,0 +1,11 @@
+TaskFromPipelineTaskDetails
+===========================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: TaskFromPipelineTaskDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.TaskOperator.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.TaskOperator.rst
@@ -1,0 +1,11 @@
+TaskOperator
+============
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: TaskOperator
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.TaskSchedule.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.TaskSchedule.rst
@@ -1,0 +1,11 @@
+TaskSchedule
+============
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: TaskSchedule
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.TaskSummaryFromPipelineTask.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.TaskSummaryFromPipelineTask.rst
@@ -1,0 +1,11 @@
+TaskSummaryFromPipelineTask
+===========================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: TaskSummaryFromPipelineTask
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.Time.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.Time.rst
@@ -1,0 +1,11 @@
+Time
+====
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: Time
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.Union.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.Union.rst
@@ -1,0 +1,11 @@
+Union
+=====
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: Union
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.UpdatePipelineDetails.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.UpdatePipelineDetails.rst
@@ -1,0 +1,11 @@
+UpdatePipelineDetails
+=====================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: UpdatePipelineDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.UpdateTaskFromPipelineTask.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.UpdateTaskFromPipelineTask.rst
@@ -1,0 +1,11 @@
+UpdateTaskFromPipelineTask
+==========================
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: UpdateTaskFromPipelineTask
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_integration/models/oci.data_integration.models.Variable.rst
+++ b/docs/api/data_integration/models/oci.data_integration.models.Variable.rst
@@ -1,0 +1,11 @@
+Variable
+========
+
+.. currentmodule:: oci.data_integration.models
+
+.. autoclass:: Variable
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/file_storage.rst
+++ b/docs/api/file_storage.rst
@@ -35,6 +35,7 @@ File Storage
     oci.file_storage.models.MountTargetSummary
     oci.file_storage.models.Snapshot
     oci.file_storage.models.SnapshotSummary
+    oci.file_storage.models.SourceDetails
     oci.file_storage.models.UpdateExportDetails
     oci.file_storage.models.UpdateExportSetDetails
     oci.file_storage.models.UpdateFileSystemDetails

--- a/docs/api/file_storage/models/oci.file_storage.models.SourceDetails.rst
+++ b/docs/api/file_storage/models/oci.file_storage.models.SourceDetails.rst
@@ -1,0 +1,11 @@
+SourceDetails
+=============
+
+.. currentmodule:: oci.file_storage.models
+
+.. autoclass:: SourceDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/examples/showoci/CHANGELOG.rst
+++ b/examples/showoci/CHANGELOG.rst
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 
 =====================
+21.02.30 - 21.02.30
+=====================
+* Added Created for database componenets
+* Added internal fqdn to compute and CSV
+
+=====================
 21.01.21 - 21.01.21
 =====================
 * Added SGW transit route

--- a/examples/showoci/showoci.py
+++ b/examples/showoci/showoci.py
@@ -92,7 +92,7 @@ import sys
 import argparse
 import datetime
 
-version = "21.01.21"
+version = "21.03.02"
 
 ##########################################################################
 # check OCI version

--- a/examples/showoci/showoci_data.py
+++ b/examples/showoci/showoci_data.py
@@ -1590,7 +1590,11 @@ class ShowOCIData(object):
 
                     if 'vnic_details' in vnic:
                         if 'display_name' in vnic['vnic_details']:
-                            val = {'id': vnic['vnic_id'], 'desc': vnic['vnic_details']['display_name'] + str(comp_text), 'details': vnic['vnic_details']}
+                            val = {
+                                'id': vnic['vnic_id'],
+                                'desc': vnic['vnic_details']['display_name'] + str(comp_text),
+                                'details': vnic['vnic_details']
+                            }
                             if 'ip_addresses' in vnic['vnic_details']:
                                 val['ip_addresses'] = vnic['vnic_details']['ip_addresses']
                             vnicdata.append(val)
@@ -2162,6 +2166,7 @@ class ShowOCIData(object):
 
             for dbs in list_autos:
                 freemsg = ",  FreeTier" if dbs['is_free_tier'] else ""
+                freesum = "Free " if dbs['is_free_tier'] else ""
                 value = {'id': str(dbs['id']),
                          'name': str(dbs['db_name']) + " (" + (str(dbs['display_name']) + ") - " + str(dbs['license_model']) + " - " + str(dbs['lifecycle_state']) + " (" + str(dbs['sum_count']) + " OCPUs" + (" AutoScale" if dbs['is_auto_scaling_enabled'] else "") + ") - " + dbs['db_workload'] + " - " + dbs['db_type'] + freemsg),
                          'display_name': dbs['display_name'],
@@ -2175,11 +2180,11 @@ class ShowOCIData(object):
                          'service_console_url': str(dbs['service_console_url']),
                          'time_created': str(dbs['time_created'])[0:16],
                          'connection_strings': str(dbs['connection_strings']),
-                         'sum_info': "Autonomous Database " + str(dbs['db_workload']) + " (OCPUs) - " + dbs['license_model'],
-                         'sum_info_stopped': "Stopped Autonomous Database " + str(dbs['db_workload']) + " (Count) - " + dbs['license_model'],
-                         'sum_info_count': "Autonomous Database " + str(dbs['db_workload']) + " (Count) - " + dbs['license_model'],
+                         'sum_info': "Autonomous Database " + freesum + str(dbs['db_workload']) + " (OCPUs) - " + dbs['license_model'],
+                         'sum_info_stopped': "Stopped Autonomous Database " + freesum + str(dbs['db_workload']) + " (Count) - " + dbs['license_model'],
+                         'sum_info_count': "Autonomous Database " + freesum + str(dbs['db_workload']) + " (Count) - " + dbs['license_model'],
                          'sum_count': str(dbs['sum_count']),
-                         'sum_info_storage': "Autonomous Database (TB)",
+                         'sum_info_storage': "Autonomous Database " + freesum + "(TB)",
                          'sum_size_tb': str(dbs['data_storage_size_in_tbs']), 'backups': self.__get_database_autonomous_backups(dbs['backups']),
                          'whitelisted_ips': dbs['whitelisted_ips'],
                          'is_auto_scaling_enabled': dbs['is_auto_scaling_enabled'],

--- a/examples/showoci/showoci_output.py
+++ b/examples/showoci/showoci_output.py
@@ -900,6 +900,7 @@ class ShowOCIOutput(object):
                 print("")
 
                 print(self.taba + "ExaCS   : " + dbs['name'])
+                print(self.tabs + "Created : " + dbs['time_created'][0:16])
                 print(self.tabs + "AD      : " + dbs['availability_domain'])
 
                 if 'compute_count' in dbs:
@@ -1025,6 +1026,7 @@ class ShowOCIOutput(object):
     def __print_database_db_system_details(self, dbs):
         try:
             print(self.taba + "DBaaS   : " + dbs['name'] + " - " + dbs['version'])
+            print(self.tabs + "Created : " + dbs['time_created'][0:16])
             print(self.tabs + "AD      : " + dbs['availability_domain'])
 
             if 'cpu_core_count' in dbs:
@@ -1832,6 +1834,9 @@ class ShowOCIOutput(object):
                         if 'nsg_names' in vnic['details']:
                             if vnic['details']['nsg_names']:
                                 print(self.tabs2 + "     : SecGrp: " + vnic['details']['nsg_names'])
+                        if 'internal_fqdn' in vnic['details']:
+                            if vnic['details']['internal_fqdn']:
+                                print(self.tabs2 + "     : Int FQDN     : " + vnic['details']['internal_fqdn'])
                         if 'ip_addresses' in vnic:
                             print(self.tabs2 + "     : IP Addresses : " + str(', '.join(x['ip_address'] for x in vnic['ip_addresses'])))
 
@@ -3619,6 +3624,7 @@ class ShowOCICSV(object):
                         'public_ips': str(', '.join(x['details']['public_ip'] for x in instance['vnic'])),
                         'private_ips': str(', '.join(x['details']['private_ip'] for x in instance['vnic'])),
                         'security_groups': str(', '.join(x['details']['nsg_names'] for x in instance['vnic'])),
+                        'internal_fqdn': str(', '.join(x['details']['internal_fqdn'] for x in instance['vnic'])),
                         'time_created': instance['time_created'][0:16],
                         'boot_volume': "",
                         'boot_volume_size_gb': "",

--- a/examples/showoci/showoci_service.py
+++ b/examples/showoci/showoci_service.py
@@ -1952,6 +1952,7 @@ class ShowOCIService(object):
                            'ipv6_cidr_block': str(vcn.ipv6_cidr_block),
                            'ipv6_public_cidr_block': str(vcn.ipv6_public_cidr_block),
                            'time_created': str(vcn.time_created),
+                           'vcn_domain_name': str(vcn.vcn_domain_name),
                            'compartment_name': str(compartment['name']),
                            'defined_tags': [] if vcn.defined_tags is None else vcn.defined_tags,
                            'freeform_tags': [] if vcn.freeform_tags is None else vcn.freeform_tags,
@@ -2902,6 +2903,8 @@ class ShowOCIService(object):
                            'vcn_id': str(subnet.vcn_id),
                            'vcn_name': "",
                            'vcn_cidr': "",
+                           'vcn_domain_name': "",
+                           'dns': "",
                            'name': str(subnet.display_name),
                            'cidr_block': str(subnet.cidr_block),
                            'subnet': (str(subnet.cidr_block) + "  " + availability_domain + (" (Private) " if subnet.prohibit_public_ip_on_vnic else " (Public)")),
@@ -2910,7 +2913,8 @@ class ShowOCIService(object):
                            'time_created': str(subnet.time_created),
                            'security_list_ids': [str(es) for es in subnet.security_list_ids],
                            'dhcp_options_id': str(subnet.dhcp_options_id),
-                           'route_table_id': str(subnet.route_table_id), 'dns_label': str(subnet.dns_label),
+                           'route_table_id': str(subnet.route_table_id),
+                           'dns_label': str(subnet.dns_label),
                            'defined_tags': [] if subnet.defined_tags is None else subnet.defined_tags,
                            'freeform_tags': [] if subnet.freeform_tags is None else subnet.freeform_tags,
                            'compartment_name': str(compartment['name']), 'compartment_id': str(compartment['id']),
@@ -2920,7 +2924,9 @@ class ShowOCIService(object):
                     # find vcn
                     for vcn in vcns:
                         if str(subnet.vcn_id) == vcn['id']:
+                            val['dns'] = str(subnet.dns_label) + "." + vcn['vcn_domain_name']
                             val['vcn_name'] = vcn['display_name']
+                            val['vcn_domain_name'] = vcn['vcn_domain_name']
                             val['vcn_cidr'] = str(', '.join(x for x in vcn['cidr_blocks']))
 
                     data.append(val)
@@ -4303,6 +4309,10 @@ class ShowOCIService(object):
             data['skip_source_dest_check'] = vnic.skip_source_dest_check
             data['is_primary'] = vnic.is_primary
             data['subnet'] = ""
+            data['hostname_label'] = str(vnic.hostname_label)
+            data['internal_fqdn'] = ""
+            data['mac_address'] = str(vnic.mac_address)
+            data['time_created'] = str(vnic.time_created)
             data['subnet_id'] = ""
             data['nsg_ids'] = [x for x in vnic.nsg_ids]
             data['nsg_names'] = self.__load_core_network_get_nsg_names(vnic.nsg_ids)
@@ -4316,6 +4326,7 @@ class ShowOCIService(object):
                 data['vcn'] = subnet['vcn_name'] + " " + subnet['vcn_cidr']
                 data['subnet_id'] = subnet['id']
                 subnet_display = ", Subnet (" + data['subnet'] + "), VCN (" + data['vcn'] + ")"
+                data['internal_fqdn'] = str(vnic.hostname_label) + '.' + subnet['dns']
 
             # check vnic information
             if vnic.public_ip is not None:

--- a/src/oci/data_integration/data_integration_client.py
+++ b/src/oci/data_integration/data_integration_client.py
@@ -1186,6 +1186,184 @@ class DataIntegrationClient(object):
                 body=create_patch_details,
                 response_type="Patch")
 
+    def create_pipeline(self, workspace_id, create_pipeline_details, **kwargs):
+        """
+        Creates a new pipeline in a project or folder ready for performing task orchestration.
+
+
+        :param str workspace_id: (required)
+            The workspace ID.
+
+        :param oci.data_integration.models.CreatePipelineDetails create_pipeline_details: (required)
+            The details needed to create a new pipeline.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or server error without risk of executing that same action again.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If
+            you need to contact Oracle about a particular request,
+            please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.data_integration.models.Pipeline`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/dataintegration/create_pipeline.py.html>`__ to see an example of how to use create_pipeline API.
+        """
+        resource_path = "/workspaces/{workspaceId}/pipelines"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "create_pipeline got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "workspaceId": workspace_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=create_pipeline_details,
+                response_type="Pipeline")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=create_pipeline_details,
+                response_type="Pipeline")
+
+    def create_pipeline_validation(self, workspace_id, create_pipeline_validation_details, **kwargs):
+        """
+        Accepts the data flow definition in the request payload and creates a pipeline validation.
+
+
+        :param str workspace_id: (required)
+            The workspace ID.
+
+        :param oci.data_integration.models.CreatePipelineValidationDetails create_pipeline_validation_details: (required)
+            The information needed to create the data flow validation for the pipeline object.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If
+            you need to contact Oracle about a particular request,
+            please provide the request ID.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or server error without risk of executing that same action again.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.data_integration.models.PipelineValidation`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/dataintegration/create_pipeline_validation.py.html>`__ to see an example of how to use create_pipeline_validation API.
+        """
+        resource_path = "/workspaces/{workspaceId}/pipelineValidations"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "create_pipeline_validation got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "workspaceId": workspace_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=create_pipeline_validation_details,
+                response_type="PipelineValidation")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=create_pipeline_validation_details,
+                response_type="PipelineValidation")
+
     def create_project(self, workspace_id, create_project_details, **kwargs):
         """
         Creates a project. Projects are organizational constructs within a workspace that you use to organize your design-time resources, such as tasks or data flows. Projects can be organized into folders.
@@ -2456,6 +2634,178 @@ class DataIntegrationClient(object):
             "workspaceId": workspace_id,
             "applicationKey": application_key,
             "patchKey": patch_key
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
+    def delete_pipeline(self, workspace_id, pipeline_key, **kwargs):
+        """
+        Removes a pipeline from a project or folder using the specified identifier.
+
+
+        :param str workspace_id: (required)
+            The workspace ID.
+
+        :param str pipeline_key: (required)
+            The pipeline key.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match` parameter to the value of the `etag` from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the `etag` you provide matches the resource's current `etag` value.
+            When 'if-match' is provided and its value does not exactly match the 'etag' of the resource on the server, the request fails with the 412 response code.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If
+            you need to contact Oracle about a particular request,
+            please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/dataintegration/delete_pipeline.py.html>`__ to see an example of how to use delete_pipeline API.
+        """
+        resource_path = "/workspaces/{workspaceId}/pipelines/{pipelineKey}"
+        method = "DELETE"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "delete_pipeline got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "workspaceId": workspace_id,
+            "pipelineKey": pipeline_key
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
+    def delete_pipeline_validation(self, workspace_id, pipeline_validation_key, **kwargs):
+        """
+        Removes a pipeline validation using the specified identifier.
+
+
+        :param str workspace_id: (required)
+            The workspace ID.
+
+        :param str pipeline_validation_key: (required)
+            The key of the pipeline validation.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match` parameter to the value of the `etag` from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the `etag` you provide matches the resource's current `etag` value.
+            When 'if-match' is provided and its value does not exactly match the 'etag' of the resource on the server, the request fails with the 412 response code.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If
+            you need to contact Oracle about a particular request,
+            please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/dataintegration/delete_pipeline_validation.py.html>`__ to see an example of how to use delete_pipeline_validation API.
+        """
+        resource_path = "/workspaces/{workspaceId}/pipelineValidations/{pipelineValidationKey}"
+        method = "DELETE"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "delete_pipeline_validation got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "workspaceId": workspace_id,
+            "pipelineValidationKey": pipeline_validation_key
         }
 
         path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
@@ -4014,6 +4364,168 @@ class DataIntegrationClient(object):
                 header_params=header_params,
                 response_type="Patch")
 
+    def get_pipeline(self, workspace_id, pipeline_key, **kwargs):
+        """
+        Retrieves a pipeline using the specified identifier.
+
+
+        :param str workspace_id: (required)
+            The workspace ID.
+
+        :param str pipeline_key: (required)
+            The pipeline key.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If
+            you need to contact Oracle about a particular request,
+            please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.data_integration.models.Pipeline`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/dataintegration/get_pipeline.py.html>`__ to see an example of how to use get_pipeline API.
+        """
+        resource_path = "/workspaces/{workspaceId}/pipelines/{pipelineKey}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_pipeline got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "workspaceId": workspace_id,
+            "pipelineKey": pipeline_key
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="Pipeline")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="Pipeline")
+
+    def get_pipeline_validation(self, workspace_id, pipeline_validation_key, **kwargs):
+        """
+        Retrieves a pipeline validation using the specified identifier.
+
+
+        :param str workspace_id: (required)
+            The workspace ID.
+
+        :param str pipeline_validation_key: (required)
+            The key of the pipeline validation.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If
+            you need to contact Oracle about a particular request,
+            please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.data_integration.models.PipelineValidation`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/dataintegration/get_pipeline_validation.py.html>`__ to see an example of how to use get_pipeline_validation API.
+        """
+        resource_path = "/workspaces/{workspaceId}/pipelineValidations/{pipelineValidationKey}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_pipeline_validation got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "workspaceId": workspace_id,
+            "pipelineValidationKey": pipeline_validation_key
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="PipelineValidation")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="PipelineValidation")
+
     def get_project(self, workspace_id, project_key, **kwargs):
         """
         Retrieves a project using the specified identifier.
@@ -4377,6 +4889,9 @@ class DataIntegrationClient(object):
             you need to contact Oracle about a particular request,
             please provide the request ID.
 
+        :param str expand_references: (optional)
+            Used to expand references of the object. If value is true, then all referenced objects are expanded. If value is false, then shallow objects are returned in place of references. Default is false. <br><br><B>Example:</B><br> <ul> <li><B>?expandReferences=true</B> returns all objects of type data loader task</li> </ul>
+
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
 
@@ -4397,7 +4912,8 @@ class DataIntegrationClient(object):
         # Don't accept unknown kwargs
         expected_kwargs = [
             "retry_strategy",
-            "opc_request_id"
+            "opc_request_id",
+            "expand_references"
         ]
         extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
         if extra_kwargs:
@@ -4414,6 +4930,11 @@ class DataIntegrationClient(object):
         for (k, v) in six.iteritems(path_params):
             if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
                 raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        query_params = {
+            "expandReferences": kwargs.get("expand_references", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
 
         header_params = {
             "accept": "application/json",
@@ -4432,6 +4953,7 @@ class DataIntegrationClient(object):
                 resource_path=resource_path,
                 method=method,
                 path_params=path_params,
+                query_params=query_params,
                 header_params=header_params,
                 response_type="Task")
         else:
@@ -4439,6 +4961,7 @@ class DataIntegrationClient(object):
                 resource_path=resource_path,
                 method=method,
                 path_params=path_params,
+                query_params=query_params,
                 header_params=header_params,
                 response_type="Task")
 
@@ -5379,6 +5902,12 @@ class DataIntegrationClient(object):
             you need to contact Oracle about a particular request,
             please provide the request ID.
 
+        :param list[str] name_list: (optional)
+            Used to filter by the name of the object.
+
+        :param bool is_pattern: (optional)
+            This parameter can be used to specify whether entity search type is pattern search or not.
+
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
 
@@ -5406,7 +5935,9 @@ class DataIntegrationClient(object):
             "fields",
             "sort_by",
             "sort_order",
-            "opc_request_id"
+            "opc_request_id",
+            "name_list",
+            "is_pattern"
         ]
         extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
         if extra_kwargs:
@@ -5446,7 +5977,9 @@ class DataIntegrationClient(object):
             "limit": kwargs.get("limit", missing),
             "fields": self.base_client.generate_collection_format_param(kwargs.get("fields", missing), 'multi'),
             "sortBy": kwargs.get("sort_by", missing),
-            "sortOrder": kwargs.get("sort_order", missing)
+            "sortOrder": kwargs.get("sort_order", missing),
+            "nameList": self.base_client.generate_collection_format_param(kwargs.get("name_list", missing), 'multi'),
+            "isPattern": kwargs.get("is_pattern", missing)
         }
         query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
 
@@ -6643,6 +7176,296 @@ class DataIntegrationClient(object):
                 header_params=header_params,
                 response_type="PatchSummaryCollection")
 
+    def list_pipeline_validations(self, workspace_id, **kwargs):
+        """
+        Retrieves a list of pipeline validations within the specified workspace.
+
+
+        :param str workspace_id: (required)
+            The workspace ID.
+
+        :param str key: (optional)
+            Used to filter by the key of the object.
+
+        :param str name: (optional)
+            Used to filter by the name of the object.
+
+        :param str identifier: (optional)
+            Used to filter by the identifier of the object.
+
+        :param list[str] fields: (optional)
+            Specifies the fields to get for an object.
+
+        :param str page: (optional)
+            For list pagination. The value for this parameter is the `opc-next-page` or the `opc-prev-page` response header from the previous `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+
+        :param int limit: (optional)
+            Sets the maximum number of results per page, or items to return in a paginated `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+
+        :param str sort_by: (optional)
+            Specifies the field to sort by. Accepts only one field. By default, when you sort by time fields, results are shown in descending order. All other fields default to ascending order. Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+
+            Allowed values are: "TIME_CREATED", "DISPLAY_NAME"
+
+        :param str sort_order: (optional)
+            Specifies sort order to use, either `ASC` (ascending) or `DESC` (descending).
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If
+            you need to contact Oracle about a particular request,
+            please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.data_integration.models.PipelineValidationSummaryCollection`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/dataintegration/list_pipeline_validations.py.html>`__ to see an example of how to use list_pipeline_validations API.
+        """
+        resource_path = "/workspaces/{workspaceId}/pipelineValidations"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "key",
+            "name",
+            "identifier",
+            "fields",
+            "page",
+            "limit",
+            "sort_by",
+            "sort_order",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_pipeline_validations got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "workspaceId": workspace_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["TIME_CREATED", "DISPLAY_NAME"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        query_params = {
+            "key": kwargs.get("key", missing),
+            "name": kwargs.get("name", missing),
+            "identifier": kwargs.get("identifier", missing),
+            "fields": self.base_client.generate_collection_format_param(kwargs.get("fields", missing), 'multi'),
+            "page": kwargs.get("page", missing),
+            "limit": kwargs.get("limit", missing),
+            "sortBy": kwargs.get("sort_by", missing),
+            "sortOrder": kwargs.get("sort_order", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="PipelineValidationSummaryCollection")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="PipelineValidationSummaryCollection")
+
+    def list_pipelines(self, workspace_id, **kwargs):
+        """
+        Retrieves a list of pipelines in a project or folder from within a workspace, the query parameter specifies the project or folder.
+
+
+        :param str workspace_id: (required)
+            The workspace ID.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If
+            you need to contact Oracle about a particular request,
+            please provide the request ID.
+
+        :param str aggregator_key: (optional)
+            Used to filter by the project or the folder object.
+
+        :param list[str] fields: (optional)
+            Specifies the fields to get for an object.
+
+        :param str name: (optional)
+            Used to filter by the name of the object.
+
+        :param list[str] identifier: (optional)
+            Used to filter by the identifier of the object.
+
+        :param int limit: (optional)
+            Sets the maximum number of results per page, or items to return in a paginated `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+
+        :param str page: (optional)
+            For list pagination. The value for this parameter is the `opc-next-page` or the `opc-prev-page` response header from the previous `List` call. See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+
+        :param str sort_order: (optional)
+            Specifies sort order to use, either `ASC` (ascending) or `DESC` (descending).
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str sort_by: (optional)
+            Specifies the field to sort by. Accepts only one field. By default, when you sort by time fields, results are shown in descending order. All other fields default to ascending order. Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+
+            Allowed values are: "TIME_CREATED", "DISPLAY_NAME"
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.data_integration.models.PipelineSummaryCollection`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/dataintegration/list_pipelines.py.html>`__ to see an example of how to use list_pipelines API.
+        """
+        resource_path = "/workspaces/{workspaceId}/pipelines"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "aggregator_key",
+            "fields",
+            "name",
+            "identifier",
+            "limit",
+            "page",
+            "sort_order",
+            "sort_by"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_pipelines got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "workspaceId": workspace_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["TIME_CREATED", "DISPLAY_NAME"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        query_params = {
+            "aggregatorKey": kwargs.get("aggregator_key", missing),
+            "fields": self.base_client.generate_collection_format_param(kwargs.get("fields", missing), 'multi'),
+            "name": kwargs.get("name", missing),
+            "identifier": self.base_client.generate_collection_format_param(kwargs.get("identifier", missing), 'multi'),
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "sortBy": kwargs.get("sort_by", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="PipelineSummaryCollection")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="PipelineSummaryCollection")
+
     def list_projects(self, workspace_id, **kwargs):
         """
         Retrieves a lists of projects in a workspace and provides options to filter the list.
@@ -7120,6 +7943,9 @@ class DataIntegrationClient(object):
             you need to contact Oracle about a particular request,
             please provide the request ID.
 
+        :param list[str] name_list: (optional)
+            Used to filter by the name of the object.
+
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
 
@@ -7146,7 +7972,8 @@ class DataIntegrationClient(object):
             "sort_by",
             "sort_order",
             "name",
-            "opc_request_id"
+            "opc_request_id",
+            "name_list"
         ]
         extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
         if extra_kwargs:
@@ -7185,7 +8012,8 @@ class DataIntegrationClient(object):
             "sortBy": kwargs.get("sort_by", missing),
             "sortOrder": kwargs.get("sort_order", missing),
             "schemaResourceName": schema_resource_name,
-            "name": kwargs.get("name", missing)
+            "name": kwargs.get("name", missing),
+            "nameList": self.base_client.generate_collection_format_param(kwargs.get("name_list", missing), 'multi')
         }
         query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
 
@@ -7367,6 +8195,9 @@ class DataIntegrationClient(object):
             you need to contact Oracle about a particular request,
             please provide the request ID.
 
+        :param str aggregator_key: (optional)
+            Used to filter by the project or the folder object.
+
         :param list[str] fields: (optional)
             Specifies the fields to get for an object.
 
@@ -7417,6 +8248,7 @@ class DataIntegrationClient(object):
         expected_kwargs = [
             "retry_strategy",
             "opc_request_id",
+            "aggregator_key",
             "fields",
             "name",
             "identifier",
@@ -7456,6 +8288,7 @@ class DataIntegrationClient(object):
                 )
 
         query_params = {
+            "aggregatorKey": kwargs.get("aggregator_key", missing),
             "fields": self.base_client.generate_collection_format_param(kwargs.get("fields", missing), 'multi'),
             "name": kwargs.get("name", missing),
             "identifier": self.base_client.generate_collection_format_param(kwargs.get("identifier", missing), 'multi'),
@@ -8058,6 +8891,9 @@ class DataIntegrationClient(object):
             you need to contact Oracle about a particular request,
             please provide the request ID.
 
+        :param str workspace_id: (optional)
+            DIS workspace id
+
         :param str work_request_status: (optional)
             The work request status.
 
@@ -8104,6 +8940,7 @@ class DataIntegrationClient(object):
         expected_kwargs = [
             "retry_strategy",
             "opc_request_id",
+            "workspace_id",
             "work_request_status",
             "page",
             "limit",
@@ -8138,6 +8975,7 @@ class DataIntegrationClient(object):
 
         query_params = {
             "compartmentId": compartment_id,
+            "workspaceId": kwargs.get("workspace_id", missing),
             "workRequestStatus": kwargs.get("work_request_status", missing),
             "page": kwargs.get("page", missing),
             "limit": kwargs.get("limit", missing),
@@ -9061,6 +9899,99 @@ class DataIntegrationClient(object):
                 header_params=header_params,
                 body=update_folder_details,
                 response_type="Folder")
+
+    def update_pipeline(self, workspace_id, pipeline_key, update_pipeline_details, **kwargs):
+        """
+        Updates a specific pipeline.
+
+
+        :param str workspace_id: (required)
+            The workspace ID.
+
+        :param str pipeline_key: (required)
+            The pipeline key.
+
+        :param oci.data_integration.models.UpdatePipelineDetails update_pipeline_details: (required)
+            The details needed to updated a pipeline.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If
+            you need to contact Oracle about a particular request,
+            please provide the request ID.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match` parameter to the value of the `etag` from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the `etag` you provide matches the resource's current `etag` value.
+            When 'if-match' is provided and its value does not exactly match the 'etag' of the resource on the server, the request fails with the 412 response code.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.data_integration.models.Pipeline`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/dataintegration/update_pipeline.py.html>`__ to see an example of how to use update_pipeline API.
+        """
+        resource_path = "/workspaces/{workspaceId}/pipelines/{pipelineKey}"
+        method = "PUT"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "if_match"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "update_pipeline got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "workspaceId": workspace_id,
+            "pipelineKey": pipeline_key
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_pipeline_details,
+                response_type="Pipeline")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_pipeline_details,
+                response_type="Pipeline")
 
     def update_project(self, workspace_id, project_key, update_project_details, **kwargs):
         """

--- a/src/oci/data_integration/models/__init__.py
+++ b/src/oci/data_integration/models/__init__.py
@@ -7,9 +7,11 @@ from __future__ import absolute_import
 from .abstract_data_operation_config import AbstractDataOperationConfig
 from .abstract_field import AbstractField
 from .abstract_format_attribute import AbstractFormatAttribute
+from .abstract_frequency_details import AbstractFrequencyDetails
 from .abstract_read_attribute import AbstractReadAttribute
 from .abstract_write_attribute import AbstractWriteAttribute
 from .aggregator import Aggregator
+from .aggregator_summary import AggregatorSummary
 from .application import Application
 from .application_details import ApplicationDetails
 from .application_summary import ApplicationSummary
@@ -21,6 +23,7 @@ from .child_reference import ChildReference
 from .child_reference_detail import ChildReferenceDetail
 from .composite_field_map import CompositeFieldMap
 from .composite_type import CompositeType
+from .compression import Compression
 from .conditional_input_link import ConditionalInputLink
 from .config_definition import ConfigDefinition
 from .config_parameter_definition import ConfigParameterDefinition
@@ -82,17 +85,22 @@ from .create_external_publication_details import CreateExternalPublicationDetail
 from .create_external_publication_validation_details import CreateExternalPublicationValidationDetails
 from .create_folder_details import CreateFolderDetails
 from .create_patch_details import CreatePatchDetails
+from .create_pipeline_details import CreatePipelineDetails
+from .create_pipeline_validation_details import CreatePipelineValidationDetails
 from .create_project_details import CreateProjectDetails
 from .create_source_application_info import CreateSourceApplicationInfo
 from .create_task_details import CreateTaskDetails
 from .create_task_from_data_loader_task import CreateTaskFromDataLoaderTask
 from .create_task_from_integration_task import CreateTaskFromIntegrationTask
+from .create_task_from_pipeline_task import CreateTaskFromPipelineTask
 from .create_task_run_details import CreateTaskRunDetails
 from .create_task_validation_details import CreateTaskValidationDetails
 from .create_task_validation_from_data_loader_task import CreateTaskValidationFromDataLoaderTask
 from .create_task_validation_from_integration_task import CreateTaskValidationFromIntegrationTask
+from .create_task_validation_from_pipeline_task import CreateTaskValidationFromPipelineTask
 from .create_workspace_details import CreateWorkspaceDetails
 from .csv_format_attribute import CsvFormatAttribute
+from .daily_frequency_details import DailyFrequencyDetails
 from .data_asset import DataAsset
 from .data_asset_from_adwc_details import DataAssetFromAdwcDetails
 from .data_asset_from_atp_details import DataAssetFromAtpDetails
@@ -142,6 +150,7 @@ from .dynamic_input_field import DynamicInputField
 from .dynamic_proxy_field import DynamicProxyField
 from .dynamic_type import DynamicType
 from .dynamic_type_handler import DynamicTypeHandler
+from .end_operator import EndOperator
 from .enriched_entity import EnrichedEntity
 from .entity_shape import EntityShape
 from .entity_shape_from_file import EntityShapeFromFile
@@ -164,9 +173,11 @@ from .folder_details import FolderDetails
 from .folder_summary import FolderSummary
 from .folder_summary_collection import FolderSummaryCollection
 from .foreign_key import ForeignKey
+from .hourly_frequency_details import HourlyFrequencyDetails
 from .input_field import InputField
 from .input_link import InputLink
 from .input_port import InputPort
+from .intersect import Intersect
 from .java_type import JavaType
 from .join import Join
 from .joiner import Joiner
@@ -175,12 +186,17 @@ from .key import Key
 from .key_attribute import KeyAttribute
 from .key_range import KeyRange
 from .key_range_partition_config import KeyRangePartitionConfig
+from .last_run_details import LastRunDetails
 from .macro_field import MacroField
+from .merge_operator import MergeOperator
 from .message import Message
+from .minus import Minus
+from .monthly_frequency_details import MonthlyFrequencyDetails
 from .name_list_rule import NameListRule
 from .name_pattern_rule import NamePatternRule
 from .native_shape_field import NativeShapeField
 from .object_metadata import ObjectMetadata
+from .oci_vault_secret_config import OciVaultSecretConfig
 from .operator import Operator
 from .oracle_adwc_write_attribute import OracleAdwcWriteAttribute
 from .oracle_adwc_write_attributes import OracleAdwcWriteAttributes
@@ -203,6 +219,12 @@ from .patch_change_summary_collection import PatchChangeSummaryCollection
 from .patch_object_metadata import PatchObjectMetadata
 from .patch_summary import PatchSummary
 from .patch_summary_collection import PatchSummaryCollection
+from .pipeline import Pipeline
+from .pipeline_summary import PipelineSummary
+from .pipeline_summary_collection import PipelineSummaryCollection
+from .pipeline_validation import PipelineValidation
+from .pipeline_validation_summary import PipelineValidationSummary
+from .pipeline_validation_summary_collection import PipelineValidationSummaryCollection
 from .primary_key import PrimaryKey
 from .project import Project
 from .project_details import ProjectDetails
@@ -214,6 +236,8 @@ from .proxy_field import ProxyField
 from .published_object import PublishedObject
 from .published_object_from_data_loader_task import PublishedObjectFromDataLoaderTask
 from .published_object_from_integration_task import PublishedObjectFromIntegrationTask
+from .published_object_from_pipeline_task import PublishedObjectFromPipelineTask
+from .published_object_from_pipeline_task_summary import PublishedObjectFromPipelineTaskSummary
 from .published_object_summary import PublishedObjectSummary
 from .published_object_summary_collection import PublishedObjectSummaryCollection
 from .published_object_summary_from_data_loader_task import PublishedObjectSummaryFromDataLoaderTask
@@ -231,10 +255,14 @@ from .resource_configuration import ResourceConfiguration
 from .root_object import RootObject
 from .rule_based_field_map import RuleBasedFieldMap
 from .rule_type_config import RuleTypeConfig
+from .schedule import Schedule
 from .schema import Schema
+from .schema_drift_config import SchemaDriftConfig
 from .schema_summary import SchemaSummary
 from .schema_summary_collection import SchemaSummaryCollection
+from .secret_config import SecretConfig
 from .select import Select
+from .sensitive_attribute import SensitiveAttribute
 from .shape import Shape
 from .shape_field import ShapeField
 from .sort import Sort
@@ -244,29 +272,36 @@ from .sort_key_rule import SortKeyRule
 from .sort_oper import SortOper
 from .source import Source
 from .source_application_info import SourceApplicationInfo
+from .start_operator import StartOperator
 from .structured_type import StructuredType
 from .target import Target
 from .task import Task
 from .task_from_data_loader_task_details import TaskFromDataLoaderTaskDetails
 from .task_from_integration_task_details import TaskFromIntegrationTaskDetails
+from .task_from_pipeline_task_details import TaskFromPipelineTaskDetails
+from .task_operator import TaskOperator
 from .task_run import TaskRun
 from .task_run_details import TaskRunDetails
 from .task_run_log_summary import TaskRunLogSummary
 from .task_run_summary import TaskRunSummary
 from .task_run_summary_collection import TaskRunSummaryCollection
+from .task_schedule import TaskSchedule
 from .task_summary import TaskSummary
 from .task_summary_collection import TaskSummaryCollection
 from .task_summary_from_data_loader_task import TaskSummaryFromDataLoaderTask
 from .task_summary_from_integration_task import TaskSummaryFromIntegrationTask
+from .task_summary_from_pipeline_task import TaskSummaryFromPipelineTask
 from .task_validation import TaskValidation
 from .task_validation_summary import TaskValidationSummary
 from .task_validation_summary_collection import TaskValidationSummaryCollection
+from .time import Time
 from .type_library import TypeLibrary
 from .type_list_rule import TypeListRule
 from .type_system import TypeSystem
 from .typed_name_pattern_rule import TypedNamePatternRule
 from .typed_object import TypedObject
 from .ui_properties import UIProperties
+from .union import Union
 from .unique_key import UniqueKey
 from .update_application_details import UpdateApplicationDetails
 from .update_connection_details import UpdateConnectionDetails
@@ -286,14 +321,17 @@ from .update_data_asset_from_oracle import UpdateDataAssetFromOracle
 from .update_data_flow_details import UpdateDataFlowDetails
 from .update_external_publication_details import UpdateExternalPublicationDetails
 from .update_folder_details import UpdateFolderDetails
+from .update_pipeline_details import UpdatePipelineDetails
 from .update_project_details import UpdateProjectDetails
 from .update_reference_details import UpdateReferenceDetails
 from .update_task_details import UpdateTaskDetails
 from .update_task_from_data_loader_task import UpdateTaskFromDataLoaderTask
 from .update_task_from_integration_task import UpdateTaskFromIntegrationTask
+from .update_task_from_pipeline_task import UpdateTaskFromPipelineTask
 from .update_task_run_details import UpdateTaskRunDetails
 from .update_workspace_details import UpdateWorkspaceDetails
 from .validation_message import ValidationMessage
+from .variable import Variable
 from .work_request import WorkRequest
 from .work_request_error import WorkRequestError
 from .work_request_log_entry import WorkRequestLogEntry
@@ -308,9 +346,11 @@ data_integration_type_mapping = {
     "AbstractDataOperationConfig": AbstractDataOperationConfig,
     "AbstractField": AbstractField,
     "AbstractFormatAttribute": AbstractFormatAttribute,
+    "AbstractFrequencyDetails": AbstractFrequencyDetails,
     "AbstractReadAttribute": AbstractReadAttribute,
     "AbstractWriteAttribute": AbstractWriteAttribute,
     "Aggregator": Aggregator,
+    "AggregatorSummary": AggregatorSummary,
     "Application": Application,
     "ApplicationDetails": ApplicationDetails,
     "ApplicationSummary": ApplicationSummary,
@@ -322,6 +362,7 @@ data_integration_type_mapping = {
     "ChildReferenceDetail": ChildReferenceDetail,
     "CompositeFieldMap": CompositeFieldMap,
     "CompositeType": CompositeType,
+    "Compression": Compression,
     "ConditionalInputLink": ConditionalInputLink,
     "ConfigDefinition": ConfigDefinition,
     "ConfigParameterDefinition": ConfigParameterDefinition,
@@ -383,17 +424,22 @@ data_integration_type_mapping = {
     "CreateExternalPublicationValidationDetails": CreateExternalPublicationValidationDetails,
     "CreateFolderDetails": CreateFolderDetails,
     "CreatePatchDetails": CreatePatchDetails,
+    "CreatePipelineDetails": CreatePipelineDetails,
+    "CreatePipelineValidationDetails": CreatePipelineValidationDetails,
     "CreateProjectDetails": CreateProjectDetails,
     "CreateSourceApplicationInfo": CreateSourceApplicationInfo,
     "CreateTaskDetails": CreateTaskDetails,
     "CreateTaskFromDataLoaderTask": CreateTaskFromDataLoaderTask,
     "CreateTaskFromIntegrationTask": CreateTaskFromIntegrationTask,
+    "CreateTaskFromPipelineTask": CreateTaskFromPipelineTask,
     "CreateTaskRunDetails": CreateTaskRunDetails,
     "CreateTaskValidationDetails": CreateTaskValidationDetails,
     "CreateTaskValidationFromDataLoaderTask": CreateTaskValidationFromDataLoaderTask,
     "CreateTaskValidationFromIntegrationTask": CreateTaskValidationFromIntegrationTask,
+    "CreateTaskValidationFromPipelineTask": CreateTaskValidationFromPipelineTask,
     "CreateWorkspaceDetails": CreateWorkspaceDetails,
     "CsvFormatAttribute": CsvFormatAttribute,
+    "DailyFrequencyDetails": DailyFrequencyDetails,
     "DataAsset": DataAsset,
     "DataAssetFromAdwcDetails": DataAssetFromAdwcDetails,
     "DataAssetFromAtpDetails": DataAssetFromAtpDetails,
@@ -443,6 +489,7 @@ data_integration_type_mapping = {
     "DynamicProxyField": DynamicProxyField,
     "DynamicType": DynamicType,
     "DynamicTypeHandler": DynamicTypeHandler,
+    "EndOperator": EndOperator,
     "EnrichedEntity": EnrichedEntity,
     "EntityShape": EntityShape,
     "EntityShapeFromFile": EntityShapeFromFile,
@@ -465,9 +512,11 @@ data_integration_type_mapping = {
     "FolderSummary": FolderSummary,
     "FolderSummaryCollection": FolderSummaryCollection,
     "ForeignKey": ForeignKey,
+    "HourlyFrequencyDetails": HourlyFrequencyDetails,
     "InputField": InputField,
     "InputLink": InputLink,
     "InputPort": InputPort,
+    "Intersect": Intersect,
     "JavaType": JavaType,
     "Join": Join,
     "Joiner": Joiner,
@@ -476,12 +525,17 @@ data_integration_type_mapping = {
     "KeyAttribute": KeyAttribute,
     "KeyRange": KeyRange,
     "KeyRangePartitionConfig": KeyRangePartitionConfig,
+    "LastRunDetails": LastRunDetails,
     "MacroField": MacroField,
+    "MergeOperator": MergeOperator,
     "Message": Message,
+    "Minus": Minus,
+    "MonthlyFrequencyDetails": MonthlyFrequencyDetails,
     "NameListRule": NameListRule,
     "NamePatternRule": NamePatternRule,
     "NativeShapeField": NativeShapeField,
     "ObjectMetadata": ObjectMetadata,
+    "OciVaultSecretConfig": OciVaultSecretConfig,
     "Operator": Operator,
     "OracleAdwcWriteAttribute": OracleAdwcWriteAttribute,
     "OracleAdwcWriteAttributes": OracleAdwcWriteAttributes,
@@ -504,6 +558,12 @@ data_integration_type_mapping = {
     "PatchObjectMetadata": PatchObjectMetadata,
     "PatchSummary": PatchSummary,
     "PatchSummaryCollection": PatchSummaryCollection,
+    "Pipeline": Pipeline,
+    "PipelineSummary": PipelineSummary,
+    "PipelineSummaryCollection": PipelineSummaryCollection,
+    "PipelineValidation": PipelineValidation,
+    "PipelineValidationSummary": PipelineValidationSummary,
+    "PipelineValidationSummaryCollection": PipelineValidationSummaryCollection,
     "PrimaryKey": PrimaryKey,
     "Project": Project,
     "ProjectDetails": ProjectDetails,
@@ -515,6 +575,8 @@ data_integration_type_mapping = {
     "PublishedObject": PublishedObject,
     "PublishedObjectFromDataLoaderTask": PublishedObjectFromDataLoaderTask,
     "PublishedObjectFromIntegrationTask": PublishedObjectFromIntegrationTask,
+    "PublishedObjectFromPipelineTask": PublishedObjectFromPipelineTask,
+    "PublishedObjectFromPipelineTaskSummary": PublishedObjectFromPipelineTaskSummary,
     "PublishedObjectSummary": PublishedObjectSummary,
     "PublishedObjectSummaryCollection": PublishedObjectSummaryCollection,
     "PublishedObjectSummaryFromDataLoaderTask": PublishedObjectSummaryFromDataLoaderTask,
@@ -532,10 +594,14 @@ data_integration_type_mapping = {
     "RootObject": RootObject,
     "RuleBasedFieldMap": RuleBasedFieldMap,
     "RuleTypeConfig": RuleTypeConfig,
+    "Schedule": Schedule,
     "Schema": Schema,
+    "SchemaDriftConfig": SchemaDriftConfig,
     "SchemaSummary": SchemaSummary,
     "SchemaSummaryCollection": SchemaSummaryCollection,
+    "SecretConfig": SecretConfig,
     "Select": Select,
+    "SensitiveAttribute": SensitiveAttribute,
     "Shape": Shape,
     "ShapeField": ShapeField,
     "Sort": Sort,
@@ -545,29 +611,36 @@ data_integration_type_mapping = {
     "SortOper": SortOper,
     "Source": Source,
     "SourceApplicationInfo": SourceApplicationInfo,
+    "StartOperator": StartOperator,
     "StructuredType": StructuredType,
     "Target": Target,
     "Task": Task,
     "TaskFromDataLoaderTaskDetails": TaskFromDataLoaderTaskDetails,
     "TaskFromIntegrationTaskDetails": TaskFromIntegrationTaskDetails,
+    "TaskFromPipelineTaskDetails": TaskFromPipelineTaskDetails,
+    "TaskOperator": TaskOperator,
     "TaskRun": TaskRun,
     "TaskRunDetails": TaskRunDetails,
     "TaskRunLogSummary": TaskRunLogSummary,
     "TaskRunSummary": TaskRunSummary,
     "TaskRunSummaryCollection": TaskRunSummaryCollection,
+    "TaskSchedule": TaskSchedule,
     "TaskSummary": TaskSummary,
     "TaskSummaryCollection": TaskSummaryCollection,
     "TaskSummaryFromDataLoaderTask": TaskSummaryFromDataLoaderTask,
     "TaskSummaryFromIntegrationTask": TaskSummaryFromIntegrationTask,
+    "TaskSummaryFromPipelineTask": TaskSummaryFromPipelineTask,
     "TaskValidation": TaskValidation,
     "TaskValidationSummary": TaskValidationSummary,
     "TaskValidationSummaryCollection": TaskValidationSummaryCollection,
+    "Time": Time,
     "TypeLibrary": TypeLibrary,
     "TypeListRule": TypeListRule,
     "TypeSystem": TypeSystem,
     "TypedNamePatternRule": TypedNamePatternRule,
     "TypedObject": TypedObject,
     "UIProperties": UIProperties,
+    "Union": Union,
     "UniqueKey": UniqueKey,
     "UpdateApplicationDetails": UpdateApplicationDetails,
     "UpdateConnectionDetails": UpdateConnectionDetails,
@@ -587,14 +660,17 @@ data_integration_type_mapping = {
     "UpdateDataFlowDetails": UpdateDataFlowDetails,
     "UpdateExternalPublicationDetails": UpdateExternalPublicationDetails,
     "UpdateFolderDetails": UpdateFolderDetails,
+    "UpdatePipelineDetails": UpdatePipelineDetails,
     "UpdateProjectDetails": UpdateProjectDetails,
     "UpdateReferenceDetails": UpdateReferenceDetails,
     "UpdateTaskDetails": UpdateTaskDetails,
     "UpdateTaskFromDataLoaderTask": UpdateTaskFromDataLoaderTask,
     "UpdateTaskFromIntegrationTask": UpdateTaskFromIntegrationTask,
+    "UpdateTaskFromPipelineTask": UpdateTaskFromPipelineTask,
     "UpdateTaskRunDetails": UpdateTaskRunDetails,
     "UpdateWorkspaceDetails": UpdateWorkspaceDetails,
     "ValidationMessage": ValidationMessage,
+    "Variable": Variable,
     "WorkRequest": WorkRequest,
     "WorkRequestError": WorkRequestError,
     "WorkRequestLogEntry": WorkRequestLogEntry,

--- a/src/oci/data_integration/models/abstract_frequency_details.py
+++ b/src/oci/data_integration/models/abstract_frequency_details.py
@@ -1,0 +1,166 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class AbstractFrequencyDetails(object):
+    """
+    The model that holds the frequency details.
+    """
+
+    #: A constant which can be used with the model_type property of a AbstractFrequencyDetails.
+    #: This constant has a value of "HOURLY"
+    MODEL_TYPE_HOURLY = "HOURLY"
+
+    #: A constant which can be used with the model_type property of a AbstractFrequencyDetails.
+    #: This constant has a value of "DAILY"
+    MODEL_TYPE_DAILY = "DAILY"
+
+    #: A constant which can be used with the model_type property of a AbstractFrequencyDetails.
+    #: This constant has a value of "MONTHLY"
+    MODEL_TYPE_MONTHLY = "MONTHLY"
+
+    #: A constant which can be used with the frequency property of a AbstractFrequencyDetails.
+    #: This constant has a value of "HOURLY"
+    FREQUENCY_HOURLY = "HOURLY"
+
+    #: A constant which can be used with the frequency property of a AbstractFrequencyDetails.
+    #: This constant has a value of "DAILY"
+    FREQUENCY_DAILY = "DAILY"
+
+    #: A constant which can be used with the frequency property of a AbstractFrequencyDetails.
+    #: This constant has a value of "MONTHLY"
+    FREQUENCY_MONTHLY = "MONTHLY"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new AbstractFrequencyDetails object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
+        to a service operations then you should favor using a subclass over the base class:
+
+        * :class:`~oci.data_integration.models.MonthlyFrequencyDetails`
+        * :class:`~oci.data_integration.models.DailyFrequencyDetails`
+        * :class:`~oci.data_integration.models.HourlyFrequencyDetails`
+
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param model_type:
+            The value to assign to the model_type property of this AbstractFrequencyDetails.
+            Allowed values for this property are: "HOURLY", "DAILY", "MONTHLY", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type model_type: str
+
+        :param frequency:
+            The value to assign to the frequency property of this AbstractFrequencyDetails.
+            Allowed values for this property are: "HOURLY", "DAILY", "MONTHLY", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type frequency: str
+
+        """
+        self.swagger_types = {
+            'model_type': 'str',
+            'frequency': 'str'
+        }
+
+        self.attribute_map = {
+            'model_type': 'modelType',
+            'frequency': 'frequency'
+        }
+
+        self._model_type = None
+        self._frequency = None
+
+    @staticmethod
+    def get_subtype(object_dictionary):
+        """
+        Given the hash representation of a subtype of this class,
+        use the info in the hash to return the class of the subtype.
+        """
+        type = object_dictionary['modelType']
+
+        if type == 'MONTHLY':
+            return 'MonthlyFrequencyDetails'
+
+        if type == 'DAILY':
+            return 'DailyFrequencyDetails'
+
+        if type == 'HOURLY':
+            return 'HourlyFrequencyDetails'
+        else:
+            return 'AbstractFrequencyDetails'
+
+    @property
+    def model_type(self):
+        """
+        **[Required]** Gets the model_type of this AbstractFrequencyDetails.
+        The type of the model
+
+        Allowed values for this property are: "HOURLY", "DAILY", "MONTHLY", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The model_type of this AbstractFrequencyDetails.
+        :rtype: str
+        """
+        return self._model_type
+
+    @model_type.setter
+    def model_type(self, model_type):
+        """
+        Sets the model_type of this AbstractFrequencyDetails.
+        The type of the model
+
+
+        :param model_type: The model_type of this AbstractFrequencyDetails.
+        :type: str
+        """
+        allowed_values = ["HOURLY", "DAILY", "MONTHLY"]
+        if not value_allowed_none_or_none_sentinel(model_type, allowed_values):
+            model_type = 'UNKNOWN_ENUM_VALUE'
+        self._model_type = model_type
+
+    @property
+    def frequency(self):
+        """
+        Gets the frequency of this AbstractFrequencyDetails.
+        the frequency of the schedule.
+
+        Allowed values for this property are: "HOURLY", "DAILY", "MONTHLY", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The frequency of this AbstractFrequencyDetails.
+        :rtype: str
+        """
+        return self._frequency
+
+    @frequency.setter
+    def frequency(self, frequency):
+        """
+        Sets the frequency of this AbstractFrequencyDetails.
+        the frequency of the schedule.
+
+
+        :param frequency: The frequency of this AbstractFrequencyDetails.
+        :type: str
+        """
+        allowed_values = ["HOURLY", "DAILY", "MONTHLY"]
+        if not value_allowed_none_or_none_sentinel(frequency, allowed_values):
+            frequency = 'UNKNOWN_ENUM_VALUE'
+        self._frequency = frequency
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/aggregator.py
+++ b/src/oci/data_integration/models/aggregator.py
@@ -21,7 +21,7 @@ class Aggregator(Operator):
 
         :param model_type:
             The value to assign to the model_type property of this Aggregator.
-            Allowed values for this property are: "SOURCE_OPERATOR", "FILTER_OPERATOR", "JOINER_OPERATOR", "AGGREGATOR_OPERATOR", "PROJECTION_OPERATOR", "TARGET_OPERATOR", "DISTINCT_OPERATOR", "SORT_OPERATOR"
+            Allowed values for this property are: "SOURCE_OPERATOR", "FILTER_OPERATOR", "JOINER_OPERATOR", "AGGREGATOR_OPERATOR", "PROJECTION_OPERATOR", "TARGET_OPERATOR", "DISTINCT_OPERATOR", "SORT_OPERATOR", "UNION_OPERATOR", "INTERSECT_OPERATOR", "MINUS_OPERATOR", "MERGE_OPERATOR", "START_OPERATOR", "END_OPERATOR", "PIPELINE_OPERATOR", "REST_OPERATOR", "TASK_OPERATOR"
         :type model_type: str
 
         :param key:

--- a/src/oci/data_integration/models/aggregator_summary.py
+++ b/src/oci/data_integration/models/aggregator_summary.py
@@ -1,0 +1,194 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class AggregatorSummary(object):
+    """
+    A summary type containing information about the object's aggregator including its type, key, name and description.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new AggregatorSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param type:
+            The value to assign to the type property of this AggregatorSummary.
+        :type type: str
+
+        :param key:
+            The value to assign to the key property of this AggregatorSummary.
+        :type key: str
+
+        :param name:
+            The value to assign to the name property of this AggregatorSummary.
+        :type name: str
+
+        :param identifier:
+            The value to assign to the identifier property of this AggregatorSummary.
+        :type identifier: str
+
+        :param description:
+            The value to assign to the description property of this AggregatorSummary.
+        :type description: str
+
+        """
+        self.swagger_types = {
+            'type': 'str',
+            'key': 'str',
+            'name': 'str',
+            'identifier': 'str',
+            'description': 'str'
+        }
+
+        self.attribute_map = {
+            'type': 'type',
+            'key': 'key',
+            'name': 'name',
+            'identifier': 'identifier',
+            'description': 'description'
+        }
+
+        self._type = None
+        self._key = None
+        self._name = None
+        self._identifier = None
+        self._description = None
+
+    @property
+    def type(self):
+        """
+        Gets the type of this AggregatorSummary.
+        The type of the aggregator.
+
+
+        :return: The type of this AggregatorSummary.
+        :rtype: str
+        """
+        return self._type
+
+    @type.setter
+    def type(self, type):
+        """
+        Sets the type of this AggregatorSummary.
+        The type of the aggregator.
+
+
+        :param type: The type of this AggregatorSummary.
+        :type: str
+        """
+        self._type = type
+
+    @property
+    def key(self):
+        """
+        Gets the key of this AggregatorSummary.
+        The key of the aggregator object.
+
+
+        :return: The key of this AggregatorSummary.
+        :rtype: str
+        """
+        return self._key
+
+    @key.setter
+    def key(self, key):
+        """
+        Sets the key of this AggregatorSummary.
+        The key of the aggregator object.
+
+
+        :param key: The key of this AggregatorSummary.
+        :type: str
+        """
+        self._key = key
+
+    @property
+    def name(self):
+        """
+        Gets the name of this AggregatorSummary.
+        The name of the aggregator.
+
+
+        :return: The name of this AggregatorSummary.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this AggregatorSummary.
+        The name of the aggregator.
+
+
+        :param name: The name of this AggregatorSummary.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def identifier(self):
+        """
+        Gets the identifier of this AggregatorSummary.
+        The identifier of the aggregator.
+
+
+        :return: The identifier of this AggregatorSummary.
+        :rtype: str
+        """
+        return self._identifier
+
+    @identifier.setter
+    def identifier(self, identifier):
+        """
+        Sets the identifier of this AggregatorSummary.
+        The identifier of the aggregator.
+
+
+        :param identifier: The identifier of this AggregatorSummary.
+        :type: str
+        """
+        self._identifier = identifier
+
+    @property
+    def description(self):
+        """
+        Gets the description of this AggregatorSummary.
+        The description of the aggregator.
+
+
+        :return: The description of this AggregatorSummary.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this AggregatorSummary.
+        The description of the aggregator.
+
+
+        :param description: The description of this AggregatorSummary.
+        :type: str
+        """
+        self._description = description
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/base_type.py
+++ b/src/oci/data_integration/models/base_type.py
@@ -37,6 +37,10 @@ class BaseType(object):
     #: This constant has a value of "COMPOSITE_TYPE"
     MODEL_TYPE_COMPOSITE_TYPE = "COMPOSITE_TYPE"
 
+    #: A constant which can be used with the model_type property of a BaseType.
+    #: This constant has a value of "DERIVED_TYPE"
+    MODEL_TYPE_DERIVED_TYPE = "DERIVED_TYPE"
+
     def __init__(self, **kwargs):
         """
         Initializes a new BaseType object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
@@ -53,7 +57,7 @@ class BaseType(object):
 
         :param model_type:
             The value to assign to the model_type property of this BaseType.
-            Allowed values for this property are: "DYNAMIC_TYPE", "STRUCTURED_TYPE", "DATA_TYPE", "JAVA_TYPE", "CONFIGURED_TYPE", "COMPOSITE_TYPE", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "DYNAMIC_TYPE", "STRUCTURED_TYPE", "DATA_TYPE", "JAVA_TYPE", "CONFIGURED_TYPE", "COMPOSITE_TYPE", "DERIVED_TYPE", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type model_type: str
 
@@ -144,7 +148,7 @@ class BaseType(object):
         **[Required]** Gets the model_type of this BaseType.
         The property which disciminates the subtypes.
 
-        Allowed values for this property are: "DYNAMIC_TYPE", "STRUCTURED_TYPE", "DATA_TYPE", "JAVA_TYPE", "CONFIGURED_TYPE", "COMPOSITE_TYPE", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "DYNAMIC_TYPE", "STRUCTURED_TYPE", "DATA_TYPE", "JAVA_TYPE", "CONFIGURED_TYPE", "COMPOSITE_TYPE", "DERIVED_TYPE", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -163,7 +167,7 @@ class BaseType(object):
         :param model_type: The model_type of this BaseType.
         :type: str
         """
-        allowed_values = ["DYNAMIC_TYPE", "STRUCTURED_TYPE", "DATA_TYPE", "JAVA_TYPE", "CONFIGURED_TYPE", "COMPOSITE_TYPE"]
+        allowed_values = ["DYNAMIC_TYPE", "STRUCTURED_TYPE", "DATA_TYPE", "JAVA_TYPE", "CONFIGURED_TYPE", "COMPOSITE_TYPE", "DERIVED_TYPE"]
         if not value_allowed_none_or_none_sentinel(model_type, allowed_values):
             model_type = 'UNKNOWN_ENUM_VALUE'
         self._model_type = model_type

--- a/src/oci/data_integration/models/composite_type.py
+++ b/src/oci/data_integration/models/composite_type.py
@@ -21,7 +21,7 @@ class CompositeType(BaseType):
 
         :param model_type:
             The value to assign to the model_type property of this CompositeType.
-            Allowed values for this property are: "DYNAMIC_TYPE", "STRUCTURED_TYPE", "DATA_TYPE", "JAVA_TYPE", "CONFIGURED_TYPE", "COMPOSITE_TYPE"
+            Allowed values for this property are: "DYNAMIC_TYPE", "STRUCTURED_TYPE", "DATA_TYPE", "JAVA_TYPE", "CONFIGURED_TYPE", "COMPOSITE_TYPE", "DERIVED_TYPE"
         :type model_type: str
 
         :param key:

--- a/src/oci/data_integration/models/compression.py
+++ b/src/oci/data_integration/models/compression.py
@@ -1,0 +1,106 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class Compression(object):
+    """
+    The optional compression configuration.
+    """
+
+    #: A constant which can be used with the codec property of a Compression.
+    #: This constant has a value of "NONE"
+    CODEC_NONE = "NONE"
+
+    #: A constant which can be used with the codec property of a Compression.
+    #: This constant has a value of "AUTO"
+    CODEC_AUTO = "AUTO"
+
+    #: A constant which can be used with the codec property of a Compression.
+    #: This constant has a value of "GZIP"
+    CODEC_GZIP = "GZIP"
+
+    #: A constant which can be used with the codec property of a Compression.
+    #: This constant has a value of "BZIP2"
+    CODEC_BZIP2 = "BZIP2"
+
+    #: A constant which can be used with the codec property of a Compression.
+    #: This constant has a value of "DEFLATE"
+    CODEC_DEFLATE = "DEFLATE"
+
+    #: A constant which can be used with the codec property of a Compression.
+    #: This constant has a value of "LZ4"
+    CODEC_LZ4 = "LZ4"
+
+    #: A constant which can be used with the codec property of a Compression.
+    #: This constant has a value of "SNAPPY"
+    CODEC_SNAPPY = "SNAPPY"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new Compression object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param codec:
+            The value to assign to the codec property of this Compression.
+            Allowed values for this property are: "NONE", "AUTO", "GZIP", "BZIP2", "DEFLATE", "LZ4", "SNAPPY", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type codec: str
+
+        """
+        self.swagger_types = {
+            'codec': 'str'
+        }
+
+        self.attribute_map = {
+            'codec': 'codec'
+        }
+
+        self._codec = None
+
+    @property
+    def codec(self):
+        """
+        Gets the codec of this Compression.
+        Compression algorithm
+
+        Allowed values for this property are: "NONE", "AUTO", "GZIP", "BZIP2", "DEFLATE", "LZ4", "SNAPPY", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The codec of this Compression.
+        :rtype: str
+        """
+        return self._codec
+
+    @codec.setter
+    def codec(self, codec):
+        """
+        Sets the codec of this Compression.
+        Compression algorithm
+
+
+        :param codec: The codec of this Compression.
+        :type: str
+        """
+        allowed_values = ["NONE", "AUTO", "GZIP", "BZIP2", "DEFLATE", "LZ4", "SNAPPY"]
+        if not value_allowed_none_or_none_sentinel(codec, allowed_values):
+            codec = 'UNKNOWN_ENUM_VALUE'
+        self._codec = codec
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/config_parameter_value.py
+++ b/src/oci/data_integration/models/config_parameter_value.py
@@ -26,6 +26,10 @@ class ConfigParameterValue(object):
             The value to assign to the int_value property of this ConfigParameterValue.
         :type int_value: int
 
+        :param object_value:
+            The value to assign to the object_value property of this ConfigParameterValue.
+        :type object_value: object
+
         :param ref_value:
             The value to assign to the ref_value property of this ConfigParameterValue.
         :type ref_value: object
@@ -38,6 +42,7 @@ class ConfigParameterValue(object):
         self.swagger_types = {
             'string_value': 'str',
             'int_value': 'int',
+            'object_value': 'object',
             'ref_value': 'object',
             'parameter_value': 'str'
         }
@@ -45,12 +50,14 @@ class ConfigParameterValue(object):
         self.attribute_map = {
             'string_value': 'stringValue',
             'int_value': 'intValue',
+            'object_value': 'objectValue',
             'ref_value': 'refValue',
             'parameter_value': 'parameterValue'
         }
 
         self._string_value = None
         self._int_value = None
+        self._object_value = None
         self._ref_value = None
         self._parameter_value = None
 
@@ -101,6 +108,30 @@ class ConfigParameterValue(object):
         :type: int
         """
         self._int_value = int_value
+
+    @property
+    def object_value(self):
+        """
+        Gets the object_value of this ConfigParameterValue.
+        An object value of the parameter.
+
+
+        :return: The object_value of this ConfigParameterValue.
+        :rtype: object
+        """
+        return self._object_value
+
+    @object_value.setter
+    def object_value(self, object_value):
+        """
+        Sets the object_value of this ConfigParameterValue.
+        An object value of the parameter.
+
+
+        :param object_value: The object_value of this ConfigParameterValue.
+        :type: object
+        """
+        self._object_value = object_value
 
     @property
     def ref_value(self):

--- a/src/oci/data_integration/models/configured_type.py
+++ b/src/oci/data_integration/models/configured_type.py
@@ -21,7 +21,7 @@ class ConfiguredType(BaseType):
 
         :param model_type:
             The value to assign to the model_type property of this ConfiguredType.
-            Allowed values for this property are: "DYNAMIC_TYPE", "STRUCTURED_TYPE", "DATA_TYPE", "JAVA_TYPE", "CONFIGURED_TYPE", "COMPOSITE_TYPE"
+            Allowed values for this property are: "DYNAMIC_TYPE", "STRUCTURED_TYPE", "DATA_TYPE", "JAVA_TYPE", "CONFIGURED_TYPE", "COMPOSITE_TYPE", "DERIVED_TYPE"
         :type model_type: str
 
         :param key:

--- a/src/oci/data_integration/models/connection_from_adwc.py
+++ b/src/oci/data_integration/models/connection_from_adwc.py
@@ -84,6 +84,10 @@ class ConnectionFromAdwc(Connection):
             The value to assign to the password property of this ConnectionFromAdwc.
         :type password: str
 
+        :param password_secret:
+            The value to assign to the password_secret property of this ConnectionFromAdwc.
+        :type password_secret: oci.data_integration.models.SensitiveAttribute
+
         """
         self.swagger_types = {
             'model_type': 'str',
@@ -101,7 +105,8 @@ class ConnectionFromAdwc(Connection):
             'metadata': 'ObjectMetadata',
             'key_map': 'dict(str, str)',
             'username': 'str',
-            'password': 'str'
+            'password': 'str',
+            'password_secret': 'SensitiveAttribute'
         }
 
         self.attribute_map = {
@@ -120,7 +125,8 @@ class ConnectionFromAdwc(Connection):
             'metadata': 'metadata',
             'key_map': 'keyMap',
             'username': 'username',
-            'password': 'password'
+            'password': 'password',
+            'password_secret': 'passwordSecret'
         }
 
         self._model_type = None
@@ -139,6 +145,7 @@ class ConnectionFromAdwc(Connection):
         self._key_map = None
         self._username = None
         self._password = None
+        self._password_secret = None
         self._model_type = 'ORACLE_ADWC_CONNECTION'
 
     @property
@@ -188,6 +195,26 @@ class ConnectionFromAdwc(Connection):
         :type: str
         """
         self._password = password
+
+    @property
+    def password_secret(self):
+        """
+        Gets the password_secret of this ConnectionFromAdwc.
+
+        :return: The password_secret of this ConnectionFromAdwc.
+        :rtype: oci.data_integration.models.SensitiveAttribute
+        """
+        return self._password_secret
+
+    @password_secret.setter
+    def password_secret(self, password_secret):
+        """
+        Sets the password_secret of this ConnectionFromAdwc.
+
+        :param password_secret: The password_secret of this ConnectionFromAdwc.
+        :type: oci.data_integration.models.SensitiveAttribute
+        """
+        self._password_secret = password_secret
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/data_integration/models/connection_from_adwc_details.py
+++ b/src/oci/data_integration/models/connection_from_adwc_details.py
@@ -80,6 +80,10 @@ class ConnectionFromAdwcDetails(ConnectionDetails):
             The value to assign to the password property of this ConnectionFromAdwcDetails.
         :type password: str
 
+        :param password_secret:
+            The value to assign to the password_secret property of this ConnectionFromAdwcDetails.
+        :type password_secret: oci.data_integration.models.SensitiveAttribute
+
         """
         self.swagger_types = {
             'model_type': 'str',
@@ -96,7 +100,8 @@ class ConnectionFromAdwcDetails(ConnectionDetails):
             'is_default': 'bool',
             'metadata': 'ObjectMetadata',
             'username': 'str',
-            'password': 'str'
+            'password': 'str',
+            'password_secret': 'SensitiveAttribute'
         }
 
         self.attribute_map = {
@@ -114,7 +119,8 @@ class ConnectionFromAdwcDetails(ConnectionDetails):
             'is_default': 'isDefault',
             'metadata': 'metadata',
             'username': 'username',
-            'password': 'password'
+            'password': 'password',
+            'password_secret': 'passwordSecret'
         }
 
         self._model_type = None
@@ -132,6 +138,7 @@ class ConnectionFromAdwcDetails(ConnectionDetails):
         self._metadata = None
         self._username = None
         self._password = None
+        self._password_secret = None
         self._model_type = 'ORACLE_ADWC_CONNECTION'
 
     @property
@@ -181,6 +188,26 @@ class ConnectionFromAdwcDetails(ConnectionDetails):
         :type: str
         """
         self._password = password
+
+    @property
+    def password_secret(self):
+        """
+        Gets the password_secret of this ConnectionFromAdwcDetails.
+
+        :return: The password_secret of this ConnectionFromAdwcDetails.
+        :rtype: oci.data_integration.models.SensitiveAttribute
+        """
+        return self._password_secret
+
+    @password_secret.setter
+    def password_secret(self, password_secret):
+        """
+        Sets the password_secret of this ConnectionFromAdwcDetails.
+
+        :param password_secret: The password_secret of this ConnectionFromAdwcDetails.
+        :type: oci.data_integration.models.SensitiveAttribute
+        """
+        self._password_secret = password_secret
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/data_integration/models/connection_from_atp.py
+++ b/src/oci/data_integration/models/connection_from_atp.py
@@ -84,6 +84,10 @@ class ConnectionFromAtp(Connection):
             The value to assign to the password property of this ConnectionFromAtp.
         :type password: str
 
+        :param password_secret:
+            The value to assign to the password_secret property of this ConnectionFromAtp.
+        :type password_secret: oci.data_integration.models.SensitiveAttribute
+
         """
         self.swagger_types = {
             'model_type': 'str',
@@ -101,7 +105,8 @@ class ConnectionFromAtp(Connection):
             'metadata': 'ObjectMetadata',
             'key_map': 'dict(str, str)',
             'username': 'str',
-            'password': 'str'
+            'password': 'str',
+            'password_secret': 'SensitiveAttribute'
         }
 
         self.attribute_map = {
@@ -120,7 +125,8 @@ class ConnectionFromAtp(Connection):
             'metadata': 'metadata',
             'key_map': 'keyMap',
             'username': 'username',
-            'password': 'password'
+            'password': 'password',
+            'password_secret': 'passwordSecret'
         }
 
         self._model_type = None
@@ -139,6 +145,7 @@ class ConnectionFromAtp(Connection):
         self._key_map = None
         self._username = None
         self._password = None
+        self._password_secret = None
         self._model_type = 'ORACLE_ATP_CONNECTION'
 
     @property
@@ -188,6 +195,26 @@ class ConnectionFromAtp(Connection):
         :type: str
         """
         self._password = password
+
+    @property
+    def password_secret(self):
+        """
+        Gets the password_secret of this ConnectionFromAtp.
+
+        :return: The password_secret of this ConnectionFromAtp.
+        :rtype: oci.data_integration.models.SensitiveAttribute
+        """
+        return self._password_secret
+
+    @password_secret.setter
+    def password_secret(self, password_secret):
+        """
+        Sets the password_secret of this ConnectionFromAtp.
+
+        :param password_secret: The password_secret of this ConnectionFromAtp.
+        :type: oci.data_integration.models.SensitiveAttribute
+        """
+        self._password_secret = password_secret
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/data_integration/models/connection_from_atp_details.py
+++ b/src/oci/data_integration/models/connection_from_atp_details.py
@@ -80,6 +80,10 @@ class ConnectionFromAtpDetails(ConnectionDetails):
             The value to assign to the password property of this ConnectionFromAtpDetails.
         :type password: str
 
+        :param password_secret:
+            The value to assign to the password_secret property of this ConnectionFromAtpDetails.
+        :type password_secret: oci.data_integration.models.SensitiveAttribute
+
         """
         self.swagger_types = {
             'model_type': 'str',
@@ -96,7 +100,8 @@ class ConnectionFromAtpDetails(ConnectionDetails):
             'is_default': 'bool',
             'metadata': 'ObjectMetadata',
             'username': 'str',
-            'password': 'str'
+            'password': 'str',
+            'password_secret': 'SensitiveAttribute'
         }
 
         self.attribute_map = {
@@ -114,7 +119,8 @@ class ConnectionFromAtpDetails(ConnectionDetails):
             'is_default': 'isDefault',
             'metadata': 'metadata',
             'username': 'username',
-            'password': 'password'
+            'password': 'password',
+            'password_secret': 'passwordSecret'
         }
 
         self._model_type = None
@@ -132,6 +138,7 @@ class ConnectionFromAtpDetails(ConnectionDetails):
         self._metadata = None
         self._username = None
         self._password = None
+        self._password_secret = None
         self._model_type = 'ORACLE_ATP_CONNECTION'
 
     @property
@@ -181,6 +188,26 @@ class ConnectionFromAtpDetails(ConnectionDetails):
         :type: str
         """
         self._password = password
+
+    @property
+    def password_secret(self):
+        """
+        Gets the password_secret of this ConnectionFromAtpDetails.
+
+        :return: The password_secret of this ConnectionFromAtpDetails.
+        :rtype: oci.data_integration.models.SensitiveAttribute
+        """
+        return self._password_secret
+
+    @password_secret.setter
+    def password_secret(self, password_secret):
+        """
+        Sets the password_secret of this ConnectionFromAtpDetails.
+
+        :param password_secret: The password_secret of this ConnectionFromAtpDetails.
+        :type: oci.data_integration.models.SensitiveAttribute
+        """
+        self._password_secret = password_secret
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/data_integration/models/connection_from_oracle.py
+++ b/src/oci/data_integration/models/connection_from_oracle.py
@@ -84,6 +84,10 @@ class ConnectionFromOracle(Connection):
             The value to assign to the password property of this ConnectionFromOracle.
         :type password: str
 
+        :param password_secret:
+            The value to assign to the password_secret property of this ConnectionFromOracle.
+        :type password_secret: oci.data_integration.models.SensitiveAttribute
+
         """
         self.swagger_types = {
             'model_type': 'str',
@@ -101,7 +105,8 @@ class ConnectionFromOracle(Connection):
             'metadata': 'ObjectMetadata',
             'key_map': 'dict(str, str)',
             'username': 'str',
-            'password': 'str'
+            'password': 'str',
+            'password_secret': 'SensitiveAttribute'
         }
 
         self.attribute_map = {
@@ -120,7 +125,8 @@ class ConnectionFromOracle(Connection):
             'metadata': 'metadata',
             'key_map': 'keyMap',
             'username': 'username',
-            'password': 'password'
+            'password': 'password',
+            'password_secret': 'passwordSecret'
         }
 
         self._model_type = None
@@ -139,6 +145,7 @@ class ConnectionFromOracle(Connection):
         self._key_map = None
         self._username = None
         self._password = None
+        self._password_secret = None
         self._model_type = 'ORACLEDB_CONNECTION'
 
     @property
@@ -188,6 +195,26 @@ class ConnectionFromOracle(Connection):
         :type: str
         """
         self._password = password
+
+    @property
+    def password_secret(self):
+        """
+        Gets the password_secret of this ConnectionFromOracle.
+
+        :return: The password_secret of this ConnectionFromOracle.
+        :rtype: oci.data_integration.models.SensitiveAttribute
+        """
+        return self._password_secret
+
+    @password_secret.setter
+    def password_secret(self, password_secret):
+        """
+        Sets the password_secret of this ConnectionFromOracle.
+
+        :param password_secret: The password_secret of this ConnectionFromOracle.
+        :type: oci.data_integration.models.SensitiveAttribute
+        """
+        self._password_secret = password_secret
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/data_integration/models/connection_from_oracle_details.py
+++ b/src/oci/data_integration/models/connection_from_oracle_details.py
@@ -81,6 +81,10 @@ class ConnectionFromOracleDetails(ConnectionDetails):
             The value to assign to the password property of this ConnectionFromOracleDetails.
         :type password: str
 
+        :param password_secret:
+            The value to assign to the password_secret property of this ConnectionFromOracleDetails.
+        :type password_secret: oci.data_integration.models.SensitiveAttribute
+
         """
         self.swagger_types = {
             'model_type': 'str',
@@ -97,7 +101,8 @@ class ConnectionFromOracleDetails(ConnectionDetails):
             'is_default': 'bool',
             'metadata': 'ObjectMetadata',
             'username': 'str',
-            'password': 'str'
+            'password': 'str',
+            'password_secret': 'SensitiveAttribute'
         }
 
         self.attribute_map = {
@@ -115,7 +120,8 @@ class ConnectionFromOracleDetails(ConnectionDetails):
             'is_default': 'isDefault',
             'metadata': 'metadata',
             'username': 'username',
-            'password': 'password'
+            'password': 'password',
+            'password_secret': 'passwordSecret'
         }
 
         self._model_type = None
@@ -133,6 +139,7 @@ class ConnectionFromOracleDetails(ConnectionDetails):
         self._metadata = None
         self._username = None
         self._password = None
+        self._password_secret = None
         self._model_type = 'ORACLEDB_CONNECTION'
 
     @property
@@ -182,6 +189,26 @@ class ConnectionFromOracleDetails(ConnectionDetails):
         :type: str
         """
         self._password = password
+
+    @property
+    def password_secret(self):
+        """
+        Gets the password_secret of this ConnectionFromOracleDetails.
+
+        :return: The password_secret of this ConnectionFromOracleDetails.
+        :rtype: oci.data_integration.models.SensitiveAttribute
+        """
+        return self._password_secret
+
+    @password_secret.setter
+    def password_secret(self, password_secret):
+        """
+        Sets the password_secret of this ConnectionFromOracleDetails.
+
+        :param password_secret: The password_secret of this ConnectionFromOracleDetails.
+        :type: oci.data_integration.models.SensitiveAttribute
+        """
+        self._password_secret = password_secret
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/data_integration/models/connection_summary_from_adwc.py
+++ b/src/oci/data_integration/models/connection_summary_from_adwc.py
@@ -84,6 +84,10 @@ class ConnectionSummaryFromAdwc(ConnectionSummary):
             The value to assign to the password property of this ConnectionSummaryFromAdwc.
         :type password: str
 
+        :param password_secret:
+            The value to assign to the password_secret property of this ConnectionSummaryFromAdwc.
+        :type password_secret: oci.data_integration.models.SensitiveAttribute
+
         """
         self.swagger_types = {
             'model_type': 'str',
@@ -101,7 +105,8 @@ class ConnectionSummaryFromAdwc(ConnectionSummary):
             'metadata': 'ObjectMetadata',
             'key_map': 'dict(str, str)',
             'username': 'str',
-            'password': 'str'
+            'password': 'str',
+            'password_secret': 'SensitiveAttribute'
         }
 
         self.attribute_map = {
@@ -120,7 +125,8 @@ class ConnectionSummaryFromAdwc(ConnectionSummary):
             'metadata': 'metadata',
             'key_map': 'keyMap',
             'username': 'username',
-            'password': 'password'
+            'password': 'password',
+            'password_secret': 'passwordSecret'
         }
 
         self._model_type = None
@@ -139,6 +145,7 @@ class ConnectionSummaryFromAdwc(ConnectionSummary):
         self._key_map = None
         self._username = None
         self._password = None
+        self._password_secret = None
         self._model_type = 'ORACLE_ADWC_CONNECTION'
 
     @property
@@ -188,6 +195,26 @@ class ConnectionSummaryFromAdwc(ConnectionSummary):
         :type: str
         """
         self._password = password
+
+    @property
+    def password_secret(self):
+        """
+        Gets the password_secret of this ConnectionSummaryFromAdwc.
+
+        :return: The password_secret of this ConnectionSummaryFromAdwc.
+        :rtype: oci.data_integration.models.SensitiveAttribute
+        """
+        return self._password_secret
+
+    @password_secret.setter
+    def password_secret(self, password_secret):
+        """
+        Sets the password_secret of this ConnectionSummaryFromAdwc.
+
+        :param password_secret: The password_secret of this ConnectionSummaryFromAdwc.
+        :type: oci.data_integration.models.SensitiveAttribute
+        """
+        self._password_secret = password_secret
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/data_integration/models/connection_summary_from_atp.py
+++ b/src/oci/data_integration/models/connection_summary_from_atp.py
@@ -84,6 +84,10 @@ class ConnectionSummaryFromAtp(ConnectionSummary):
             The value to assign to the password property of this ConnectionSummaryFromAtp.
         :type password: str
 
+        :param password_secret:
+            The value to assign to the password_secret property of this ConnectionSummaryFromAtp.
+        :type password_secret: oci.data_integration.models.SensitiveAttribute
+
         """
         self.swagger_types = {
             'model_type': 'str',
@@ -101,7 +105,8 @@ class ConnectionSummaryFromAtp(ConnectionSummary):
             'metadata': 'ObjectMetadata',
             'key_map': 'dict(str, str)',
             'username': 'str',
-            'password': 'str'
+            'password': 'str',
+            'password_secret': 'SensitiveAttribute'
         }
 
         self.attribute_map = {
@@ -120,7 +125,8 @@ class ConnectionSummaryFromAtp(ConnectionSummary):
             'metadata': 'metadata',
             'key_map': 'keyMap',
             'username': 'username',
-            'password': 'password'
+            'password': 'password',
+            'password_secret': 'passwordSecret'
         }
 
         self._model_type = None
@@ -139,6 +145,7 @@ class ConnectionSummaryFromAtp(ConnectionSummary):
         self._key_map = None
         self._username = None
         self._password = None
+        self._password_secret = None
         self._model_type = 'ORACLE_ATP_CONNECTION'
 
     @property
@@ -188,6 +195,26 @@ class ConnectionSummaryFromAtp(ConnectionSummary):
         :type: str
         """
         self._password = password
+
+    @property
+    def password_secret(self):
+        """
+        Gets the password_secret of this ConnectionSummaryFromAtp.
+
+        :return: The password_secret of this ConnectionSummaryFromAtp.
+        :rtype: oci.data_integration.models.SensitiveAttribute
+        """
+        return self._password_secret
+
+    @password_secret.setter
+    def password_secret(self, password_secret):
+        """
+        Sets the password_secret of this ConnectionSummaryFromAtp.
+
+        :param password_secret: The password_secret of this ConnectionSummaryFromAtp.
+        :type: oci.data_integration.models.SensitiveAttribute
+        """
+        self._password_secret = password_secret
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/data_integration/models/connection_summary_from_oracle.py
+++ b/src/oci/data_integration/models/connection_summary_from_oracle.py
@@ -85,6 +85,10 @@ class ConnectionSummaryFromOracle(ConnectionSummary):
             The value to assign to the password property of this ConnectionSummaryFromOracle.
         :type password: str
 
+        :param password_secret:
+            The value to assign to the password_secret property of this ConnectionSummaryFromOracle.
+        :type password_secret: oci.data_integration.models.SensitiveAttribute
+
         """
         self.swagger_types = {
             'model_type': 'str',
@@ -102,7 +106,8 @@ class ConnectionSummaryFromOracle(ConnectionSummary):
             'metadata': 'ObjectMetadata',
             'key_map': 'dict(str, str)',
             'username': 'str',
-            'password': 'str'
+            'password': 'str',
+            'password_secret': 'SensitiveAttribute'
         }
 
         self.attribute_map = {
@@ -121,7 +126,8 @@ class ConnectionSummaryFromOracle(ConnectionSummary):
             'metadata': 'metadata',
             'key_map': 'keyMap',
             'username': 'username',
-            'password': 'password'
+            'password': 'password',
+            'password_secret': 'passwordSecret'
         }
 
         self._model_type = None
@@ -140,6 +146,7 @@ class ConnectionSummaryFromOracle(ConnectionSummary):
         self._key_map = None
         self._username = None
         self._password = None
+        self._password_secret = None
         self._model_type = 'ORACLEDB_CONNECTION'
 
     @property
@@ -189,6 +196,26 @@ class ConnectionSummaryFromOracle(ConnectionSummary):
         :type: str
         """
         self._password = password
+
+    @property
+    def password_secret(self):
+        """
+        Gets the password_secret of this ConnectionSummaryFromOracle.
+
+        :return: The password_secret of this ConnectionSummaryFromOracle.
+        :rtype: oci.data_integration.models.SensitiveAttribute
+        """
+        return self._password_secret
+
+    @password_secret.setter
+    def password_secret(self, password_secret):
+        """
+        Sets the password_secret of this ConnectionSummaryFromOracle.
+
+        :param password_secret: The password_secret of this ConnectionSummaryFromOracle.
+        :type: oci.data_integration.models.SensitiveAttribute
+        """
+        self._password_secret = password_secret
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/data_integration/models/create_connection_from_adwc.py
+++ b/src/oci/data_integration/models/create_connection_from_adwc.py
@@ -68,6 +68,10 @@ class CreateConnectionFromAdwc(CreateConnectionDetails):
             The value to assign to the password property of this CreateConnectionFromAdwc.
         :type password: str
 
+        :param password_secret:
+            The value to assign to the password_secret property of this CreateConnectionFromAdwc.
+        :type password_secret: oci.data_integration.models.SensitiveAttribute
+
         """
         self.swagger_types = {
             'model_type': 'str',
@@ -81,7 +85,8 @@ class CreateConnectionFromAdwc(CreateConnectionDetails):
             'connection_properties': 'list[ConnectionProperty]',
             'registry_metadata': 'RegistryMetadata',
             'username': 'str',
-            'password': 'str'
+            'password': 'str',
+            'password_secret': 'SensitiveAttribute'
         }
 
         self.attribute_map = {
@@ -96,7 +101,8 @@ class CreateConnectionFromAdwc(CreateConnectionDetails):
             'connection_properties': 'connectionProperties',
             'registry_metadata': 'registryMetadata',
             'username': 'username',
-            'password': 'password'
+            'password': 'password',
+            'password_secret': 'passwordSecret'
         }
 
         self._model_type = None
@@ -111,6 +117,7 @@ class CreateConnectionFromAdwc(CreateConnectionDetails):
         self._registry_metadata = None
         self._username = None
         self._password = None
+        self._password_secret = None
         self._model_type = 'ORACLE_ADWC_CONNECTION'
 
     @property
@@ -160,6 +167,26 @@ class CreateConnectionFromAdwc(CreateConnectionDetails):
         :type: str
         """
         self._password = password
+
+    @property
+    def password_secret(self):
+        """
+        Gets the password_secret of this CreateConnectionFromAdwc.
+
+        :return: The password_secret of this CreateConnectionFromAdwc.
+        :rtype: oci.data_integration.models.SensitiveAttribute
+        """
+        return self._password_secret
+
+    @password_secret.setter
+    def password_secret(self, password_secret):
+        """
+        Sets the password_secret of this CreateConnectionFromAdwc.
+
+        :param password_secret: The password_secret of this CreateConnectionFromAdwc.
+        :type: oci.data_integration.models.SensitiveAttribute
+        """
+        self._password_secret = password_secret
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/data_integration/models/create_connection_from_atp.py
+++ b/src/oci/data_integration/models/create_connection_from_atp.py
@@ -68,6 +68,10 @@ class CreateConnectionFromAtp(CreateConnectionDetails):
             The value to assign to the password property of this CreateConnectionFromAtp.
         :type password: str
 
+        :param password_secret:
+            The value to assign to the password_secret property of this CreateConnectionFromAtp.
+        :type password_secret: oci.data_integration.models.SensitiveAttribute
+
         """
         self.swagger_types = {
             'model_type': 'str',
@@ -81,7 +85,8 @@ class CreateConnectionFromAtp(CreateConnectionDetails):
             'connection_properties': 'list[ConnectionProperty]',
             'registry_metadata': 'RegistryMetadata',
             'username': 'str',
-            'password': 'str'
+            'password': 'str',
+            'password_secret': 'SensitiveAttribute'
         }
 
         self.attribute_map = {
@@ -96,7 +101,8 @@ class CreateConnectionFromAtp(CreateConnectionDetails):
             'connection_properties': 'connectionProperties',
             'registry_metadata': 'registryMetadata',
             'username': 'username',
-            'password': 'password'
+            'password': 'password',
+            'password_secret': 'passwordSecret'
         }
 
         self._model_type = None
@@ -111,6 +117,7 @@ class CreateConnectionFromAtp(CreateConnectionDetails):
         self._registry_metadata = None
         self._username = None
         self._password = None
+        self._password_secret = None
         self._model_type = 'ORACLE_ATP_CONNECTION'
 
     @property
@@ -160,6 +167,26 @@ class CreateConnectionFromAtp(CreateConnectionDetails):
         :type: str
         """
         self._password = password
+
+    @property
+    def password_secret(self):
+        """
+        Gets the password_secret of this CreateConnectionFromAtp.
+
+        :return: The password_secret of this CreateConnectionFromAtp.
+        :rtype: oci.data_integration.models.SensitiveAttribute
+        """
+        return self._password_secret
+
+    @password_secret.setter
+    def password_secret(self, password_secret):
+        """
+        Sets the password_secret of this CreateConnectionFromAtp.
+
+        :param password_secret: The password_secret of this CreateConnectionFromAtp.
+        :type: oci.data_integration.models.SensitiveAttribute
+        """
+        self._password_secret = password_secret
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/data_integration/models/create_connection_from_jdbc.py
+++ b/src/oci/data_integration/models/create_connection_from_jdbc.py
@@ -68,6 +68,10 @@ class CreateConnectionFromJdbc(CreateConnectionDetails):
             The value to assign to the password property of this CreateConnectionFromJdbc.
         :type password: str
 
+        :param password_secret:
+            The value to assign to the password_secret property of this CreateConnectionFromJdbc.
+        :type password_secret: oci.data_integration.models.SensitiveAttribute
+
         """
         self.swagger_types = {
             'model_type': 'str',
@@ -81,7 +85,8 @@ class CreateConnectionFromJdbc(CreateConnectionDetails):
             'connection_properties': 'list[ConnectionProperty]',
             'registry_metadata': 'RegistryMetadata',
             'username': 'str',
-            'password': 'str'
+            'password': 'str',
+            'password_secret': 'SensitiveAttribute'
         }
 
         self.attribute_map = {
@@ -96,7 +101,8 @@ class CreateConnectionFromJdbc(CreateConnectionDetails):
             'connection_properties': 'connectionProperties',
             'registry_metadata': 'registryMetadata',
             'username': 'username',
-            'password': 'password'
+            'password': 'password',
+            'password_secret': 'passwordSecret'
         }
 
         self._model_type = None
@@ -111,6 +117,7 @@ class CreateConnectionFromJdbc(CreateConnectionDetails):
         self._registry_metadata = None
         self._username = None
         self._password = None
+        self._password_secret = None
         self._model_type = 'GENERIC_JDBC_CONNECTION'
 
     @property
@@ -160,6 +167,26 @@ class CreateConnectionFromJdbc(CreateConnectionDetails):
         :type: str
         """
         self._password = password
+
+    @property
+    def password_secret(self):
+        """
+        Gets the password_secret of this CreateConnectionFromJdbc.
+
+        :return: The password_secret of this CreateConnectionFromJdbc.
+        :rtype: oci.data_integration.models.SensitiveAttribute
+        """
+        return self._password_secret
+
+    @password_secret.setter
+    def password_secret(self, password_secret):
+        """
+        Sets the password_secret of this CreateConnectionFromJdbc.
+
+        :param password_secret: The password_secret of this CreateConnectionFromJdbc.
+        :type: oci.data_integration.models.SensitiveAttribute
+        """
+        self._password_secret = password_secret
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/data_integration/models/create_connection_from_my_sql.py
+++ b/src/oci/data_integration/models/create_connection_from_my_sql.py
@@ -68,6 +68,10 @@ class CreateConnectionFromMySQL(CreateConnectionDetails):
             The value to assign to the password property of this CreateConnectionFromMySQL.
         :type password: str
 
+        :param password_secret:
+            The value to assign to the password_secret property of this CreateConnectionFromMySQL.
+        :type password_secret: oci.data_integration.models.SensitiveAttribute
+
         """
         self.swagger_types = {
             'model_type': 'str',
@@ -81,7 +85,8 @@ class CreateConnectionFromMySQL(CreateConnectionDetails):
             'connection_properties': 'list[ConnectionProperty]',
             'registry_metadata': 'RegistryMetadata',
             'username': 'str',
-            'password': 'str'
+            'password': 'str',
+            'password_secret': 'SensitiveAttribute'
         }
 
         self.attribute_map = {
@@ -96,7 +101,8 @@ class CreateConnectionFromMySQL(CreateConnectionDetails):
             'connection_properties': 'connectionProperties',
             'registry_metadata': 'registryMetadata',
             'username': 'username',
-            'password': 'password'
+            'password': 'password',
+            'password_secret': 'passwordSecret'
         }
 
         self._model_type = None
@@ -111,6 +117,7 @@ class CreateConnectionFromMySQL(CreateConnectionDetails):
         self._registry_metadata = None
         self._username = None
         self._password = None
+        self._password_secret = None
         self._model_type = 'MYSQL_CONNECTION'
 
     @property
@@ -160,6 +167,26 @@ class CreateConnectionFromMySQL(CreateConnectionDetails):
         :type: str
         """
         self._password = password
+
+    @property
+    def password_secret(self):
+        """
+        Gets the password_secret of this CreateConnectionFromMySQL.
+
+        :return: The password_secret of this CreateConnectionFromMySQL.
+        :rtype: oci.data_integration.models.SensitiveAttribute
+        """
+        return self._password_secret
+
+    @password_secret.setter
+    def password_secret(self, password_secret):
+        """
+        Sets the password_secret of this CreateConnectionFromMySQL.
+
+        :param password_secret: The password_secret of this CreateConnectionFromMySQL.
+        :type: oci.data_integration.models.SensitiveAttribute
+        """
+        self._password_secret = password_secret
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/data_integration/models/create_connection_from_oracle.py
+++ b/src/oci/data_integration/models/create_connection_from_oracle.py
@@ -68,6 +68,10 @@ class CreateConnectionFromOracle(CreateConnectionDetails):
             The value to assign to the password property of this CreateConnectionFromOracle.
         :type password: str
 
+        :param password_secret:
+            The value to assign to the password_secret property of this CreateConnectionFromOracle.
+        :type password_secret: oci.data_integration.models.SensitiveAttribute
+
         """
         self.swagger_types = {
             'model_type': 'str',
@@ -81,7 +85,8 @@ class CreateConnectionFromOracle(CreateConnectionDetails):
             'connection_properties': 'list[ConnectionProperty]',
             'registry_metadata': 'RegistryMetadata',
             'username': 'str',
-            'password': 'str'
+            'password': 'str',
+            'password_secret': 'SensitiveAttribute'
         }
 
         self.attribute_map = {
@@ -96,7 +101,8 @@ class CreateConnectionFromOracle(CreateConnectionDetails):
             'connection_properties': 'connectionProperties',
             'registry_metadata': 'registryMetadata',
             'username': 'username',
-            'password': 'password'
+            'password': 'password',
+            'password_secret': 'passwordSecret'
         }
 
         self._model_type = None
@@ -111,6 +117,7 @@ class CreateConnectionFromOracle(CreateConnectionDetails):
         self._registry_metadata = None
         self._username = None
         self._password = None
+        self._password_secret = None
         self._model_type = 'ORACLEDB_CONNECTION'
 
     @property
@@ -160,6 +167,26 @@ class CreateConnectionFromOracle(CreateConnectionDetails):
         :type: str
         """
         self._password = password
+
+    @property
+    def password_secret(self):
+        """
+        Gets the password_secret of this CreateConnectionFromOracle.
+
+        :return: The password_secret of this CreateConnectionFromOracle.
+        :rtype: oci.data_integration.models.SensitiveAttribute
+        """
+        return self._password_secret
+
+    @password_secret.setter
+    def password_secret(self, password_secret):
+        """
+        Sets the password_secret of this CreateConnectionFromOracle.
+
+        :param password_secret: The password_secret of this CreateConnectionFromOracle.
+        :type: oci.data_integration.models.SensitiveAttribute
+        """
+        self._password_secret = password_secret
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/data_integration/models/create_data_asset_from_adwc.py
+++ b/src/oci/data_integration/models/create_data_asset_from_adwc.py
@@ -72,6 +72,14 @@ class CreateDataAssetFromAdwc(CreateDataAssetDetails):
             The value to assign to the credential_file_content property of this CreateDataAssetFromAdwc.
         :type credential_file_content: str
 
+        :param wallet_secret:
+            The value to assign to the wallet_secret property of this CreateDataAssetFromAdwc.
+        :type wallet_secret: oci.data_integration.models.SensitiveAttribute
+
+        :param wallet_password_secret:
+            The value to assign to the wallet_password_secret property of this CreateDataAssetFromAdwc.
+        :type wallet_password_secret: oci.data_integration.models.SensitiveAttribute
+
         :param default_connection:
             The value to assign to the default_connection property of this CreateDataAssetFromAdwc.
         :type default_connection: oci.data_integration.models.CreateConnectionFromAdwc
@@ -91,6 +99,8 @@ class CreateDataAssetFromAdwc(CreateDataAssetDetails):
             'service_name': 'str',
             'driver_class': 'str',
             'credential_file_content': 'str',
+            'wallet_secret': 'SensitiveAttribute',
+            'wallet_password_secret': 'SensitiveAttribute',
             'default_connection': 'CreateConnectionFromAdwc'
         }
 
@@ -108,6 +118,8 @@ class CreateDataAssetFromAdwc(CreateDataAssetDetails):
             'service_name': 'serviceName',
             'driver_class': 'driverClass',
             'credential_file_content': 'credentialFileContent',
+            'wallet_secret': 'walletSecret',
+            'wallet_password_secret': 'walletPasswordSecret',
             'default_connection': 'defaultConnection'
         }
 
@@ -124,6 +136,8 @@ class CreateDataAssetFromAdwc(CreateDataAssetDetails):
         self._service_name = None
         self._driver_class = None
         self._credential_file_content = None
+        self._wallet_secret = None
+        self._wallet_password_secret = None
         self._default_connection = None
         self._model_type = 'ORACLE_ADWC_DATA_ASSET'
 
@@ -198,6 +212,46 @@ class CreateDataAssetFromAdwc(CreateDataAssetDetails):
         :type: str
         """
         self._credential_file_content = credential_file_content
+
+    @property
+    def wallet_secret(self):
+        """
+        Gets the wallet_secret of this CreateDataAssetFromAdwc.
+
+        :return: The wallet_secret of this CreateDataAssetFromAdwc.
+        :rtype: oci.data_integration.models.SensitiveAttribute
+        """
+        return self._wallet_secret
+
+    @wallet_secret.setter
+    def wallet_secret(self, wallet_secret):
+        """
+        Sets the wallet_secret of this CreateDataAssetFromAdwc.
+
+        :param wallet_secret: The wallet_secret of this CreateDataAssetFromAdwc.
+        :type: oci.data_integration.models.SensitiveAttribute
+        """
+        self._wallet_secret = wallet_secret
+
+    @property
+    def wallet_password_secret(self):
+        """
+        Gets the wallet_password_secret of this CreateDataAssetFromAdwc.
+
+        :return: The wallet_password_secret of this CreateDataAssetFromAdwc.
+        :rtype: oci.data_integration.models.SensitiveAttribute
+        """
+        return self._wallet_password_secret
+
+    @wallet_password_secret.setter
+    def wallet_password_secret(self, wallet_password_secret):
+        """
+        Sets the wallet_password_secret of this CreateDataAssetFromAdwc.
+
+        :param wallet_password_secret: The wallet_password_secret of this CreateDataAssetFromAdwc.
+        :type: oci.data_integration.models.SensitiveAttribute
+        """
+        self._wallet_password_secret = wallet_password_secret
 
     @property
     def default_connection(self):

--- a/src/oci/data_integration/models/create_data_asset_from_atp.py
+++ b/src/oci/data_integration/models/create_data_asset_from_atp.py
@@ -72,6 +72,14 @@ class CreateDataAssetFromAtp(CreateDataAssetDetails):
             The value to assign to the credential_file_content property of this CreateDataAssetFromAtp.
         :type credential_file_content: str
 
+        :param wallet_secret:
+            The value to assign to the wallet_secret property of this CreateDataAssetFromAtp.
+        :type wallet_secret: oci.data_integration.models.SensitiveAttribute
+
+        :param wallet_password_secret:
+            The value to assign to the wallet_password_secret property of this CreateDataAssetFromAtp.
+        :type wallet_password_secret: oci.data_integration.models.SensitiveAttribute
+
         :param default_connection:
             The value to assign to the default_connection property of this CreateDataAssetFromAtp.
         :type default_connection: oci.data_integration.models.CreateConnectionFromAtp
@@ -91,6 +99,8 @@ class CreateDataAssetFromAtp(CreateDataAssetDetails):
             'service_name': 'str',
             'driver_class': 'str',
             'credential_file_content': 'str',
+            'wallet_secret': 'SensitiveAttribute',
+            'wallet_password_secret': 'SensitiveAttribute',
             'default_connection': 'CreateConnectionFromAtp'
         }
 
@@ -108,6 +118,8 @@ class CreateDataAssetFromAtp(CreateDataAssetDetails):
             'service_name': 'serviceName',
             'driver_class': 'driverClass',
             'credential_file_content': 'credentialFileContent',
+            'wallet_secret': 'walletSecret',
+            'wallet_password_secret': 'walletPasswordSecret',
             'default_connection': 'defaultConnection'
         }
 
@@ -124,6 +136,8 @@ class CreateDataAssetFromAtp(CreateDataAssetDetails):
         self._service_name = None
         self._driver_class = None
         self._credential_file_content = None
+        self._wallet_secret = None
+        self._wallet_password_secret = None
         self._default_connection = None
         self._model_type = 'ORACLE_ATP_DATA_ASSET'
 
@@ -198,6 +212,46 @@ class CreateDataAssetFromAtp(CreateDataAssetDetails):
         :type: str
         """
         self._credential_file_content = credential_file_content
+
+    @property
+    def wallet_secret(self):
+        """
+        Gets the wallet_secret of this CreateDataAssetFromAtp.
+
+        :return: The wallet_secret of this CreateDataAssetFromAtp.
+        :rtype: oci.data_integration.models.SensitiveAttribute
+        """
+        return self._wallet_secret
+
+    @wallet_secret.setter
+    def wallet_secret(self, wallet_secret):
+        """
+        Sets the wallet_secret of this CreateDataAssetFromAtp.
+
+        :param wallet_secret: The wallet_secret of this CreateDataAssetFromAtp.
+        :type: oci.data_integration.models.SensitiveAttribute
+        """
+        self._wallet_secret = wallet_secret
+
+    @property
+    def wallet_password_secret(self):
+        """
+        Gets the wallet_password_secret of this CreateDataAssetFromAtp.
+
+        :return: The wallet_password_secret of this CreateDataAssetFromAtp.
+        :rtype: oci.data_integration.models.SensitiveAttribute
+        """
+        return self._wallet_password_secret
+
+    @wallet_password_secret.setter
+    def wallet_password_secret(self, wallet_password_secret):
+        """
+        Sets the wallet_password_secret of this CreateDataAssetFromAtp.
+
+        :param wallet_password_secret: The wallet_password_secret of this CreateDataAssetFromAtp.
+        :type: oci.data_integration.models.SensitiveAttribute
+        """
+        self._wallet_password_secret = wallet_password_secret
 
     @property
     def default_connection(self):

--- a/src/oci/data_integration/models/create_data_asset_from_oracle.py
+++ b/src/oci/data_integration/models/create_data_asset_from_oracle.py
@@ -84,6 +84,14 @@ class CreateDataAssetFromOracle(CreateDataAssetDetails):
             The value to assign to the credential_file_content property of this CreateDataAssetFromOracle.
         :type credential_file_content: str
 
+        :param wallet_secret:
+            The value to assign to the wallet_secret property of this CreateDataAssetFromOracle.
+        :type wallet_secret: oci.data_integration.models.SensitiveAttribute
+
+        :param wallet_password_secret:
+            The value to assign to the wallet_password_secret property of this CreateDataAssetFromOracle.
+        :type wallet_password_secret: oci.data_integration.models.SensitiveAttribute
+
         :param default_connection:
             The value to assign to the default_connection property of this CreateDataAssetFromOracle.
         :type default_connection: oci.data_integration.models.CreateConnectionFromOracle
@@ -106,6 +114,8 @@ class CreateDataAssetFromOracle(CreateDataAssetDetails):
             'driver_class': 'str',
             'sid': 'str',
             'credential_file_content': 'str',
+            'wallet_secret': 'SensitiveAttribute',
+            'wallet_password_secret': 'SensitiveAttribute',
             'default_connection': 'CreateConnectionFromOracle'
         }
 
@@ -126,6 +136,8 @@ class CreateDataAssetFromOracle(CreateDataAssetDetails):
             'driver_class': 'driverClass',
             'sid': 'sid',
             'credential_file_content': 'credentialFileContent',
+            'wallet_secret': 'walletSecret',
+            'wallet_password_secret': 'walletPasswordSecret',
             'default_connection': 'defaultConnection'
         }
 
@@ -145,6 +157,8 @@ class CreateDataAssetFromOracle(CreateDataAssetDetails):
         self._driver_class = None
         self._sid = None
         self._credential_file_content = None
+        self._wallet_secret = None
+        self._wallet_password_secret = None
         self._default_connection = None
         self._model_type = 'ORACLE_DATA_ASSET'
 
@@ -291,6 +305,46 @@ class CreateDataAssetFromOracle(CreateDataAssetDetails):
         :type: str
         """
         self._credential_file_content = credential_file_content
+
+    @property
+    def wallet_secret(self):
+        """
+        Gets the wallet_secret of this CreateDataAssetFromOracle.
+
+        :return: The wallet_secret of this CreateDataAssetFromOracle.
+        :rtype: oci.data_integration.models.SensitiveAttribute
+        """
+        return self._wallet_secret
+
+    @wallet_secret.setter
+    def wallet_secret(self, wallet_secret):
+        """
+        Sets the wallet_secret of this CreateDataAssetFromOracle.
+
+        :param wallet_secret: The wallet_secret of this CreateDataAssetFromOracle.
+        :type: oci.data_integration.models.SensitiveAttribute
+        """
+        self._wallet_secret = wallet_secret
+
+    @property
+    def wallet_password_secret(self):
+        """
+        Gets the wallet_password_secret of this CreateDataAssetFromOracle.
+
+        :return: The wallet_password_secret of this CreateDataAssetFromOracle.
+        :rtype: oci.data_integration.models.SensitiveAttribute
+        """
+        return self._wallet_password_secret
+
+    @wallet_password_secret.setter
+    def wallet_password_secret(self, wallet_password_secret):
+        """
+        Sets the wallet_password_secret of this CreateDataAssetFromOracle.
+
+        :param wallet_password_secret: The wallet_password_secret of this CreateDataAssetFromOracle.
+        :type: oci.data_integration.models.SensitiveAttribute
+        """
+        self._wallet_password_secret = wallet_password_secret
 
     @property
     def default_connection(self):

--- a/src/oci/data_integration/models/create_pipeline_details.py
+++ b/src/oci/data_integration/models/create_pipeline_details.py
@@ -1,0 +1,461 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreatePipelineDetails(object):
+    """
+    Properties used in pipeline create operations
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreatePipelineDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param key:
+            The value to assign to the key property of this CreatePipelineDetails.
+        :type key: str
+
+        :param model_version:
+            The value to assign to the model_version property of this CreatePipelineDetails.
+        :type model_version: str
+
+        :param parent_ref:
+            The value to assign to the parent_ref property of this CreatePipelineDetails.
+        :type parent_ref: oci.data_integration.models.ParentReference
+
+        :param name:
+            The value to assign to the name property of this CreatePipelineDetails.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this CreatePipelineDetails.
+        :type description: str
+
+        :param model_type:
+            The value to assign to the model_type property of this CreatePipelineDetails.
+        :type model_type: str
+
+        :param object_version:
+            The value to assign to the object_version property of this CreatePipelineDetails.
+        :type object_version: int
+
+        :param object_status:
+            The value to assign to the object_status property of this CreatePipelineDetails.
+        :type object_status: int
+
+        :param identifier:
+            The value to assign to the identifier property of this CreatePipelineDetails.
+        :type identifier: str
+
+        :param nodes:
+            The value to assign to the nodes property of this CreatePipelineDetails.
+        :type nodes: list[oci.data_integration.models.FlowNode]
+
+        :param parameters:
+            The value to assign to the parameters property of this CreatePipelineDetails.
+        :type parameters: list[oci.data_integration.models.Parameter]
+
+        :param flow_config_values:
+            The value to assign to the flow_config_values property of this CreatePipelineDetails.
+        :type flow_config_values: oci.data_integration.models.ConfigValues
+
+        :param variables:
+            The value to assign to the variables property of this CreatePipelineDetails.
+        :type variables: list[oci.data_integration.models.Variable]
+
+        :param registry_metadata:
+            The value to assign to the registry_metadata property of this CreatePipelineDetails.
+        :type registry_metadata: oci.data_integration.models.RegistryMetadata
+
+        """
+        self.swagger_types = {
+            'key': 'str',
+            'model_version': 'str',
+            'parent_ref': 'ParentReference',
+            'name': 'str',
+            'description': 'str',
+            'model_type': 'str',
+            'object_version': 'int',
+            'object_status': 'int',
+            'identifier': 'str',
+            'nodes': 'list[FlowNode]',
+            'parameters': 'list[Parameter]',
+            'flow_config_values': 'ConfigValues',
+            'variables': 'list[Variable]',
+            'registry_metadata': 'RegistryMetadata'
+        }
+
+        self.attribute_map = {
+            'key': 'key',
+            'model_version': 'modelVersion',
+            'parent_ref': 'parentRef',
+            'name': 'name',
+            'description': 'description',
+            'model_type': 'modelType',
+            'object_version': 'objectVersion',
+            'object_status': 'objectStatus',
+            'identifier': 'identifier',
+            'nodes': 'nodes',
+            'parameters': 'parameters',
+            'flow_config_values': 'flowConfigValues',
+            'variables': 'variables',
+            'registry_metadata': 'registryMetadata'
+        }
+
+        self._key = None
+        self._model_version = None
+        self._parent_ref = None
+        self._name = None
+        self._description = None
+        self._model_type = None
+        self._object_version = None
+        self._object_status = None
+        self._identifier = None
+        self._nodes = None
+        self._parameters = None
+        self._flow_config_values = None
+        self._variables = None
+        self._registry_metadata = None
+
+    @property
+    def key(self):
+        """
+        Gets the key of this CreatePipelineDetails.
+        Generated key that can be used in API calls to identify pipeline. On scenarios where reference to the pipeline is needed, a value can be passed in create.
+
+
+        :return: The key of this CreatePipelineDetails.
+        :rtype: str
+        """
+        return self._key
+
+    @key.setter
+    def key(self, key):
+        """
+        Sets the key of this CreatePipelineDetails.
+        Generated key that can be used in API calls to identify pipeline. On scenarios where reference to the pipeline is needed, a value can be passed in create.
+
+
+        :param key: The key of this CreatePipelineDetails.
+        :type: str
+        """
+        self._key = key
+
+    @property
+    def model_version(self):
+        """
+        Gets the model_version of this CreatePipelineDetails.
+        This is a version number that is used by the service to upgrade objects if needed through releases of the service.
+
+
+        :return: The model_version of this CreatePipelineDetails.
+        :rtype: str
+        """
+        return self._model_version
+
+    @model_version.setter
+    def model_version(self, model_version):
+        """
+        Sets the model_version of this CreatePipelineDetails.
+        This is a version number that is used by the service to upgrade objects if needed through releases of the service.
+
+
+        :param model_version: The model_version of this CreatePipelineDetails.
+        :type: str
+        """
+        self._model_version = model_version
+
+    @property
+    def parent_ref(self):
+        """
+        Gets the parent_ref of this CreatePipelineDetails.
+
+        :return: The parent_ref of this CreatePipelineDetails.
+        :rtype: oci.data_integration.models.ParentReference
+        """
+        return self._parent_ref
+
+    @parent_ref.setter
+    def parent_ref(self, parent_ref):
+        """
+        Sets the parent_ref of this CreatePipelineDetails.
+
+        :param parent_ref: The parent_ref of this CreatePipelineDetails.
+        :type: oci.data_integration.models.ParentReference
+        """
+        self._parent_ref = parent_ref
+
+    @property
+    def name(self):
+        """
+        **[Required]** Gets the name of this CreatePipelineDetails.
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
+
+
+        :return: The name of this CreatePipelineDetails.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this CreatePipelineDetails.
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
+
+
+        :param name: The name of this CreatePipelineDetails.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def description(self):
+        """
+        Gets the description of this CreatePipelineDetails.
+        Detailed description for the object.
+
+
+        :return: The description of this CreatePipelineDetails.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this CreatePipelineDetails.
+        Detailed description for the object.
+
+
+        :param description: The description of this CreatePipelineDetails.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def model_type(self):
+        """
+        Gets the model_type of this CreatePipelineDetails.
+        The type of the object.
+
+
+        :return: The model_type of this CreatePipelineDetails.
+        :rtype: str
+        """
+        return self._model_type
+
+    @model_type.setter
+    def model_type(self, model_type):
+        """
+        Sets the model_type of this CreatePipelineDetails.
+        The type of the object.
+
+
+        :param model_type: The model_type of this CreatePipelineDetails.
+        :type: str
+        """
+        self._model_type = model_type
+
+    @property
+    def object_version(self):
+        """
+        Gets the object_version of this CreatePipelineDetails.
+        This is used by the service for optimistic locking of the object, to prevent multiple users from simultaneously updating the object.
+
+
+        :return: The object_version of this CreatePipelineDetails.
+        :rtype: int
+        """
+        return self._object_version
+
+    @object_version.setter
+    def object_version(self, object_version):
+        """
+        Sets the object_version of this CreatePipelineDetails.
+        This is used by the service for optimistic locking of the object, to prevent multiple users from simultaneously updating the object.
+
+
+        :param object_version: The object_version of this CreatePipelineDetails.
+        :type: int
+        """
+        self._object_version = object_version
+
+    @property
+    def object_status(self):
+        """
+        Gets the object_status of this CreatePipelineDetails.
+        The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+
+
+        :return: The object_status of this CreatePipelineDetails.
+        :rtype: int
+        """
+        return self._object_status
+
+    @object_status.setter
+    def object_status(self, object_status):
+        """
+        Sets the object_status of this CreatePipelineDetails.
+        The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+
+
+        :param object_status: The object_status of this CreatePipelineDetails.
+        :type: int
+        """
+        self._object_status = object_status
+
+    @property
+    def identifier(self):
+        """
+        **[Required]** Gets the identifier of this CreatePipelineDetails.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
+
+
+        :return: The identifier of this CreatePipelineDetails.
+        :rtype: str
+        """
+        return self._identifier
+
+    @identifier.setter
+    def identifier(self, identifier):
+        """
+        Sets the identifier of this CreatePipelineDetails.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
+
+
+        :param identifier: The identifier of this CreatePipelineDetails.
+        :type: str
+        """
+        self._identifier = identifier
+
+    @property
+    def nodes(self):
+        """
+        Gets the nodes of this CreatePipelineDetails.
+        A list of nodes attached to the pipeline
+
+
+        :return: The nodes of this CreatePipelineDetails.
+        :rtype: list[oci.data_integration.models.FlowNode]
+        """
+        return self._nodes
+
+    @nodes.setter
+    def nodes(self, nodes):
+        """
+        Sets the nodes of this CreatePipelineDetails.
+        A list of nodes attached to the pipeline
+
+
+        :param nodes: The nodes of this CreatePipelineDetails.
+        :type: list[oci.data_integration.models.FlowNode]
+        """
+        self._nodes = nodes
+
+    @property
+    def parameters(self):
+        """
+        Gets the parameters of this CreatePipelineDetails.
+        A list of additional parameters required in pipeline.
+
+
+        :return: The parameters of this CreatePipelineDetails.
+        :rtype: list[oci.data_integration.models.Parameter]
+        """
+        return self._parameters
+
+    @parameters.setter
+    def parameters(self, parameters):
+        """
+        Sets the parameters of this CreatePipelineDetails.
+        A list of additional parameters required in pipeline.
+
+
+        :param parameters: The parameters of this CreatePipelineDetails.
+        :type: list[oci.data_integration.models.Parameter]
+        """
+        self._parameters = parameters
+
+    @property
+    def flow_config_values(self):
+        """
+        Gets the flow_config_values of this CreatePipelineDetails.
+
+        :return: The flow_config_values of this CreatePipelineDetails.
+        :rtype: oci.data_integration.models.ConfigValues
+        """
+        return self._flow_config_values
+
+    @flow_config_values.setter
+    def flow_config_values(self, flow_config_values):
+        """
+        Sets the flow_config_values of this CreatePipelineDetails.
+
+        :param flow_config_values: The flow_config_values of this CreatePipelineDetails.
+        :type: oci.data_integration.models.ConfigValues
+        """
+        self._flow_config_values = flow_config_values
+
+    @property
+    def variables(self):
+        """
+        Gets the variables of this CreatePipelineDetails.
+        The list of variables required in pipeline.
+
+
+        :return: The variables of this CreatePipelineDetails.
+        :rtype: list[oci.data_integration.models.Variable]
+        """
+        return self._variables
+
+    @variables.setter
+    def variables(self, variables):
+        """
+        Sets the variables of this CreatePipelineDetails.
+        The list of variables required in pipeline.
+
+
+        :param variables: The variables of this CreatePipelineDetails.
+        :type: list[oci.data_integration.models.Variable]
+        """
+        self._variables = variables
+
+    @property
+    def registry_metadata(self):
+        """
+        **[Required]** Gets the registry_metadata of this CreatePipelineDetails.
+
+        :return: The registry_metadata of this CreatePipelineDetails.
+        :rtype: oci.data_integration.models.RegistryMetadata
+        """
+        return self._registry_metadata
+
+    @registry_metadata.setter
+    def registry_metadata(self, registry_metadata):
+        """
+        Sets the registry_metadata of this CreatePipelineDetails.
+
+        :param registry_metadata: The registry_metadata of this CreatePipelineDetails.
+        :type: oci.data_integration.models.RegistryMetadata
+        """
+        self._registry_metadata = registry_metadata
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/create_pipeline_validation_details.py
+++ b/src/oci/data_integration/models/create_pipeline_validation_details.py
@@ -1,0 +1,461 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreatePipelineValidationDetails(object):
+    """
+    The properties used in create pipeline validation operations.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreatePipelineValidationDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param key:
+            The value to assign to the key property of this CreatePipelineValidationDetails.
+        :type key: str
+
+        :param model_version:
+            The value to assign to the model_version property of this CreatePipelineValidationDetails.
+        :type model_version: str
+
+        :param parent_ref:
+            The value to assign to the parent_ref property of this CreatePipelineValidationDetails.
+        :type parent_ref: oci.data_integration.models.ParentReference
+
+        :param name:
+            The value to assign to the name property of this CreatePipelineValidationDetails.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this CreatePipelineValidationDetails.
+        :type description: str
+
+        :param model_type:
+            The value to assign to the model_type property of this CreatePipelineValidationDetails.
+        :type model_type: str
+
+        :param object_version:
+            The value to assign to the object_version property of this CreatePipelineValidationDetails.
+        :type object_version: int
+
+        :param object_status:
+            The value to assign to the object_status property of this CreatePipelineValidationDetails.
+        :type object_status: int
+
+        :param identifier:
+            The value to assign to the identifier property of this CreatePipelineValidationDetails.
+        :type identifier: str
+
+        :param nodes:
+            The value to assign to the nodes property of this CreatePipelineValidationDetails.
+        :type nodes: list[oci.data_integration.models.FlowNode]
+
+        :param parameters:
+            The value to assign to the parameters property of this CreatePipelineValidationDetails.
+        :type parameters: list[oci.data_integration.models.Parameter]
+
+        :param flow_config_values:
+            The value to assign to the flow_config_values property of this CreatePipelineValidationDetails.
+        :type flow_config_values: oci.data_integration.models.ConfigValues
+
+        :param variables:
+            The value to assign to the variables property of this CreatePipelineValidationDetails.
+        :type variables: list[oci.data_integration.models.Variable]
+
+        :param metadata:
+            The value to assign to the metadata property of this CreatePipelineValidationDetails.
+        :type metadata: oci.data_integration.models.ObjectMetadata
+
+        """
+        self.swagger_types = {
+            'key': 'str',
+            'model_version': 'str',
+            'parent_ref': 'ParentReference',
+            'name': 'str',
+            'description': 'str',
+            'model_type': 'str',
+            'object_version': 'int',
+            'object_status': 'int',
+            'identifier': 'str',
+            'nodes': 'list[FlowNode]',
+            'parameters': 'list[Parameter]',
+            'flow_config_values': 'ConfigValues',
+            'variables': 'list[Variable]',
+            'metadata': 'ObjectMetadata'
+        }
+
+        self.attribute_map = {
+            'key': 'key',
+            'model_version': 'modelVersion',
+            'parent_ref': 'parentRef',
+            'name': 'name',
+            'description': 'description',
+            'model_type': 'modelType',
+            'object_version': 'objectVersion',
+            'object_status': 'objectStatus',
+            'identifier': 'identifier',
+            'nodes': 'nodes',
+            'parameters': 'parameters',
+            'flow_config_values': 'flowConfigValues',
+            'variables': 'variables',
+            'metadata': 'metadata'
+        }
+
+        self._key = None
+        self._model_version = None
+        self._parent_ref = None
+        self._name = None
+        self._description = None
+        self._model_type = None
+        self._object_version = None
+        self._object_status = None
+        self._identifier = None
+        self._nodes = None
+        self._parameters = None
+        self._flow_config_values = None
+        self._variables = None
+        self._metadata = None
+
+    @property
+    def key(self):
+        """
+        Gets the key of this CreatePipelineValidationDetails.
+        Generated key that can be used in API calls to identify pipeline. On scenarios where reference to the pipeline is needed, a value can be passed in create.
+
+
+        :return: The key of this CreatePipelineValidationDetails.
+        :rtype: str
+        """
+        return self._key
+
+    @key.setter
+    def key(self, key):
+        """
+        Sets the key of this CreatePipelineValidationDetails.
+        Generated key that can be used in API calls to identify pipeline. On scenarios where reference to the pipeline is needed, a value can be passed in create.
+
+
+        :param key: The key of this CreatePipelineValidationDetails.
+        :type: str
+        """
+        self._key = key
+
+    @property
+    def model_version(self):
+        """
+        Gets the model_version of this CreatePipelineValidationDetails.
+        This is a version number that is used by the service to upgrade objects if needed through releases of the service.
+
+
+        :return: The model_version of this CreatePipelineValidationDetails.
+        :rtype: str
+        """
+        return self._model_version
+
+    @model_version.setter
+    def model_version(self, model_version):
+        """
+        Sets the model_version of this CreatePipelineValidationDetails.
+        This is a version number that is used by the service to upgrade objects if needed through releases of the service.
+
+
+        :param model_version: The model_version of this CreatePipelineValidationDetails.
+        :type: str
+        """
+        self._model_version = model_version
+
+    @property
+    def parent_ref(self):
+        """
+        Gets the parent_ref of this CreatePipelineValidationDetails.
+
+        :return: The parent_ref of this CreatePipelineValidationDetails.
+        :rtype: oci.data_integration.models.ParentReference
+        """
+        return self._parent_ref
+
+    @parent_ref.setter
+    def parent_ref(self, parent_ref):
+        """
+        Sets the parent_ref of this CreatePipelineValidationDetails.
+
+        :param parent_ref: The parent_ref of this CreatePipelineValidationDetails.
+        :type: oci.data_integration.models.ParentReference
+        """
+        self._parent_ref = parent_ref
+
+    @property
+    def name(self):
+        """
+        Gets the name of this CreatePipelineValidationDetails.
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
+
+
+        :return: The name of this CreatePipelineValidationDetails.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this CreatePipelineValidationDetails.
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
+
+
+        :param name: The name of this CreatePipelineValidationDetails.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def description(self):
+        """
+        Gets the description of this CreatePipelineValidationDetails.
+        Detailed description for the object.
+
+
+        :return: The description of this CreatePipelineValidationDetails.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this CreatePipelineValidationDetails.
+        Detailed description for the object.
+
+
+        :param description: The description of this CreatePipelineValidationDetails.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def model_type(self):
+        """
+        Gets the model_type of this CreatePipelineValidationDetails.
+        The type of the object.
+
+
+        :return: The model_type of this CreatePipelineValidationDetails.
+        :rtype: str
+        """
+        return self._model_type
+
+    @model_type.setter
+    def model_type(self, model_type):
+        """
+        Sets the model_type of this CreatePipelineValidationDetails.
+        The type of the object.
+
+
+        :param model_type: The model_type of this CreatePipelineValidationDetails.
+        :type: str
+        """
+        self._model_type = model_type
+
+    @property
+    def object_version(self):
+        """
+        Gets the object_version of this CreatePipelineValidationDetails.
+        This is used by the service for optimistic locking of the object, to prevent multiple users from simultaneously updating the object.
+
+
+        :return: The object_version of this CreatePipelineValidationDetails.
+        :rtype: int
+        """
+        return self._object_version
+
+    @object_version.setter
+    def object_version(self, object_version):
+        """
+        Sets the object_version of this CreatePipelineValidationDetails.
+        This is used by the service for optimistic locking of the object, to prevent multiple users from simultaneously updating the object.
+
+
+        :param object_version: The object_version of this CreatePipelineValidationDetails.
+        :type: int
+        """
+        self._object_version = object_version
+
+    @property
+    def object_status(self):
+        """
+        Gets the object_status of this CreatePipelineValidationDetails.
+        The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+
+
+        :return: The object_status of this CreatePipelineValidationDetails.
+        :rtype: int
+        """
+        return self._object_status
+
+    @object_status.setter
+    def object_status(self, object_status):
+        """
+        Sets the object_status of this CreatePipelineValidationDetails.
+        The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+
+
+        :param object_status: The object_status of this CreatePipelineValidationDetails.
+        :type: int
+        """
+        self._object_status = object_status
+
+    @property
+    def identifier(self):
+        """
+        Gets the identifier of this CreatePipelineValidationDetails.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
+
+
+        :return: The identifier of this CreatePipelineValidationDetails.
+        :rtype: str
+        """
+        return self._identifier
+
+    @identifier.setter
+    def identifier(self, identifier):
+        """
+        Sets the identifier of this CreatePipelineValidationDetails.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
+
+
+        :param identifier: The identifier of this CreatePipelineValidationDetails.
+        :type: str
+        """
+        self._identifier = identifier
+
+    @property
+    def nodes(self):
+        """
+        Gets the nodes of this CreatePipelineValidationDetails.
+        A list of nodes attached to the pipeline.
+
+
+        :return: The nodes of this CreatePipelineValidationDetails.
+        :rtype: list[oci.data_integration.models.FlowNode]
+        """
+        return self._nodes
+
+    @nodes.setter
+    def nodes(self, nodes):
+        """
+        Sets the nodes of this CreatePipelineValidationDetails.
+        A list of nodes attached to the pipeline.
+
+
+        :param nodes: The nodes of this CreatePipelineValidationDetails.
+        :type: list[oci.data_integration.models.FlowNode]
+        """
+        self._nodes = nodes
+
+    @property
+    def parameters(self):
+        """
+        Gets the parameters of this CreatePipelineValidationDetails.
+        A list of parameters for the pipeline, this allows certain aspects of the pipeline to be configured when the pipeline is executed.
+
+
+        :return: The parameters of this CreatePipelineValidationDetails.
+        :rtype: list[oci.data_integration.models.Parameter]
+        """
+        return self._parameters
+
+    @parameters.setter
+    def parameters(self, parameters):
+        """
+        Sets the parameters of this CreatePipelineValidationDetails.
+        A list of parameters for the pipeline, this allows certain aspects of the pipeline to be configured when the pipeline is executed.
+
+
+        :param parameters: The parameters of this CreatePipelineValidationDetails.
+        :type: list[oci.data_integration.models.Parameter]
+        """
+        self._parameters = parameters
+
+    @property
+    def flow_config_values(self):
+        """
+        Gets the flow_config_values of this CreatePipelineValidationDetails.
+
+        :return: The flow_config_values of this CreatePipelineValidationDetails.
+        :rtype: oci.data_integration.models.ConfigValues
+        """
+        return self._flow_config_values
+
+    @flow_config_values.setter
+    def flow_config_values(self, flow_config_values):
+        """
+        Sets the flow_config_values of this CreatePipelineValidationDetails.
+
+        :param flow_config_values: The flow_config_values of this CreatePipelineValidationDetails.
+        :type: oci.data_integration.models.ConfigValues
+        """
+        self._flow_config_values = flow_config_values
+
+    @property
+    def variables(self):
+        """
+        Gets the variables of this CreatePipelineValidationDetails.
+        The list of variables required in pipeline, variables can be used to store values that can be used as inputs to tasks in the pipeline.
+
+
+        :return: The variables of this CreatePipelineValidationDetails.
+        :rtype: list[oci.data_integration.models.Variable]
+        """
+        return self._variables
+
+    @variables.setter
+    def variables(self, variables):
+        """
+        Sets the variables of this CreatePipelineValidationDetails.
+        The list of variables required in pipeline, variables can be used to store values that can be used as inputs to tasks in the pipeline.
+
+
+        :param variables: The variables of this CreatePipelineValidationDetails.
+        :type: list[oci.data_integration.models.Variable]
+        """
+        self._variables = variables
+
+    @property
+    def metadata(self):
+        """
+        Gets the metadata of this CreatePipelineValidationDetails.
+
+        :return: The metadata of this CreatePipelineValidationDetails.
+        :rtype: oci.data_integration.models.ObjectMetadata
+        """
+        return self._metadata
+
+    @metadata.setter
+    def metadata(self, metadata):
+        """
+        Sets the metadata of this CreatePipelineValidationDetails.
+
+        :param metadata: The metadata of this CreatePipelineValidationDetails.
+        :type: oci.data_integration.models.ObjectMetadata
+        """
+        self._metadata = metadata
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/create_task_details.py
+++ b/src/oci/data_integration/models/create_task_details.py
@@ -21,6 +21,10 @@ class CreateTaskDetails(object):
     #: This constant has a value of "DATA_LOADER_TASK"
     MODEL_TYPE_DATA_LOADER_TASK = "DATA_LOADER_TASK"
 
+    #: A constant which can be used with the model_type property of a CreateTaskDetails.
+    #: This constant has a value of "PIPELINE_TASK"
+    MODEL_TYPE_PIPELINE_TASK = "PIPELINE_TASK"
+
     def __init__(self, **kwargs):
         """
         Initializes a new CreateTaskDetails object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
@@ -28,12 +32,13 @@ class CreateTaskDetails(object):
 
         * :class:`~oci.data_integration.models.CreateTaskFromIntegrationTask`
         * :class:`~oci.data_integration.models.CreateTaskFromDataLoaderTask`
+        * :class:`~oci.data_integration.models.CreateTaskFromPipelineTask`
 
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
         :param model_type:
             The value to assign to the model_type property of this CreateTaskDetails.
-            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK"
+            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK"
         :type model_type: str
 
         :param key:
@@ -151,6 +156,9 @@ class CreateTaskDetails(object):
 
         if type == 'DATA_LOADER_TASK':
             return 'CreateTaskFromDataLoaderTask'
+
+        if type == 'PIPELINE_TASK':
+            return 'CreateTaskFromPipelineTask'
         else:
             return 'CreateTaskDetails'
 
@@ -160,7 +168,7 @@ class CreateTaskDetails(object):
         **[Required]** Gets the model_type of this CreateTaskDetails.
         The type of the task.
 
-        Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK"
+        Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK"
 
 
         :return: The model_type of this CreateTaskDetails.
@@ -178,7 +186,7 @@ class CreateTaskDetails(object):
         :param model_type: The model_type of this CreateTaskDetails.
         :type: str
         """
-        allowed_values = ["INTEGRATION_TASK", "DATA_LOADER_TASK"]
+        allowed_values = ["INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK"]
         if not value_allowed_none_or_none_sentinel(model_type, allowed_values):
             raise ValueError(
                 "Invalid value for `model_type`, must be None or one of {0}"

--- a/src/oci/data_integration/models/create_task_from_data_loader_task.py
+++ b/src/oci/data_integration/models/create_task_from_data_loader_task.py
@@ -21,7 +21,7 @@ class CreateTaskFromDataLoaderTask(CreateTaskDetails):
 
         :param model_type:
             The value to assign to the model_type property of this CreateTaskFromDataLoaderTask.
-            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK"
+            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK"
         :type model_type: str
 
         :param key:

--- a/src/oci/data_integration/models/create_task_from_integration_task.py
+++ b/src/oci/data_integration/models/create_task_from_integration_task.py
@@ -21,7 +21,7 @@ class CreateTaskFromIntegrationTask(CreateTaskDetails):
 
         :param model_type:
             The value to assign to the model_type property of this CreateTaskFromIntegrationTask.
-            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK"
+            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK"
         :type model_type: str
 
         :param key:

--- a/src/oci/data_integration/models/create_task_from_pipeline_task.py
+++ b/src/oci/data_integration/models/create_task_from_pipeline_task.py
@@ -1,0 +1,167 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .create_task_details import CreateTaskDetails
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateTaskFromPipelineTask(CreateTaskDetails):
+    """
+    The information about the pipeline task.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateTaskFromPipelineTask object with values from keyword arguments. The default value of the :py:attr:`~oci.data_integration.models.CreateTaskFromPipelineTask.model_type` attribute
+        of this class is ``PIPELINE_TASK`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param model_type:
+            The value to assign to the model_type property of this CreateTaskFromPipelineTask.
+            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK"
+        :type model_type: str
+
+        :param key:
+            The value to assign to the key property of this CreateTaskFromPipelineTask.
+        :type key: str
+
+        :param model_version:
+            The value to assign to the model_version property of this CreateTaskFromPipelineTask.
+        :type model_version: str
+
+        :param parent_ref:
+            The value to assign to the parent_ref property of this CreateTaskFromPipelineTask.
+        :type parent_ref: oci.data_integration.models.ParentReference
+
+        :param name:
+            The value to assign to the name property of this CreateTaskFromPipelineTask.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this CreateTaskFromPipelineTask.
+        :type description: str
+
+        :param object_status:
+            The value to assign to the object_status property of this CreateTaskFromPipelineTask.
+        :type object_status: int
+
+        :param identifier:
+            The value to assign to the identifier property of this CreateTaskFromPipelineTask.
+        :type identifier: str
+
+        :param input_ports:
+            The value to assign to the input_ports property of this CreateTaskFromPipelineTask.
+        :type input_ports: list[oci.data_integration.models.InputPort]
+
+        :param output_ports:
+            The value to assign to the output_ports property of this CreateTaskFromPipelineTask.
+        :type output_ports: list[oci.data_integration.models.OutputPort]
+
+        :param parameters:
+            The value to assign to the parameters property of this CreateTaskFromPipelineTask.
+        :type parameters: list[oci.data_integration.models.Parameter]
+
+        :param op_config_values:
+            The value to assign to the op_config_values property of this CreateTaskFromPipelineTask.
+        :type op_config_values: oci.data_integration.models.ConfigValues
+
+        :param config_provider_delegate:
+            The value to assign to the config_provider_delegate property of this CreateTaskFromPipelineTask.
+        :type config_provider_delegate: oci.data_integration.models.CreateConfigProvider
+
+        :param registry_metadata:
+            The value to assign to the registry_metadata property of this CreateTaskFromPipelineTask.
+        :type registry_metadata: oci.data_integration.models.RegistryMetadata
+
+        :param pipeline:
+            The value to assign to the pipeline property of this CreateTaskFromPipelineTask.
+        :type pipeline: oci.data_integration.models.Pipeline
+
+        """
+        self.swagger_types = {
+            'model_type': 'str',
+            'key': 'str',
+            'model_version': 'str',
+            'parent_ref': 'ParentReference',
+            'name': 'str',
+            'description': 'str',
+            'object_status': 'int',
+            'identifier': 'str',
+            'input_ports': 'list[InputPort]',
+            'output_ports': 'list[OutputPort]',
+            'parameters': 'list[Parameter]',
+            'op_config_values': 'ConfigValues',
+            'config_provider_delegate': 'CreateConfigProvider',
+            'registry_metadata': 'RegistryMetadata',
+            'pipeline': 'Pipeline'
+        }
+
+        self.attribute_map = {
+            'model_type': 'modelType',
+            'key': 'key',
+            'model_version': 'modelVersion',
+            'parent_ref': 'parentRef',
+            'name': 'name',
+            'description': 'description',
+            'object_status': 'objectStatus',
+            'identifier': 'identifier',
+            'input_ports': 'inputPorts',
+            'output_ports': 'outputPorts',
+            'parameters': 'parameters',
+            'op_config_values': 'opConfigValues',
+            'config_provider_delegate': 'configProviderDelegate',
+            'registry_metadata': 'registryMetadata',
+            'pipeline': 'pipeline'
+        }
+
+        self._model_type = None
+        self._key = None
+        self._model_version = None
+        self._parent_ref = None
+        self._name = None
+        self._description = None
+        self._object_status = None
+        self._identifier = None
+        self._input_ports = None
+        self._output_ports = None
+        self._parameters = None
+        self._op_config_values = None
+        self._config_provider_delegate = None
+        self._registry_metadata = None
+        self._pipeline = None
+        self._model_type = 'PIPELINE_TASK'
+
+    @property
+    def pipeline(self):
+        """
+        Gets the pipeline of this CreateTaskFromPipelineTask.
+
+        :return: The pipeline of this CreateTaskFromPipelineTask.
+        :rtype: oci.data_integration.models.Pipeline
+        """
+        return self._pipeline
+
+    @pipeline.setter
+    def pipeline(self, pipeline):
+        """
+        Sets the pipeline of this CreateTaskFromPipelineTask.
+
+        :param pipeline: The pipeline of this CreateTaskFromPipelineTask.
+        :type: oci.data_integration.models.Pipeline
+        """
+        self._pipeline = pipeline
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/create_task_validation_details.py
+++ b/src/oci/data_integration/models/create_task_validation_details.py
@@ -21,19 +21,24 @@ class CreateTaskValidationDetails(object):
     #: This constant has a value of "DATA_LOADER_TASK"
     MODEL_TYPE_DATA_LOADER_TASK = "DATA_LOADER_TASK"
 
+    #: A constant which can be used with the model_type property of a CreateTaskValidationDetails.
+    #: This constant has a value of "PIPELINE_TASK"
+    MODEL_TYPE_PIPELINE_TASK = "PIPELINE_TASK"
+
     def __init__(self, **kwargs):
         """
         Initializes a new CreateTaskValidationDetails object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
         to a service operations then you should favor using a subclass over the base class:
 
         * :class:`~oci.data_integration.models.CreateTaskValidationFromDataLoaderTask`
+        * :class:`~oci.data_integration.models.CreateTaskValidationFromPipelineTask`
         * :class:`~oci.data_integration.models.CreateTaskValidationFromIntegrationTask`
 
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
         :param model_type:
             The value to assign to the model_type property of this CreateTaskValidationDetails.
-            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK"
+            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK"
         :type model_type: str
 
         :param key:
@@ -156,6 +161,9 @@ class CreateTaskValidationDetails(object):
         if type == 'DATA_LOADER_TASK':
             return 'CreateTaskValidationFromDataLoaderTask'
 
+        if type == 'PIPELINE_TASK':
+            return 'CreateTaskValidationFromPipelineTask'
+
         if type == 'INTEGRATION_TASK':
             return 'CreateTaskValidationFromIntegrationTask'
         else:
@@ -167,7 +175,7 @@ class CreateTaskValidationDetails(object):
         Gets the model_type of this CreateTaskValidationDetails.
         The type of the task.
 
-        Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK"
+        Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK"
 
 
         :return: The model_type of this CreateTaskValidationDetails.
@@ -185,7 +193,7 @@ class CreateTaskValidationDetails(object):
         :param model_type: The model_type of this CreateTaskValidationDetails.
         :type: str
         """
-        allowed_values = ["INTEGRATION_TASK", "DATA_LOADER_TASK"]
+        allowed_values = ["INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK"]
         if not value_allowed_none_or_none_sentinel(model_type, allowed_values):
             raise ValueError(
                 "Invalid value for `model_type`, must be None or one of {0}"

--- a/src/oci/data_integration/models/create_task_validation_from_data_loader_task.py
+++ b/src/oci/data_integration/models/create_task_validation_from_data_loader_task.py
@@ -21,7 +21,7 @@ class CreateTaskValidationFromDataLoaderTask(CreateTaskValidationDetails):
 
         :param model_type:
             The value to assign to the model_type property of this CreateTaskValidationFromDataLoaderTask.
-            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK"
+            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK"
         :type model_type: str
 
         :param key:

--- a/src/oci/data_integration/models/create_task_validation_from_integration_task.py
+++ b/src/oci/data_integration/models/create_task_validation_from_integration_task.py
@@ -21,7 +21,7 @@ class CreateTaskValidationFromIntegrationTask(CreateTaskValidationDetails):
 
         :param model_type:
             The value to assign to the model_type property of this CreateTaskValidationFromIntegrationTask.
-            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK"
+            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK"
         :type model_type: str
 
         :param key:

--- a/src/oci/data_integration/models/create_task_validation_from_pipeline_task.py
+++ b/src/oci/data_integration/models/create_task_validation_from_pipeline_task.py
@@ -1,0 +1,174 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .create_task_validation_details import CreateTaskValidationDetails
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateTaskValidationFromPipelineTask(CreateTaskValidationDetails):
+    """
+    The information about a pipeline task.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateTaskValidationFromPipelineTask object with values from keyword arguments. The default value of the :py:attr:`~oci.data_integration.models.CreateTaskValidationFromPipelineTask.model_type` attribute
+        of this class is ``PIPELINE_TASK`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param model_type:
+            The value to assign to the model_type property of this CreateTaskValidationFromPipelineTask.
+            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK"
+        :type model_type: str
+
+        :param key:
+            The value to assign to the key property of this CreateTaskValidationFromPipelineTask.
+        :type key: str
+
+        :param model_version:
+            The value to assign to the model_version property of this CreateTaskValidationFromPipelineTask.
+        :type model_version: str
+
+        :param parent_ref:
+            The value to assign to the parent_ref property of this CreateTaskValidationFromPipelineTask.
+        :type parent_ref: oci.data_integration.models.ParentReference
+
+        :param name:
+            The value to assign to the name property of this CreateTaskValidationFromPipelineTask.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this CreateTaskValidationFromPipelineTask.
+        :type description: str
+
+        :param object_version:
+            The value to assign to the object_version property of this CreateTaskValidationFromPipelineTask.
+        :type object_version: int
+
+        :param object_status:
+            The value to assign to the object_status property of this CreateTaskValidationFromPipelineTask.
+        :type object_status: int
+
+        :param identifier:
+            The value to assign to the identifier property of this CreateTaskValidationFromPipelineTask.
+        :type identifier: str
+
+        :param input_ports:
+            The value to assign to the input_ports property of this CreateTaskValidationFromPipelineTask.
+        :type input_ports: list[oci.data_integration.models.InputPort]
+
+        :param output_ports:
+            The value to assign to the output_ports property of this CreateTaskValidationFromPipelineTask.
+        :type output_ports: list[oci.data_integration.models.OutputPort]
+
+        :param parameters:
+            The value to assign to the parameters property of this CreateTaskValidationFromPipelineTask.
+        :type parameters: list[oci.data_integration.models.Parameter]
+
+        :param op_config_values:
+            The value to assign to the op_config_values property of this CreateTaskValidationFromPipelineTask.
+        :type op_config_values: oci.data_integration.models.ConfigValues
+
+        :param config_provider_delegate:
+            The value to assign to the config_provider_delegate property of this CreateTaskValidationFromPipelineTask.
+        :type config_provider_delegate: oci.data_integration.models.ConfigProvider
+
+        :param metadata:
+            The value to assign to the metadata property of this CreateTaskValidationFromPipelineTask.
+        :type metadata: oci.data_integration.models.ObjectMetadata
+
+        :param pipeline:
+            The value to assign to the pipeline property of this CreateTaskValidationFromPipelineTask.
+        :type pipeline: oci.data_integration.models.Pipeline
+
+        """
+        self.swagger_types = {
+            'model_type': 'str',
+            'key': 'str',
+            'model_version': 'str',
+            'parent_ref': 'ParentReference',
+            'name': 'str',
+            'description': 'str',
+            'object_version': 'int',
+            'object_status': 'int',
+            'identifier': 'str',
+            'input_ports': 'list[InputPort]',
+            'output_ports': 'list[OutputPort]',
+            'parameters': 'list[Parameter]',
+            'op_config_values': 'ConfigValues',
+            'config_provider_delegate': 'ConfigProvider',
+            'metadata': 'ObjectMetadata',
+            'pipeline': 'Pipeline'
+        }
+
+        self.attribute_map = {
+            'model_type': 'modelType',
+            'key': 'key',
+            'model_version': 'modelVersion',
+            'parent_ref': 'parentRef',
+            'name': 'name',
+            'description': 'description',
+            'object_version': 'objectVersion',
+            'object_status': 'objectStatus',
+            'identifier': 'identifier',
+            'input_ports': 'inputPorts',
+            'output_ports': 'outputPorts',
+            'parameters': 'parameters',
+            'op_config_values': 'opConfigValues',
+            'config_provider_delegate': 'configProviderDelegate',
+            'metadata': 'metadata',
+            'pipeline': 'pipeline'
+        }
+
+        self._model_type = None
+        self._key = None
+        self._model_version = None
+        self._parent_ref = None
+        self._name = None
+        self._description = None
+        self._object_version = None
+        self._object_status = None
+        self._identifier = None
+        self._input_ports = None
+        self._output_ports = None
+        self._parameters = None
+        self._op_config_values = None
+        self._config_provider_delegate = None
+        self._metadata = None
+        self._pipeline = None
+        self._model_type = 'PIPELINE_TASK'
+
+    @property
+    def pipeline(self):
+        """
+        Gets the pipeline of this CreateTaskValidationFromPipelineTask.
+
+        :return: The pipeline of this CreateTaskValidationFromPipelineTask.
+        :rtype: oci.data_integration.models.Pipeline
+        """
+        return self._pipeline
+
+    @pipeline.setter
+    def pipeline(self, pipeline):
+        """
+        Sets the pipeline of this CreateTaskValidationFromPipelineTask.
+
+        :param pipeline: The pipeline of this CreateTaskValidationFromPipelineTask.
+        :type: oci.data_integration.models.Pipeline
+        """
+        self._pipeline = pipeline
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/daily_frequency_details.py
+++ b/src/oci/data_integration/models/daily_frequency_details.py
@@ -1,0 +1,115 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .abstract_frequency_details import AbstractFrequencyDetails
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class DailyFrequencyDetails(AbstractFrequencyDetails):
+    """
+    Frequency details model to set daily frequency
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new DailyFrequencyDetails object with values from keyword arguments. The default value of the :py:attr:`~oci.data_integration.models.DailyFrequencyDetails.model_type` attribute
+        of this class is ``DAILY`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param model_type:
+            The value to assign to the model_type property of this DailyFrequencyDetails.
+            Allowed values for this property are: "HOURLY", "DAILY", "MONTHLY"
+        :type model_type: str
+
+        :param frequency:
+            The value to assign to the frequency property of this DailyFrequencyDetails.
+            Allowed values for this property are: "HOURLY", "DAILY", "MONTHLY"
+        :type frequency: str
+
+        :param interval:
+            The value to assign to the interval property of this DailyFrequencyDetails.
+        :type interval: int
+
+        :param time:
+            The value to assign to the time property of this DailyFrequencyDetails.
+        :type time: oci.data_integration.models.Time
+
+        """
+        self.swagger_types = {
+            'model_type': 'str',
+            'frequency': 'str',
+            'interval': 'int',
+            'time': 'Time'
+        }
+
+        self.attribute_map = {
+            'model_type': 'modelType',
+            'frequency': 'frequency',
+            'interval': 'interval',
+            'time': 'time'
+        }
+
+        self._model_type = None
+        self._frequency = None
+        self._interval = None
+        self._time = None
+        self._model_type = 'DAILY'
+
+    @property
+    def interval(self):
+        """
+        Gets the interval of this DailyFrequencyDetails.
+        This hold the repeatability aspect of a schedule. i.e. in a monhtly frequency, a task can be scheduled for every month, once in two months, once in tree months etc.
+
+
+        :return: The interval of this DailyFrequencyDetails.
+        :rtype: int
+        """
+        return self._interval
+
+    @interval.setter
+    def interval(self, interval):
+        """
+        Sets the interval of this DailyFrequencyDetails.
+        This hold the repeatability aspect of a schedule. i.e. in a monhtly frequency, a task can be scheduled for every month, once in two months, once in tree months etc.
+
+
+        :param interval: The interval of this DailyFrequencyDetails.
+        :type: int
+        """
+        self._interval = interval
+
+    @property
+    def time(self):
+        """
+        Gets the time of this DailyFrequencyDetails.
+
+        :return: The time of this DailyFrequencyDetails.
+        :rtype: oci.data_integration.models.Time
+        """
+        return self._time
+
+    @time.setter
+    def time(self, time):
+        """
+        Sets the time of this DailyFrequencyDetails.
+
+        :param time: The time of this DailyFrequencyDetails.
+        :type: oci.data_integration.models.Time
+        """
+        self._time = time
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/data_asset_from_oracle_details.py
+++ b/src/oci/data_integration/models/data_asset_from_oracle_details.py
@@ -100,6 +100,14 @@ class DataAssetFromOracleDetails(DataAsset):
             The value to assign to the credential_file_content property of this DataAssetFromOracleDetails.
         :type credential_file_content: str
 
+        :param wallet_secret:
+            The value to assign to the wallet_secret property of this DataAssetFromOracleDetails.
+        :type wallet_secret: oci.data_integration.models.SensitiveAttribute
+
+        :param wallet_password_secret:
+            The value to assign to the wallet_password_secret property of this DataAssetFromOracleDetails.
+        :type wallet_password_secret: oci.data_integration.models.SensitiveAttribute
+
         :param default_connection:
             The value to assign to the default_connection property of this DataAssetFromOracleDetails.
         :type default_connection: oci.data_integration.models.ConnectionFromOracleDetails
@@ -126,6 +134,8 @@ class DataAssetFromOracleDetails(DataAsset):
             'driver_class': 'str',
             'sid': 'str',
             'credential_file_content': 'str',
+            'wallet_secret': 'SensitiveAttribute',
+            'wallet_password_secret': 'SensitiveAttribute',
             'default_connection': 'ConnectionFromOracleDetails'
         }
 
@@ -150,6 +160,8 @@ class DataAssetFromOracleDetails(DataAsset):
             'driver_class': 'driverClass',
             'sid': 'sid',
             'credential_file_content': 'credentialFileContent',
+            'wallet_secret': 'walletSecret',
+            'wallet_password_secret': 'walletPasswordSecret',
             'default_connection': 'defaultConnection'
         }
 
@@ -173,6 +185,8 @@ class DataAssetFromOracleDetails(DataAsset):
         self._driver_class = None
         self._sid = None
         self._credential_file_content = None
+        self._wallet_secret = None
+        self._wallet_password_secret = None
         self._default_connection = None
         self._model_type = 'ORACLE_DATA_ASSET'
 
@@ -319,6 +333,46 @@ class DataAssetFromOracleDetails(DataAsset):
         :type: str
         """
         self._credential_file_content = credential_file_content
+
+    @property
+    def wallet_secret(self):
+        """
+        Gets the wallet_secret of this DataAssetFromOracleDetails.
+
+        :return: The wallet_secret of this DataAssetFromOracleDetails.
+        :rtype: oci.data_integration.models.SensitiveAttribute
+        """
+        return self._wallet_secret
+
+    @wallet_secret.setter
+    def wallet_secret(self, wallet_secret):
+        """
+        Sets the wallet_secret of this DataAssetFromOracleDetails.
+
+        :param wallet_secret: The wallet_secret of this DataAssetFromOracleDetails.
+        :type: oci.data_integration.models.SensitiveAttribute
+        """
+        self._wallet_secret = wallet_secret
+
+    @property
+    def wallet_password_secret(self):
+        """
+        Gets the wallet_password_secret of this DataAssetFromOracleDetails.
+
+        :return: The wallet_password_secret of this DataAssetFromOracleDetails.
+        :rtype: oci.data_integration.models.SensitiveAttribute
+        """
+        return self._wallet_password_secret
+
+    @wallet_password_secret.setter
+    def wallet_password_secret(self, wallet_password_secret):
+        """
+        Sets the wallet_password_secret of this DataAssetFromOracleDetails.
+
+        :param wallet_password_secret: The wallet_password_secret of this DataAssetFromOracleDetails.
+        :type: oci.data_integration.models.SensitiveAttribute
+        """
+        self._wallet_password_secret = wallet_password_secret
 
     @property
     def default_connection(self):

--- a/src/oci/data_integration/models/data_asset_summary_from_oracle.py
+++ b/src/oci/data_integration/models/data_asset_summary_from_oracle.py
@@ -96,6 +96,14 @@ class DataAssetSummaryFromOracle(DataAssetSummary):
             The value to assign to the credential_file_content property of this DataAssetSummaryFromOracle.
         :type credential_file_content: str
 
+        :param wallet_secret:
+            The value to assign to the wallet_secret property of this DataAssetSummaryFromOracle.
+        :type wallet_secret: oci.data_integration.models.SensitiveAttribute
+
+        :param wallet_password_secret:
+            The value to assign to the wallet_password_secret property of this DataAssetSummaryFromOracle.
+        :type wallet_password_secret: oci.data_integration.models.SensitiveAttribute
+
         :param default_connection:
             The value to assign to the default_connection property of this DataAssetSummaryFromOracle.
         :type default_connection: oci.data_integration.models.ConnectionSummaryFromOracle
@@ -121,6 +129,8 @@ class DataAssetSummaryFromOracle(DataAssetSummary):
             'driver_class': 'str',
             'sid': 'str',
             'credential_file_content': 'str',
+            'wallet_secret': 'SensitiveAttribute',
+            'wallet_password_secret': 'SensitiveAttribute',
             'default_connection': 'ConnectionSummaryFromOracle'
         }
 
@@ -144,6 +154,8 @@ class DataAssetSummaryFromOracle(DataAssetSummary):
             'driver_class': 'driverClass',
             'sid': 'sid',
             'credential_file_content': 'credentialFileContent',
+            'wallet_secret': 'walletSecret',
+            'wallet_password_secret': 'walletPasswordSecret',
             'default_connection': 'defaultConnection'
         }
 
@@ -166,6 +178,8 @@ class DataAssetSummaryFromOracle(DataAssetSummary):
         self._driver_class = None
         self._sid = None
         self._credential_file_content = None
+        self._wallet_secret = None
+        self._wallet_password_secret = None
         self._default_connection = None
         self._model_type = 'ORACLE_DATA_ASSET'
 
@@ -312,6 +326,46 @@ class DataAssetSummaryFromOracle(DataAssetSummary):
         :type: str
         """
         self._credential_file_content = credential_file_content
+
+    @property
+    def wallet_secret(self):
+        """
+        Gets the wallet_secret of this DataAssetSummaryFromOracle.
+
+        :return: The wallet_secret of this DataAssetSummaryFromOracle.
+        :rtype: oci.data_integration.models.SensitiveAttribute
+        """
+        return self._wallet_secret
+
+    @wallet_secret.setter
+    def wallet_secret(self, wallet_secret):
+        """
+        Sets the wallet_secret of this DataAssetSummaryFromOracle.
+
+        :param wallet_secret: The wallet_secret of this DataAssetSummaryFromOracle.
+        :type: oci.data_integration.models.SensitiveAttribute
+        """
+        self._wallet_secret = wallet_secret
+
+    @property
+    def wallet_password_secret(self):
+        """
+        Gets the wallet_password_secret of this DataAssetSummaryFromOracle.
+
+        :return: The wallet_password_secret of this DataAssetSummaryFromOracle.
+        :rtype: oci.data_integration.models.SensitiveAttribute
+        """
+        return self._wallet_password_secret
+
+    @wallet_password_secret.setter
+    def wallet_password_secret(self, wallet_password_secret):
+        """
+        Sets the wallet_password_secret of this DataAssetSummaryFromOracle.
+
+        :param wallet_password_secret: The wallet_password_secret of this DataAssetSummaryFromOracle.
+        :type: oci.data_integration.models.SensitiveAttribute
+        """
+        self._wallet_password_secret = wallet_password_secret
 
     @property
     def default_connection(self):

--- a/src/oci/data_integration/models/data_format.py
+++ b/src/oci/data_integration/models/data_format.py
@@ -52,19 +52,26 @@ class DataFormat(object):
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type type: str
 
+        :param compression_config:
+            The value to assign to the compression_config property of this DataFormat.
+        :type compression_config: oci.data_integration.models.Compression
+
         """
         self.swagger_types = {
             'format_attribute': 'AbstractFormatAttribute',
-            'type': 'str'
+            'type': 'str',
+            'compression_config': 'Compression'
         }
 
         self.attribute_map = {
             'format_attribute': 'formatAttribute',
-            'type': 'type'
+            'type': 'type',
+            'compression_config': 'compressionConfig'
         }
 
         self._format_attribute = None
         self._type = None
+        self._compression_config = None
 
     @property
     def format_attribute(self):
@@ -115,6 +122,26 @@ class DataFormat(object):
         if not value_allowed_none_or_none_sentinel(type, allowed_values):
             type = 'UNKNOWN_ENUM_VALUE'
         self._type = type
+
+    @property
+    def compression_config(self):
+        """
+        Gets the compression_config of this DataFormat.
+
+        :return: The compression_config of this DataFormat.
+        :rtype: oci.data_integration.models.Compression
+        """
+        return self._compression_config
+
+    @compression_config.setter
+    def compression_config(self, compression_config):
+        """
+        Sets the compression_config of this DataFormat.
+
+        :param compression_config: The compression_config of this DataFormat.
+        :type: oci.data_integration.models.Compression
+        """
+        self._compression_config = compression_config
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/data_integration/models/data_type.py
+++ b/src/oci/data_integration/models/data_type.py
@@ -29,7 +29,7 @@ class DataType(BaseType):
 
         :param model_type:
             The value to assign to the model_type property of this DataType.
-            Allowed values for this property are: "DYNAMIC_TYPE", "STRUCTURED_TYPE", "DATA_TYPE", "JAVA_TYPE", "CONFIGURED_TYPE", "COMPOSITE_TYPE", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "DYNAMIC_TYPE", "STRUCTURED_TYPE", "DATA_TYPE", "JAVA_TYPE", "CONFIGURED_TYPE", "COMPOSITE_TYPE", "DERIVED_TYPE", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type model_type: str
 

--- a/src/oci/data_integration/models/dependent_object_summary.py
+++ b/src/oci/data_integration/models/dependent_object_summary.py
@@ -46,6 +46,10 @@ class DependentObjectSummary(object):
             The value to assign to the aggregator_key property of this DependentObjectSummary.
         :type aggregator_key: str
 
+        :param aggregator:
+            The value to assign to the aggregator property of this DependentObjectSummary.
+        :type aggregator: oci.data_integration.models.AggregatorSummary
+
         :param identifier_path:
             The value to assign to the identifier_path property of this DependentObjectSummary.
         :type identifier_path: str
@@ -75,6 +79,7 @@ class DependentObjectSummary(object):
             'time_created': 'datetime',
             'time_updated': 'datetime',
             'aggregator_key': 'str',
+            'aggregator': 'AggregatorSummary',
             'identifier_path': 'str',
             'info_fields': 'dict(str, str)',
             'registry_version': 'int',
@@ -90,6 +95,7 @@ class DependentObjectSummary(object):
             'time_created': 'timeCreated',
             'time_updated': 'timeUpdated',
             'aggregator_key': 'aggregatorKey',
+            'aggregator': 'aggregator',
             'identifier_path': 'identifierPath',
             'info_fields': 'infoFields',
             'registry_version': 'registryVersion',
@@ -104,6 +110,7 @@ class DependentObjectSummary(object):
         self._time_created = None
         self._time_updated = None
         self._aggregator_key = None
+        self._aggregator = None
         self._identifier_path = None
         self._info_fields = None
         self._registry_version = None
@@ -277,6 +284,26 @@ class DependentObjectSummary(object):
         :type: str
         """
         self._aggregator_key = aggregator_key
+
+    @property
+    def aggregator(self):
+        """
+        Gets the aggregator of this DependentObjectSummary.
+
+        :return: The aggregator of this DependentObjectSummary.
+        :rtype: oci.data_integration.models.AggregatorSummary
+        """
+        return self._aggregator
+
+    @aggregator.setter
+    def aggregator(self, aggregator):
+        """
+        Sets the aggregator of this DependentObjectSummary.
+
+        :param aggregator: The aggregator of this DependentObjectSummary.
+        :type: oci.data_integration.models.AggregatorSummary
+        """
+        self._aggregator = aggregator
 
     @property
     def identifier_path(self):

--- a/src/oci/data_integration/models/derived_type.py
+++ b/src/oci/data_integration/models/derived_type.py
@@ -21,7 +21,7 @@ class DerivedType(BaseType):
 
         :param model_type:
             The value to assign to the model_type property of this DerivedType.
-            Allowed values for this property are: "DYNAMIC_TYPE", "STRUCTURED_TYPE", "DATA_TYPE", "JAVA_TYPE", "CONFIGURED_TYPE", "COMPOSITE_TYPE"
+            Allowed values for this property are: "DYNAMIC_TYPE", "STRUCTURED_TYPE", "DATA_TYPE", "JAVA_TYPE", "CONFIGURED_TYPE", "COMPOSITE_TYPE", "DERIVED_TYPE"
         :type model_type: str
 
         :param key:

--- a/src/oci/data_integration/models/distinct.py
+++ b/src/oci/data_integration/models/distinct.py
@@ -21,7 +21,7 @@ class Distinct(Operator):
 
         :param model_type:
             The value to assign to the model_type property of this Distinct.
-            Allowed values for this property are: "SOURCE_OPERATOR", "FILTER_OPERATOR", "JOINER_OPERATOR", "AGGREGATOR_OPERATOR", "PROJECTION_OPERATOR", "TARGET_OPERATOR", "DISTINCT_OPERATOR", "SORT_OPERATOR"
+            Allowed values for this property are: "SOURCE_OPERATOR", "FILTER_OPERATOR", "JOINER_OPERATOR", "AGGREGATOR_OPERATOR", "PROJECTION_OPERATOR", "TARGET_OPERATOR", "DISTINCT_OPERATOR", "SORT_OPERATOR", "UNION_OPERATOR", "INTERSECT_OPERATOR", "MINUS_OPERATOR", "MERGE_OPERATOR", "START_OPERATOR", "END_OPERATOR", "PIPELINE_OPERATOR", "REST_OPERATOR", "TASK_OPERATOR"
         :type model_type: str
 
         :param key:

--- a/src/oci/data_integration/models/dynamic_type.py
+++ b/src/oci/data_integration/models/dynamic_type.py
@@ -21,7 +21,7 @@ class DynamicType(BaseType):
 
         :param model_type:
             The value to assign to the model_type property of this DynamicType.
-            Allowed values for this property are: "DYNAMIC_TYPE", "STRUCTURED_TYPE", "DATA_TYPE", "JAVA_TYPE", "CONFIGURED_TYPE", "COMPOSITE_TYPE"
+            Allowed values for this property are: "DYNAMIC_TYPE", "STRUCTURED_TYPE", "DATA_TYPE", "JAVA_TYPE", "CONFIGURED_TYPE", "COMPOSITE_TYPE", "DERIVED_TYPE"
         :type model_type: str
 
         :param key:

--- a/src/oci/data_integration/models/end_operator.py
+++ b/src/oci/data_integration/models/end_operator.py
@@ -1,0 +1,191 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .operator import Operator
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class EndOperator(Operator):
+    """
+    Represents end of a pipeline
+    """
+
+    #: A constant which can be used with the trigger_rule property of a EndOperator.
+    #: This constant has a value of "ALL_SUCCESS"
+    TRIGGER_RULE_ALL_SUCCESS = "ALL_SUCCESS"
+
+    #: A constant which can be used with the trigger_rule property of a EndOperator.
+    #: This constant has a value of "ALL_FAILED"
+    TRIGGER_RULE_ALL_FAILED = "ALL_FAILED"
+
+    #: A constant which can be used with the trigger_rule property of a EndOperator.
+    #: This constant has a value of "ALL_COMPLETE"
+    TRIGGER_RULE_ALL_COMPLETE = "ALL_COMPLETE"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new EndOperator object with values from keyword arguments. The default value of the :py:attr:`~oci.data_integration.models.EndOperator.model_type` attribute
+        of this class is ``END_OPERATOR`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param model_type:
+            The value to assign to the model_type property of this EndOperator.
+            Allowed values for this property are: "SOURCE_OPERATOR", "FILTER_OPERATOR", "JOINER_OPERATOR", "AGGREGATOR_OPERATOR", "PROJECTION_OPERATOR", "TARGET_OPERATOR", "DISTINCT_OPERATOR", "SORT_OPERATOR", "UNION_OPERATOR", "INTERSECT_OPERATOR", "MINUS_OPERATOR", "MERGE_OPERATOR", "START_OPERATOR", "END_OPERATOR", "PIPELINE_OPERATOR", "REST_OPERATOR", "TASK_OPERATOR", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type model_type: str
+
+        :param key:
+            The value to assign to the key property of this EndOperator.
+        :type key: str
+
+        :param model_version:
+            The value to assign to the model_version property of this EndOperator.
+        :type model_version: str
+
+        :param parent_ref:
+            The value to assign to the parent_ref property of this EndOperator.
+        :type parent_ref: oci.data_integration.models.ParentReference
+
+        :param name:
+            The value to assign to the name property of this EndOperator.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this EndOperator.
+        :type description: str
+
+        :param object_version:
+            The value to assign to the object_version property of this EndOperator.
+        :type object_version: int
+
+        :param input_ports:
+            The value to assign to the input_ports property of this EndOperator.
+        :type input_ports: list[oci.data_integration.models.InputPort]
+
+        :param output_ports:
+            The value to assign to the output_ports property of this EndOperator.
+        :type output_ports: list[oci.data_integration.models.OutputPort]
+
+        :param object_status:
+            The value to assign to the object_status property of this EndOperator.
+        :type object_status: int
+
+        :param identifier:
+            The value to assign to the identifier property of this EndOperator.
+        :type identifier: str
+
+        :param parameters:
+            The value to assign to the parameters property of this EndOperator.
+        :type parameters: list[oci.data_integration.models.Parameter]
+
+        :param op_config_values:
+            The value to assign to the op_config_values property of this EndOperator.
+        :type op_config_values: oci.data_integration.models.ConfigValues
+
+        :param trigger_rule:
+            The value to assign to the trigger_rule property of this EndOperator.
+            Allowed values for this property are: "ALL_SUCCESS", "ALL_FAILED", "ALL_COMPLETE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type trigger_rule: str
+
+        """
+        self.swagger_types = {
+            'model_type': 'str',
+            'key': 'str',
+            'model_version': 'str',
+            'parent_ref': 'ParentReference',
+            'name': 'str',
+            'description': 'str',
+            'object_version': 'int',
+            'input_ports': 'list[InputPort]',
+            'output_ports': 'list[OutputPort]',
+            'object_status': 'int',
+            'identifier': 'str',
+            'parameters': 'list[Parameter]',
+            'op_config_values': 'ConfigValues',
+            'trigger_rule': 'str'
+        }
+
+        self.attribute_map = {
+            'model_type': 'modelType',
+            'key': 'key',
+            'model_version': 'modelVersion',
+            'parent_ref': 'parentRef',
+            'name': 'name',
+            'description': 'description',
+            'object_version': 'objectVersion',
+            'input_ports': 'inputPorts',
+            'output_ports': 'outputPorts',
+            'object_status': 'objectStatus',
+            'identifier': 'identifier',
+            'parameters': 'parameters',
+            'op_config_values': 'opConfigValues',
+            'trigger_rule': 'triggerRule'
+        }
+
+        self._model_type = None
+        self._key = None
+        self._model_version = None
+        self._parent_ref = None
+        self._name = None
+        self._description = None
+        self._object_version = None
+        self._input_ports = None
+        self._output_ports = None
+        self._object_status = None
+        self._identifier = None
+        self._parameters = None
+        self._op_config_values = None
+        self._trigger_rule = None
+        self._model_type = 'END_OPERATOR'
+
+    @property
+    def trigger_rule(self):
+        """
+        Gets the trigger_rule of this EndOperator.
+        The merge condition. The conditions are
+        ALL_SUCCESS - All the preceeding operators need to be successful.
+        ALL_FAILED - All the preceeding operators should have failed.
+        ALL_COMPLETE - All the preceeding operators should have completed. It could have executed successfully or failed.
+
+        Allowed values for this property are: "ALL_SUCCESS", "ALL_FAILED", "ALL_COMPLETE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The trigger_rule of this EndOperator.
+        :rtype: str
+        """
+        return self._trigger_rule
+
+    @trigger_rule.setter
+    def trigger_rule(self, trigger_rule):
+        """
+        Sets the trigger_rule of this EndOperator.
+        The merge condition. The conditions are
+        ALL_SUCCESS - All the preceeding operators need to be successful.
+        ALL_FAILED - All the preceeding operators should have failed.
+        ALL_COMPLETE - All the preceeding operators should have completed. It could have executed successfully or failed.
+
+
+        :param trigger_rule: The trigger_rule of this EndOperator.
+        :type: str
+        """
+        allowed_values = ["ALL_SUCCESS", "ALL_FAILED", "ALL_COMPLETE"]
+        if not value_allowed_none_or_none_sentinel(trigger_rule, allowed_values):
+            trigger_rule = 'UNKNOWN_ENUM_VALUE'
+        self._trigger_rule = trigger_rule
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/filter.py
+++ b/src/oci/data_integration/models/filter.py
@@ -21,7 +21,7 @@ class Filter(Operator):
 
         :param model_type:
             The value to assign to the model_type property of this Filter.
-            Allowed values for this property are: "SOURCE_OPERATOR", "FILTER_OPERATOR", "JOINER_OPERATOR", "AGGREGATOR_OPERATOR", "PROJECTION_OPERATOR", "TARGET_OPERATOR", "DISTINCT_OPERATOR", "SORT_OPERATOR"
+            Allowed values for this property are: "SOURCE_OPERATOR", "FILTER_OPERATOR", "JOINER_OPERATOR", "AGGREGATOR_OPERATOR", "PROJECTION_OPERATOR", "TARGET_OPERATOR", "DISTINCT_OPERATOR", "SORT_OPERATOR", "UNION_OPERATOR", "INTERSECT_OPERATOR", "MINUS_OPERATOR", "MERGE_OPERATOR", "START_OPERATOR", "END_OPERATOR", "PIPELINE_OPERATOR", "REST_OPERATOR", "TASK_OPERATOR"
         :type model_type: str
 
         :param key:

--- a/src/oci/data_integration/models/foreign_key.py
+++ b/src/oci/data_integration/models/foreign_key.py
@@ -21,7 +21,8 @@ class ForeignKey(Key):
 
         :param model_type:
             The value to assign to the model_type property of this ForeignKey.
-            Allowed values for this property are: "FOREIGN_KEY", "PRIMARY_KEY", "UNIQUE_KEY"
+            Allowed values for this property are: "FOREIGN_KEY", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type model_type: str
 
         :param key:

--- a/src/oci/data_integration/models/hourly_frequency_details.py
+++ b/src/oci/data_integration/models/hourly_frequency_details.py
@@ -1,0 +1,115 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .abstract_frequency_details import AbstractFrequencyDetails
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class HourlyFrequencyDetails(AbstractFrequencyDetails):
+    """
+    Frequency details model to set hourly frequency
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new HourlyFrequencyDetails object with values from keyword arguments. The default value of the :py:attr:`~oci.data_integration.models.HourlyFrequencyDetails.model_type` attribute
+        of this class is ``HOURLY`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param model_type:
+            The value to assign to the model_type property of this HourlyFrequencyDetails.
+            Allowed values for this property are: "HOURLY", "DAILY", "MONTHLY"
+        :type model_type: str
+
+        :param frequency:
+            The value to assign to the frequency property of this HourlyFrequencyDetails.
+            Allowed values for this property are: "HOURLY", "DAILY", "MONTHLY"
+        :type frequency: str
+
+        :param interval:
+            The value to assign to the interval property of this HourlyFrequencyDetails.
+        :type interval: int
+
+        :param time:
+            The value to assign to the time property of this HourlyFrequencyDetails.
+        :type time: oci.data_integration.models.Time
+
+        """
+        self.swagger_types = {
+            'model_type': 'str',
+            'frequency': 'str',
+            'interval': 'int',
+            'time': 'Time'
+        }
+
+        self.attribute_map = {
+            'model_type': 'modelType',
+            'frequency': 'frequency',
+            'interval': 'interval',
+            'time': 'time'
+        }
+
+        self._model_type = None
+        self._frequency = None
+        self._interval = None
+        self._time = None
+        self._model_type = 'HOURLY'
+
+    @property
+    def interval(self):
+        """
+        Gets the interval of this HourlyFrequencyDetails.
+        This hold the repeatability aspect of a schedule. i.e. in a monhtly frequency, a task can be scheduled for every month, once in two months, once in tree months etc.
+
+
+        :return: The interval of this HourlyFrequencyDetails.
+        :rtype: int
+        """
+        return self._interval
+
+    @interval.setter
+    def interval(self, interval):
+        """
+        Sets the interval of this HourlyFrequencyDetails.
+        This hold the repeatability aspect of a schedule. i.e. in a monhtly frequency, a task can be scheduled for every month, once in two months, once in tree months etc.
+
+
+        :param interval: The interval of this HourlyFrequencyDetails.
+        :type: int
+        """
+        self._interval = interval
+
+    @property
+    def time(self):
+        """
+        Gets the time of this HourlyFrequencyDetails.
+
+        :return: The time of this HourlyFrequencyDetails.
+        :rtype: oci.data_integration.models.Time
+        """
+        return self._time
+
+    @time.setter
+    def time(self, time):
+        """
+        Sets the time of this HourlyFrequencyDetails.
+
+        :param time: The time of this HourlyFrequencyDetails.
+        :type: oci.data_integration.models.Time
+        """
+        self._time = time
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/intersect.py
+++ b/src/oci/data_integration/models/intersect.py
@@ -1,0 +1,212 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .operator import Operator
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class Intersect(Operator):
+    """
+    The information about a intersect object.
+    """
+
+    #: A constant which can be used with the intersect_type property of a Intersect.
+    #: This constant has a value of "NAME"
+    INTERSECT_TYPE_NAME = "NAME"
+
+    #: A constant which can be used with the intersect_type property of a Intersect.
+    #: This constant has a value of "POSITION"
+    INTERSECT_TYPE_POSITION = "POSITION"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new Intersect object with values from keyword arguments. The default value of the :py:attr:`~oci.data_integration.models.Intersect.model_type` attribute
+        of this class is ``INTERSECT_OPERATOR`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param model_type:
+            The value to assign to the model_type property of this Intersect.
+            Allowed values for this property are: "SOURCE_OPERATOR", "FILTER_OPERATOR", "JOINER_OPERATOR", "AGGREGATOR_OPERATOR", "PROJECTION_OPERATOR", "TARGET_OPERATOR", "DISTINCT_OPERATOR", "SORT_OPERATOR", "UNION_OPERATOR", "INTERSECT_OPERATOR", "MINUS_OPERATOR", "MERGE_OPERATOR", "START_OPERATOR", "END_OPERATOR", "PIPELINE_OPERATOR", "REST_OPERATOR", "TASK_OPERATOR", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type model_type: str
+
+        :param key:
+            The value to assign to the key property of this Intersect.
+        :type key: str
+
+        :param model_version:
+            The value to assign to the model_version property of this Intersect.
+        :type model_version: str
+
+        :param parent_ref:
+            The value to assign to the parent_ref property of this Intersect.
+        :type parent_ref: oci.data_integration.models.ParentReference
+
+        :param name:
+            The value to assign to the name property of this Intersect.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this Intersect.
+        :type description: str
+
+        :param object_version:
+            The value to assign to the object_version property of this Intersect.
+        :type object_version: int
+
+        :param input_ports:
+            The value to assign to the input_ports property of this Intersect.
+        :type input_ports: list[oci.data_integration.models.InputPort]
+
+        :param output_ports:
+            The value to assign to the output_ports property of this Intersect.
+        :type output_ports: list[oci.data_integration.models.OutputPort]
+
+        :param object_status:
+            The value to assign to the object_status property of this Intersect.
+        :type object_status: int
+
+        :param identifier:
+            The value to assign to the identifier property of this Intersect.
+        :type identifier: str
+
+        :param parameters:
+            The value to assign to the parameters property of this Intersect.
+        :type parameters: list[oci.data_integration.models.Parameter]
+
+        :param op_config_values:
+            The value to assign to the op_config_values property of this Intersect.
+        :type op_config_values: oci.data_integration.models.ConfigValues
+
+        :param intersect_type:
+            The value to assign to the intersect_type property of this Intersect.
+            Allowed values for this property are: "NAME", "POSITION", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type intersect_type: str
+
+        :param is_all:
+            The value to assign to the is_all property of this Intersect.
+        :type is_all: bool
+
+        """
+        self.swagger_types = {
+            'model_type': 'str',
+            'key': 'str',
+            'model_version': 'str',
+            'parent_ref': 'ParentReference',
+            'name': 'str',
+            'description': 'str',
+            'object_version': 'int',
+            'input_ports': 'list[InputPort]',
+            'output_ports': 'list[OutputPort]',
+            'object_status': 'int',
+            'identifier': 'str',
+            'parameters': 'list[Parameter]',
+            'op_config_values': 'ConfigValues',
+            'intersect_type': 'str',
+            'is_all': 'bool'
+        }
+
+        self.attribute_map = {
+            'model_type': 'modelType',
+            'key': 'key',
+            'model_version': 'modelVersion',
+            'parent_ref': 'parentRef',
+            'name': 'name',
+            'description': 'description',
+            'object_version': 'objectVersion',
+            'input_ports': 'inputPorts',
+            'output_ports': 'outputPorts',
+            'object_status': 'objectStatus',
+            'identifier': 'identifier',
+            'parameters': 'parameters',
+            'op_config_values': 'opConfigValues',
+            'intersect_type': 'intersectType',
+            'is_all': 'isAll'
+        }
+
+        self._model_type = None
+        self._key = None
+        self._model_version = None
+        self._parent_ref = None
+        self._name = None
+        self._description = None
+        self._object_version = None
+        self._input_ports = None
+        self._output_ports = None
+        self._object_status = None
+        self._identifier = None
+        self._parameters = None
+        self._op_config_values = None
+        self._intersect_type = None
+        self._is_all = None
+        self._model_type = 'INTERSECT_OPERATOR'
+
+    @property
+    def intersect_type(self):
+        """
+        Gets the intersect_type of this Intersect.
+        intersectType
+
+        Allowed values for this property are: "NAME", "POSITION", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The intersect_type of this Intersect.
+        :rtype: str
+        """
+        return self._intersect_type
+
+    @intersect_type.setter
+    def intersect_type(self, intersect_type):
+        """
+        Sets the intersect_type of this Intersect.
+        intersectType
+
+
+        :param intersect_type: The intersect_type of this Intersect.
+        :type: str
+        """
+        allowed_values = ["NAME", "POSITION"]
+        if not value_allowed_none_or_none_sentinel(intersect_type, allowed_values):
+            intersect_type = 'UNKNOWN_ENUM_VALUE'
+        self._intersect_type = intersect_type
+
+    @property
+    def is_all(self):
+        """
+        Gets the is_all of this Intersect.
+        The information about the intersect all.
+
+
+        :return: The is_all of this Intersect.
+        :rtype: bool
+        """
+        return self._is_all
+
+    @is_all.setter
+    def is_all(self, is_all):
+        """
+        Sets the is_all of this Intersect.
+        The information about the intersect all.
+
+
+        :param is_all: The is_all of this Intersect.
+        :type: bool
+        """
+        self._is_all = is_all
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/java_type.py
+++ b/src/oci/data_integration/models/java_type.py
@@ -21,7 +21,7 @@ class JavaType(BaseType):
 
         :param model_type:
             The value to assign to the model_type property of this JavaType.
-            Allowed values for this property are: "DYNAMIC_TYPE", "STRUCTURED_TYPE", "DATA_TYPE", "JAVA_TYPE", "CONFIGURED_TYPE", "COMPOSITE_TYPE"
+            Allowed values for this property are: "DYNAMIC_TYPE", "STRUCTURED_TYPE", "DATA_TYPE", "JAVA_TYPE", "CONFIGURED_TYPE", "COMPOSITE_TYPE", "DERIVED_TYPE"
         :type model_type: str
 
         :param key:

--- a/src/oci/data_integration/models/joiner.py
+++ b/src/oci/data_integration/models/joiner.py
@@ -37,7 +37,7 @@ class Joiner(Operator):
 
         :param model_type:
             The value to assign to the model_type property of this Joiner.
-            Allowed values for this property are: "SOURCE_OPERATOR", "FILTER_OPERATOR", "JOINER_OPERATOR", "AGGREGATOR_OPERATOR", "PROJECTION_OPERATOR", "TARGET_OPERATOR", "DISTINCT_OPERATOR", "SORT_OPERATOR", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "SOURCE_OPERATOR", "FILTER_OPERATOR", "JOINER_OPERATOR", "AGGREGATOR_OPERATOR", "PROJECTION_OPERATOR", "TARGET_OPERATOR", "DISTINCT_OPERATOR", "SORT_OPERATOR", "UNION_OPERATOR", "INTERSECT_OPERATOR", "MINUS_OPERATOR", "MERGE_OPERATOR", "START_OPERATOR", "END_OPERATOR", "PIPELINE_OPERATOR", "REST_OPERATOR", "TASK_OPERATOR", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type model_type: str
 

--- a/src/oci/data_integration/models/key.py
+++ b/src/oci/data_integration/models/key.py
@@ -17,27 +17,18 @@ class Key(object):
     #: This constant has a value of "FOREIGN_KEY"
     MODEL_TYPE_FOREIGN_KEY = "FOREIGN_KEY"
 
-    #: A constant which can be used with the model_type property of a Key.
-    #: This constant has a value of "PRIMARY_KEY"
-    MODEL_TYPE_PRIMARY_KEY = "PRIMARY_KEY"
-
-    #: A constant which can be used with the model_type property of a Key.
-    #: This constant has a value of "UNIQUE_KEY"
-    MODEL_TYPE_UNIQUE_KEY = "UNIQUE_KEY"
-
     def __init__(self, **kwargs):
         """
         Initializes a new Key object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
         to a service operations then you should favor using a subclass over the base class:
 
-        * :class:`~oci.data_integration.models.UniqueKey`
         * :class:`~oci.data_integration.models.ForeignKey`
 
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
         :param model_type:
             The value to assign to the model_type property of this Key.
-            Allowed values for this property are: "FOREIGN_KEY", "PRIMARY_KEY", "UNIQUE_KEY"
+            Allowed values for this property are: "FOREIGN_KEY"
         :type model_type: str
 
         """
@@ -59,9 +50,6 @@ class Key(object):
         """
         type = object_dictionary['modelType']
 
-        if type == 'UNIQUE_KEY':
-            return 'UniqueKey'
-
         if type == 'FOREIGN_KEY':
             return 'ForeignKey'
         else:
@@ -73,7 +61,7 @@ class Key(object):
         **[Required]** Gets the model_type of this Key.
         The key type.
 
-        Allowed values for this property are: "FOREIGN_KEY", "PRIMARY_KEY", "UNIQUE_KEY"
+        Allowed values for this property are: "FOREIGN_KEY"
 
 
         :return: The model_type of this Key.
@@ -91,7 +79,7 @@ class Key(object):
         :param model_type: The model_type of this Key.
         :type: str
         """
-        allowed_values = ["FOREIGN_KEY", "PRIMARY_KEY", "UNIQUE_KEY"]
+        allowed_values = ["FOREIGN_KEY"]
         if not value_allowed_none_or_none_sentinel(model_type, allowed_values):
             raise ValueError(
                 "Invalid value for `model_type`, must be None or one of {0}"

--- a/src/oci/data_integration/models/last_run_details.py
+++ b/src/oci/data_integration/models/last_run_details.py
@@ -1,0 +1,345 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class LastRunDetails(object):
+    """
+    The last run details for the task run.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new LastRunDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param key:
+            The value to assign to the key property of this LastRunDetails.
+        :type key: str
+
+        :param model_version:
+            The value to assign to the model_version property of this LastRunDetails.
+        :type model_version: str
+
+        :param model_type:
+            The value to assign to the model_type property of this LastRunDetails.
+        :type model_type: str
+
+        :param parent_ref:
+            The value to assign to the parent_ref property of this LastRunDetails.
+        :type parent_ref: oci.data_integration.models.ParentReference
+
+        :param name:
+            The value to assign to the name property of this LastRunDetails.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this LastRunDetails.
+        :type description: str
+
+        :param object_version:
+            The value to assign to the object_version property of this LastRunDetails.
+        :type object_version: int
+
+        :param object_status:
+            The value to assign to the object_status property of this LastRunDetails.
+        :type object_status: int
+
+        :param identifier:
+            The value to assign to the identifier property of this LastRunDetails.
+        :type identifier: str
+
+        :param last_run_time_millis:
+            The value to assign to the last_run_time_millis property of this LastRunDetails.
+        :type last_run_time_millis: int
+
+        """
+        self.swagger_types = {
+            'key': 'str',
+            'model_version': 'str',
+            'model_type': 'str',
+            'parent_ref': 'ParentReference',
+            'name': 'str',
+            'description': 'str',
+            'object_version': 'int',
+            'object_status': 'int',
+            'identifier': 'str',
+            'last_run_time_millis': 'int'
+        }
+
+        self.attribute_map = {
+            'key': 'key',
+            'model_version': 'modelVersion',
+            'model_type': 'modelType',
+            'parent_ref': 'parentRef',
+            'name': 'name',
+            'description': 'description',
+            'object_version': 'objectVersion',
+            'object_status': 'objectStatus',
+            'identifier': 'identifier',
+            'last_run_time_millis': 'lastRunTimeMillis'
+        }
+
+        self._key = None
+        self._model_version = None
+        self._model_type = None
+        self._parent_ref = None
+        self._name = None
+        self._description = None
+        self._object_version = None
+        self._object_status = None
+        self._identifier = None
+        self._last_run_time_millis = None
+
+    @property
+    def key(self):
+        """
+        Gets the key of this LastRunDetails.
+        Generated key that can be used in API calls to identify Last run details of a task schedule. On scenarios where reference to the lastRunDetails is needed, a value can be passed in create.
+
+
+        :return: The key of this LastRunDetails.
+        :rtype: str
+        """
+        return self._key
+
+    @key.setter
+    def key(self, key):
+        """
+        Sets the key of this LastRunDetails.
+        Generated key that can be used in API calls to identify Last run details of a task schedule. On scenarios where reference to the lastRunDetails is needed, a value can be passed in create.
+
+
+        :param key: The key of this LastRunDetails.
+        :type: str
+        """
+        self._key = key
+
+    @property
+    def model_version(self):
+        """
+        Gets the model_version of this LastRunDetails.
+        This is a version number that is used by the service to upgrade objects if needed through releases of the service.
+
+
+        :return: The model_version of this LastRunDetails.
+        :rtype: str
+        """
+        return self._model_version
+
+    @model_version.setter
+    def model_version(self, model_version):
+        """
+        Sets the model_version of this LastRunDetails.
+        This is a version number that is used by the service to upgrade objects if needed through releases of the service.
+
+
+        :param model_version: The model_version of this LastRunDetails.
+        :type: str
+        """
+        self._model_version = model_version
+
+    @property
+    def model_type(self):
+        """
+        Gets the model_type of this LastRunDetails.
+        The type of the object.
+
+
+        :return: The model_type of this LastRunDetails.
+        :rtype: str
+        """
+        return self._model_type
+
+    @model_type.setter
+    def model_type(self, model_type):
+        """
+        Sets the model_type of this LastRunDetails.
+        The type of the object.
+
+
+        :param model_type: The model_type of this LastRunDetails.
+        :type: str
+        """
+        self._model_type = model_type
+
+    @property
+    def parent_ref(self):
+        """
+        Gets the parent_ref of this LastRunDetails.
+
+        :return: The parent_ref of this LastRunDetails.
+        :rtype: oci.data_integration.models.ParentReference
+        """
+        return self._parent_ref
+
+    @parent_ref.setter
+    def parent_ref(self, parent_ref):
+        """
+        Sets the parent_ref of this LastRunDetails.
+
+        :param parent_ref: The parent_ref of this LastRunDetails.
+        :type: oci.data_integration.models.ParentReference
+        """
+        self._parent_ref = parent_ref
+
+    @property
+    def name(self):
+        """
+        Gets the name of this LastRunDetails.
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
+
+
+        :return: The name of this LastRunDetails.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this LastRunDetails.
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
+
+
+        :param name: The name of this LastRunDetails.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def description(self):
+        """
+        Gets the description of this LastRunDetails.
+        Detailed description for the object.
+
+
+        :return: The description of this LastRunDetails.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this LastRunDetails.
+        Detailed description for the object.
+
+
+        :param description: The description of this LastRunDetails.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def object_version(self):
+        """
+        Gets the object_version of this LastRunDetails.
+        This is used by the service for optimistic locking of the object, to prevent multiple users from simultaneously updating the object.
+
+
+        :return: The object_version of this LastRunDetails.
+        :rtype: int
+        """
+        return self._object_version
+
+    @object_version.setter
+    def object_version(self, object_version):
+        """
+        Sets the object_version of this LastRunDetails.
+        This is used by the service for optimistic locking of the object, to prevent multiple users from simultaneously updating the object.
+
+
+        :param object_version: The object_version of this LastRunDetails.
+        :type: int
+        """
+        self._object_version = object_version
+
+    @property
+    def object_status(self):
+        """
+        Gets the object_status of this LastRunDetails.
+        The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+
+
+        :return: The object_status of this LastRunDetails.
+        :rtype: int
+        """
+        return self._object_status
+
+    @object_status.setter
+    def object_status(self, object_status):
+        """
+        Sets the object_status of this LastRunDetails.
+        The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+
+
+        :param object_status: The object_status of this LastRunDetails.
+        :type: int
+        """
+        self._object_status = object_status
+
+    @property
+    def identifier(self):
+        """
+        Gets the identifier of this LastRunDetails.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
+
+
+        :return: The identifier of this LastRunDetails.
+        :rtype: str
+        """
+        return self._identifier
+
+    @identifier.setter
+    def identifier(self, identifier):
+        """
+        Sets the identifier of this LastRunDetails.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
+
+
+        :param identifier: The identifier of this LastRunDetails.
+        :type: str
+        """
+        self._identifier = identifier
+
+    @property
+    def last_run_time_millis(self):
+        """
+        Gets the last_run_time_millis of this LastRunDetails.
+        Time in milliseconds for the pervious schedule.
+
+
+        :return: The last_run_time_millis of this LastRunDetails.
+        :rtype: int
+        """
+        return self._last_run_time_millis
+
+    @last_run_time_millis.setter
+    def last_run_time_millis(self, last_run_time_millis):
+        """
+        Sets the last_run_time_millis of this LastRunDetails.
+        Time in milliseconds for the pervious schedule.
+
+
+        :param last_run_time_millis: The last_run_time_millis of this LastRunDetails.
+        :type: int
+        """
+        self._last_run_time_millis = last_run_time_millis
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/merge_operator.py
+++ b/src/oci/data_integration/models/merge_operator.py
@@ -1,0 +1,203 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .operator import Operator
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class MergeOperator(Operator):
+    """
+    Represents the start of a pipeline.
+    """
+
+    #: A constant which can be used with the trigger_rule property of a MergeOperator.
+    #: This constant has a value of "ALL_SUCCESS"
+    TRIGGER_RULE_ALL_SUCCESS = "ALL_SUCCESS"
+
+    #: A constant which can be used with the trigger_rule property of a MergeOperator.
+    #: This constant has a value of "ALL_FAILED"
+    TRIGGER_RULE_ALL_FAILED = "ALL_FAILED"
+
+    #: A constant which can be used with the trigger_rule property of a MergeOperator.
+    #: This constant has a value of "ALL_COMPLETE"
+    TRIGGER_RULE_ALL_COMPLETE = "ALL_COMPLETE"
+
+    #: A constant which can be used with the trigger_rule property of a MergeOperator.
+    #: This constant has a value of "ONE_SUCCESS"
+    TRIGGER_RULE_ONE_SUCCESS = "ONE_SUCCESS"
+
+    #: A constant which can be used with the trigger_rule property of a MergeOperator.
+    #: This constant has a value of "ONE_FAILED"
+    TRIGGER_RULE_ONE_FAILED = "ONE_FAILED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new MergeOperator object with values from keyword arguments. The default value of the :py:attr:`~oci.data_integration.models.MergeOperator.model_type` attribute
+        of this class is ``MERGE_OPERATOR`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param model_type:
+            The value to assign to the model_type property of this MergeOperator.
+            Allowed values for this property are: "SOURCE_OPERATOR", "FILTER_OPERATOR", "JOINER_OPERATOR", "AGGREGATOR_OPERATOR", "PROJECTION_OPERATOR", "TARGET_OPERATOR", "DISTINCT_OPERATOR", "SORT_OPERATOR", "UNION_OPERATOR", "INTERSECT_OPERATOR", "MINUS_OPERATOR", "MERGE_OPERATOR", "START_OPERATOR", "END_OPERATOR", "PIPELINE_OPERATOR", "REST_OPERATOR", "TASK_OPERATOR", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type model_type: str
+
+        :param key:
+            The value to assign to the key property of this MergeOperator.
+        :type key: str
+
+        :param model_version:
+            The value to assign to the model_version property of this MergeOperator.
+        :type model_version: str
+
+        :param parent_ref:
+            The value to assign to the parent_ref property of this MergeOperator.
+        :type parent_ref: oci.data_integration.models.ParentReference
+
+        :param name:
+            The value to assign to the name property of this MergeOperator.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this MergeOperator.
+        :type description: str
+
+        :param object_version:
+            The value to assign to the object_version property of this MergeOperator.
+        :type object_version: int
+
+        :param input_ports:
+            The value to assign to the input_ports property of this MergeOperator.
+        :type input_ports: list[oci.data_integration.models.InputPort]
+
+        :param output_ports:
+            The value to assign to the output_ports property of this MergeOperator.
+        :type output_ports: list[oci.data_integration.models.OutputPort]
+
+        :param object_status:
+            The value to assign to the object_status property of this MergeOperator.
+        :type object_status: int
+
+        :param identifier:
+            The value to assign to the identifier property of this MergeOperator.
+        :type identifier: str
+
+        :param parameters:
+            The value to assign to the parameters property of this MergeOperator.
+        :type parameters: list[oci.data_integration.models.Parameter]
+
+        :param op_config_values:
+            The value to assign to the op_config_values property of this MergeOperator.
+        :type op_config_values: oci.data_integration.models.ConfigValues
+
+        :param trigger_rule:
+            The value to assign to the trigger_rule property of this MergeOperator.
+            Allowed values for this property are: "ALL_SUCCESS", "ALL_FAILED", "ALL_COMPLETE", "ONE_SUCCESS", "ONE_FAILED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type trigger_rule: str
+
+        """
+        self.swagger_types = {
+            'model_type': 'str',
+            'key': 'str',
+            'model_version': 'str',
+            'parent_ref': 'ParentReference',
+            'name': 'str',
+            'description': 'str',
+            'object_version': 'int',
+            'input_ports': 'list[InputPort]',
+            'output_ports': 'list[OutputPort]',
+            'object_status': 'int',
+            'identifier': 'str',
+            'parameters': 'list[Parameter]',
+            'op_config_values': 'ConfigValues',
+            'trigger_rule': 'str'
+        }
+
+        self.attribute_map = {
+            'model_type': 'modelType',
+            'key': 'key',
+            'model_version': 'modelVersion',
+            'parent_ref': 'parentRef',
+            'name': 'name',
+            'description': 'description',
+            'object_version': 'objectVersion',
+            'input_ports': 'inputPorts',
+            'output_ports': 'outputPorts',
+            'object_status': 'objectStatus',
+            'identifier': 'identifier',
+            'parameters': 'parameters',
+            'op_config_values': 'opConfigValues',
+            'trigger_rule': 'triggerRule'
+        }
+
+        self._model_type = None
+        self._key = None
+        self._model_version = None
+        self._parent_ref = None
+        self._name = None
+        self._description = None
+        self._object_version = None
+        self._input_ports = None
+        self._output_ports = None
+        self._object_status = None
+        self._identifier = None
+        self._parameters = None
+        self._op_config_values = None
+        self._trigger_rule = None
+        self._model_type = 'MERGE_OPERATOR'
+
+    @property
+    def trigger_rule(self):
+        """
+        Gets the trigger_rule of this MergeOperator.
+        The merge condition. The conditions are
+        ALL_SUCCESS - All the preceeding operators need to be successful.
+        ALL_FAILED - All the preceeding operators should have failed.
+        ALL_COMPLETE - All the preceeding operators should have completed. It could have executed successfully or failed.
+        ONE_SUCCESS - Atleast one of the preceeding operators should have succeeded.
+        ONE_FAILED - Atleast one of the preceeding operators should have failed.
+
+        Allowed values for this property are: "ALL_SUCCESS", "ALL_FAILED", "ALL_COMPLETE", "ONE_SUCCESS", "ONE_FAILED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The trigger_rule of this MergeOperator.
+        :rtype: str
+        """
+        return self._trigger_rule
+
+    @trigger_rule.setter
+    def trigger_rule(self, trigger_rule):
+        """
+        Sets the trigger_rule of this MergeOperator.
+        The merge condition. The conditions are
+        ALL_SUCCESS - All the preceeding operators need to be successful.
+        ALL_FAILED - All the preceeding operators should have failed.
+        ALL_COMPLETE - All the preceeding operators should have completed. It could have executed successfully or failed.
+        ONE_SUCCESS - Atleast one of the preceeding operators should have succeeded.
+        ONE_FAILED - Atleast one of the preceeding operators should have failed.
+
+
+        :param trigger_rule: The trigger_rule of this MergeOperator.
+        :type: str
+        """
+        allowed_values = ["ALL_SUCCESS", "ALL_FAILED", "ALL_COMPLETE", "ONE_SUCCESS", "ONE_FAILED"]
+        if not value_allowed_none_or_none_sentinel(trigger_rule, allowed_values):
+            trigger_rule = 'UNKNOWN_ENUM_VALUE'
+        self._trigger_rule = trigger_rule
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/minus.py
+++ b/src/oci/data_integration/models/minus.py
@@ -1,0 +1,212 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .operator import Operator
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class Minus(Operator):
+    """
+    The information about a minus object.
+    """
+
+    #: A constant which can be used with the minus_type property of a Minus.
+    #: This constant has a value of "NAME"
+    MINUS_TYPE_NAME = "NAME"
+
+    #: A constant which can be used with the minus_type property of a Minus.
+    #: This constant has a value of "POSITION"
+    MINUS_TYPE_POSITION = "POSITION"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new Minus object with values from keyword arguments. The default value of the :py:attr:`~oci.data_integration.models.Minus.model_type` attribute
+        of this class is ``MINUS_OPERATOR`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param model_type:
+            The value to assign to the model_type property of this Minus.
+            Allowed values for this property are: "SOURCE_OPERATOR", "FILTER_OPERATOR", "JOINER_OPERATOR", "AGGREGATOR_OPERATOR", "PROJECTION_OPERATOR", "TARGET_OPERATOR", "DISTINCT_OPERATOR", "SORT_OPERATOR", "UNION_OPERATOR", "INTERSECT_OPERATOR", "MINUS_OPERATOR", "MERGE_OPERATOR", "START_OPERATOR", "END_OPERATOR", "PIPELINE_OPERATOR", "REST_OPERATOR", "TASK_OPERATOR", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type model_type: str
+
+        :param key:
+            The value to assign to the key property of this Minus.
+        :type key: str
+
+        :param model_version:
+            The value to assign to the model_version property of this Minus.
+        :type model_version: str
+
+        :param parent_ref:
+            The value to assign to the parent_ref property of this Minus.
+        :type parent_ref: oci.data_integration.models.ParentReference
+
+        :param name:
+            The value to assign to the name property of this Minus.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this Minus.
+        :type description: str
+
+        :param object_version:
+            The value to assign to the object_version property of this Minus.
+        :type object_version: int
+
+        :param input_ports:
+            The value to assign to the input_ports property of this Minus.
+        :type input_ports: list[oci.data_integration.models.InputPort]
+
+        :param output_ports:
+            The value to assign to the output_ports property of this Minus.
+        :type output_ports: list[oci.data_integration.models.OutputPort]
+
+        :param object_status:
+            The value to assign to the object_status property of this Minus.
+        :type object_status: int
+
+        :param identifier:
+            The value to assign to the identifier property of this Minus.
+        :type identifier: str
+
+        :param parameters:
+            The value to assign to the parameters property of this Minus.
+        :type parameters: list[oci.data_integration.models.Parameter]
+
+        :param op_config_values:
+            The value to assign to the op_config_values property of this Minus.
+        :type op_config_values: oci.data_integration.models.ConfigValues
+
+        :param minus_type:
+            The value to assign to the minus_type property of this Minus.
+            Allowed values for this property are: "NAME", "POSITION", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type minus_type: str
+
+        :param is_all:
+            The value to assign to the is_all property of this Minus.
+        :type is_all: bool
+
+        """
+        self.swagger_types = {
+            'model_type': 'str',
+            'key': 'str',
+            'model_version': 'str',
+            'parent_ref': 'ParentReference',
+            'name': 'str',
+            'description': 'str',
+            'object_version': 'int',
+            'input_ports': 'list[InputPort]',
+            'output_ports': 'list[OutputPort]',
+            'object_status': 'int',
+            'identifier': 'str',
+            'parameters': 'list[Parameter]',
+            'op_config_values': 'ConfigValues',
+            'minus_type': 'str',
+            'is_all': 'bool'
+        }
+
+        self.attribute_map = {
+            'model_type': 'modelType',
+            'key': 'key',
+            'model_version': 'modelVersion',
+            'parent_ref': 'parentRef',
+            'name': 'name',
+            'description': 'description',
+            'object_version': 'objectVersion',
+            'input_ports': 'inputPorts',
+            'output_ports': 'outputPorts',
+            'object_status': 'objectStatus',
+            'identifier': 'identifier',
+            'parameters': 'parameters',
+            'op_config_values': 'opConfigValues',
+            'minus_type': 'minusType',
+            'is_all': 'isAll'
+        }
+
+        self._model_type = None
+        self._key = None
+        self._model_version = None
+        self._parent_ref = None
+        self._name = None
+        self._description = None
+        self._object_version = None
+        self._input_ports = None
+        self._output_ports = None
+        self._object_status = None
+        self._identifier = None
+        self._parameters = None
+        self._op_config_values = None
+        self._minus_type = None
+        self._is_all = None
+        self._model_type = 'MINUS_OPERATOR'
+
+    @property
+    def minus_type(self):
+        """
+        Gets the minus_type of this Minus.
+        minusType
+
+        Allowed values for this property are: "NAME", "POSITION", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The minus_type of this Minus.
+        :rtype: str
+        """
+        return self._minus_type
+
+    @minus_type.setter
+    def minus_type(self, minus_type):
+        """
+        Sets the minus_type of this Minus.
+        minusType
+
+
+        :param minus_type: The minus_type of this Minus.
+        :type: str
+        """
+        allowed_values = ["NAME", "POSITION"]
+        if not value_allowed_none_or_none_sentinel(minus_type, allowed_values):
+            minus_type = 'UNKNOWN_ENUM_VALUE'
+        self._minus_type = minus_type
+
+    @property
+    def is_all(self):
+        """
+        Gets the is_all of this Minus.
+        The information about the minus all.
+
+
+        :return: The is_all of this Minus.
+        :rtype: bool
+        """
+        return self._is_all
+
+    @is_all.setter
+    def is_all(self, is_all):
+        """
+        Sets the is_all of this Minus.
+        The information about the minus all.
+
+
+        :param is_all: The is_all of this Minus.
+        :type: bool
+        """
+        self._is_all = is_all
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/monthly_frequency_details.py
+++ b/src/oci/data_integration/models/monthly_frequency_details.py
@@ -1,0 +1,146 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .abstract_frequency_details import AbstractFrequencyDetails
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class MonthlyFrequencyDetails(AbstractFrequencyDetails):
+    """
+    Frequency Details model for monthly frequency.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new MonthlyFrequencyDetails object with values from keyword arguments. The default value of the :py:attr:`~oci.data_integration.models.MonthlyFrequencyDetails.model_type` attribute
+        of this class is ``MONTHLY`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param model_type:
+            The value to assign to the model_type property of this MonthlyFrequencyDetails.
+            Allowed values for this property are: "HOURLY", "DAILY", "MONTHLY"
+        :type model_type: str
+
+        :param frequency:
+            The value to assign to the frequency property of this MonthlyFrequencyDetails.
+            Allowed values for this property are: "HOURLY", "DAILY", "MONTHLY"
+        :type frequency: str
+
+        :param interval:
+            The value to assign to the interval property of this MonthlyFrequencyDetails.
+        :type interval: int
+
+        :param time:
+            The value to assign to the time property of this MonthlyFrequencyDetails.
+        :type time: oci.data_integration.models.Time
+
+        :param days:
+            The value to assign to the days property of this MonthlyFrequencyDetails.
+        :type days: list[int]
+
+        """
+        self.swagger_types = {
+            'model_type': 'str',
+            'frequency': 'str',
+            'interval': 'int',
+            'time': 'Time',
+            'days': 'list[int]'
+        }
+
+        self.attribute_map = {
+            'model_type': 'modelType',
+            'frequency': 'frequency',
+            'interval': 'interval',
+            'time': 'time',
+            'days': 'days'
+        }
+
+        self._model_type = None
+        self._frequency = None
+        self._interval = None
+        self._time = None
+        self._days = None
+        self._model_type = 'MONTHLY'
+
+    @property
+    def interval(self):
+        """
+        Gets the interval of this MonthlyFrequencyDetails.
+        This hold the repeatability aspect of a schedule. i.e. in a monhtly frequency, a task can be scheduled for every month, once in two months, once in tree months etc.
+
+
+        :return: The interval of this MonthlyFrequencyDetails.
+        :rtype: int
+        """
+        return self._interval
+
+    @interval.setter
+    def interval(self, interval):
+        """
+        Sets the interval of this MonthlyFrequencyDetails.
+        This hold the repeatability aspect of a schedule. i.e. in a monhtly frequency, a task can be scheduled for every month, once in two months, once in tree months etc.
+
+
+        :param interval: The interval of this MonthlyFrequencyDetails.
+        :type: int
+        """
+        self._interval = interval
+
+    @property
+    def time(self):
+        """
+        Gets the time of this MonthlyFrequencyDetails.
+
+        :return: The time of this MonthlyFrequencyDetails.
+        :rtype: oci.data_integration.models.Time
+        """
+        return self._time
+
+    @time.setter
+    def time(self, time):
+        """
+        Sets the time of this MonthlyFrequencyDetails.
+
+        :param time: The time of this MonthlyFrequencyDetails.
+        :type: oci.data_integration.models.Time
+        """
+        self._time = time
+
+    @property
+    def days(self):
+        """
+        Gets the days of this MonthlyFrequencyDetails.
+        A list of days of the month to be scheduled. i.e. excute every 2nd,3rd, 10th of the month.
+
+
+        :return: The days of this MonthlyFrequencyDetails.
+        :rtype: list[int]
+        """
+        return self._days
+
+    @days.setter
+    def days(self, days):
+        """
+        Sets the days of this MonthlyFrequencyDetails.
+        A list of days of the month to be scheduled. i.e. excute every 2nd,3rd, 10th of the month.
+
+
+        :param days: The days of this MonthlyFrequencyDetails.
+        :type: list[int]
+        """
+        self._days = days
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/object_metadata.py
+++ b/src/oci/data_integration/models/object_metadata.py
@@ -46,6 +46,10 @@ class ObjectMetadata(object):
             The value to assign to the aggregator_key property of this ObjectMetadata.
         :type aggregator_key: str
 
+        :param aggregator:
+            The value to assign to the aggregator property of this ObjectMetadata.
+        :type aggregator: oci.data_integration.models.AggregatorSummary
+
         :param identifier_path:
             The value to assign to the identifier_path property of this ObjectMetadata.
         :type identifier_path: str
@@ -75,6 +79,7 @@ class ObjectMetadata(object):
             'time_created': 'datetime',
             'time_updated': 'datetime',
             'aggregator_key': 'str',
+            'aggregator': 'AggregatorSummary',
             'identifier_path': 'str',
             'info_fields': 'dict(str, str)',
             'registry_version': 'int',
@@ -90,6 +95,7 @@ class ObjectMetadata(object):
             'time_created': 'timeCreated',
             'time_updated': 'timeUpdated',
             'aggregator_key': 'aggregatorKey',
+            'aggregator': 'aggregator',
             'identifier_path': 'identifierPath',
             'info_fields': 'infoFields',
             'registry_version': 'registryVersion',
@@ -104,6 +110,7 @@ class ObjectMetadata(object):
         self._time_created = None
         self._time_updated = None
         self._aggregator_key = None
+        self._aggregator = None
         self._identifier_path = None
         self._info_fields = None
         self._registry_version = None
@@ -277,6 +284,26 @@ class ObjectMetadata(object):
         :type: str
         """
         self._aggregator_key = aggregator_key
+
+    @property
+    def aggregator(self):
+        """
+        Gets the aggregator of this ObjectMetadata.
+
+        :return: The aggregator of this ObjectMetadata.
+        :rtype: oci.data_integration.models.AggregatorSummary
+        """
+        return self._aggregator
+
+    @aggregator.setter
+    def aggregator(self, aggregator):
+        """
+        Sets the aggregator of this ObjectMetadata.
+
+        :param aggregator: The aggregator of this ObjectMetadata.
+        :type: oci.data_integration.models.AggregatorSummary
+        """
+        self._aggregator = aggregator
 
     @property
     def identifier_path(self):

--- a/src/oci/data_integration/models/oci_vault_secret_config.py
+++ b/src/oci/data_integration/models/oci_vault_secret_config.py
@@ -1,0 +1,80 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .secret_config import SecretConfig
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class OciVaultSecretConfig(SecretConfig):
+    """
+    Properties used for specifying OCI vault configuration
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new OciVaultSecretConfig object with values from keyword arguments. The default value of the :py:attr:`~oci.data_integration.models.OciVaultSecretConfig.model_type` attribute
+        of this class is ``OCI_VAULT_SECRET_CONFIG`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param model_type:
+            The value to assign to the model_type property of this OciVaultSecretConfig.
+            Allowed values for this property are: "OCI_VAULT_SECRET_CONFIG"
+        :type model_type: str
+
+        :param secret_id:
+            The value to assign to the secret_id property of this OciVaultSecretConfig.
+        :type secret_id: str
+
+        """
+        self.swagger_types = {
+            'model_type': 'str',
+            'secret_id': 'str'
+        }
+
+        self.attribute_map = {
+            'model_type': 'modelType',
+            'secret_id': 'secretId'
+        }
+
+        self._model_type = None
+        self._secret_id = None
+        self._model_type = 'OCI_VAULT_SECRET_CONFIG'
+
+    @property
+    def secret_id(self):
+        """
+        Gets the secret_id of this OciVaultSecretConfig.
+        OCID of the OCI vault secret
+
+
+        :return: The secret_id of this OciVaultSecretConfig.
+        :rtype: str
+        """
+        return self._secret_id
+
+    @secret_id.setter
+    def secret_id(self, secret_id):
+        """
+        Sets the secret_id of this OciVaultSecretConfig.
+        OCID of the OCI vault secret
+
+
+        :param secret_id: The secret_id of this OciVaultSecretConfig.
+        :type: str
+        """
+        self._secret_id = secret_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/operator.py
+++ b/src/oci/data_integration/models/operator.py
@@ -45,25 +45,68 @@ class Operator(object):
     #: This constant has a value of "SORT_OPERATOR"
     MODEL_TYPE_SORT_OPERATOR = "SORT_OPERATOR"
 
+    #: A constant which can be used with the model_type property of a Operator.
+    #: This constant has a value of "UNION_OPERATOR"
+    MODEL_TYPE_UNION_OPERATOR = "UNION_OPERATOR"
+
+    #: A constant which can be used with the model_type property of a Operator.
+    #: This constant has a value of "INTERSECT_OPERATOR"
+    MODEL_TYPE_INTERSECT_OPERATOR = "INTERSECT_OPERATOR"
+
+    #: A constant which can be used with the model_type property of a Operator.
+    #: This constant has a value of "MINUS_OPERATOR"
+    MODEL_TYPE_MINUS_OPERATOR = "MINUS_OPERATOR"
+
+    #: A constant which can be used with the model_type property of a Operator.
+    #: This constant has a value of "MERGE_OPERATOR"
+    MODEL_TYPE_MERGE_OPERATOR = "MERGE_OPERATOR"
+
+    #: A constant which can be used with the model_type property of a Operator.
+    #: This constant has a value of "START_OPERATOR"
+    MODEL_TYPE_START_OPERATOR = "START_OPERATOR"
+
+    #: A constant which can be used with the model_type property of a Operator.
+    #: This constant has a value of "END_OPERATOR"
+    MODEL_TYPE_END_OPERATOR = "END_OPERATOR"
+
+    #: A constant which can be used with the model_type property of a Operator.
+    #: This constant has a value of "PIPELINE_OPERATOR"
+    MODEL_TYPE_PIPELINE_OPERATOR = "PIPELINE_OPERATOR"
+
+    #: A constant which can be used with the model_type property of a Operator.
+    #: This constant has a value of "REST_OPERATOR"
+    MODEL_TYPE_REST_OPERATOR = "REST_OPERATOR"
+
+    #: A constant which can be used with the model_type property of a Operator.
+    #: This constant has a value of "TASK_OPERATOR"
+    MODEL_TYPE_TASK_OPERATOR = "TASK_OPERATOR"
+
     def __init__(self, **kwargs):
         """
         Initializes a new Operator object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
         to a service operations then you should favor using a subclass over the base class:
 
-        * :class:`~oci.data_integration.models.Target`
         * :class:`~oci.data_integration.models.Joiner`
-        * :class:`~oci.data_integration.models.Distinct`
-        * :class:`~oci.data_integration.models.Filter`
+        * :class:`~oci.data_integration.models.TaskOperator`
         * :class:`~oci.data_integration.models.Aggregator`
         * :class:`~oci.data_integration.models.SortOper`
         * :class:`~oci.data_integration.models.Projection`
+        * :class:`~oci.data_integration.models.EndOperator`
         * :class:`~oci.data_integration.models.Source`
+        * :class:`~oci.data_integration.models.Union`
+        * :class:`~oci.data_integration.models.Intersect`
+        * :class:`~oci.data_integration.models.Target`
+        * :class:`~oci.data_integration.models.Distinct`
+        * :class:`~oci.data_integration.models.Filter`
+        * :class:`~oci.data_integration.models.StartOperator`
+        * :class:`~oci.data_integration.models.MergeOperator`
+        * :class:`~oci.data_integration.models.Minus`
 
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
         :param model_type:
             The value to assign to the model_type property of this Operator.
-            Allowed values for this property are: "SOURCE_OPERATOR", "FILTER_OPERATOR", "JOINER_OPERATOR", "AGGREGATOR_OPERATOR", "PROJECTION_OPERATOR", "TARGET_OPERATOR", "DISTINCT_OPERATOR", "SORT_OPERATOR", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "SOURCE_OPERATOR", "FILTER_OPERATOR", "JOINER_OPERATOR", "AGGREGATOR_OPERATOR", "PROJECTION_OPERATOR", "TARGET_OPERATOR", "DISTINCT_OPERATOR", "SORT_OPERATOR", "UNION_OPERATOR", "INTERSECT_OPERATOR", "MINUS_OPERATOR", "MERGE_OPERATOR", "START_OPERATOR", "END_OPERATOR", "PIPELINE_OPERATOR", "REST_OPERATOR", "TASK_OPERATOR", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type model_type: str
 
@@ -170,17 +213,11 @@ class Operator(object):
         """
         type = object_dictionary['modelType']
 
-        if type == 'TARGET_OPERATOR':
-            return 'Target'
-
         if type == 'JOINER_OPERATOR':
             return 'Joiner'
 
-        if type == 'DISTINCT_OPERATOR':
-            return 'Distinct'
-
-        if type == 'FILTER_OPERATOR':
-            return 'Filter'
+        if type == 'TASK_OPERATOR':
+            return 'TaskOperator'
 
         if type == 'AGGREGATOR_OPERATOR':
             return 'Aggregator'
@@ -191,8 +228,35 @@ class Operator(object):
         if type == 'PROJECTION_OPERATOR':
             return 'Projection'
 
+        if type == 'END_OPERATOR':
+            return 'EndOperator'
+
         if type == 'SOURCE_OPERATOR':
             return 'Source'
+
+        if type == 'UNION_OPERATOR':
+            return 'Union'
+
+        if type == 'INTERSECT_OPERATOR':
+            return 'Intersect'
+
+        if type == 'TARGET_OPERATOR':
+            return 'Target'
+
+        if type == 'DISTINCT_OPERATOR':
+            return 'Distinct'
+
+        if type == 'FILTER_OPERATOR':
+            return 'Filter'
+
+        if type == 'START_OPERATOR':
+            return 'StartOperator'
+
+        if type == 'MERGE_OPERATOR':
+            return 'MergeOperator'
+
+        if type == 'MINUS_OPERATOR':
+            return 'Minus'
         else:
             return 'Operator'
 
@@ -202,7 +266,7 @@ class Operator(object):
         **[Required]** Gets the model_type of this Operator.
         The model type of the operator.
 
-        Allowed values for this property are: "SOURCE_OPERATOR", "FILTER_OPERATOR", "JOINER_OPERATOR", "AGGREGATOR_OPERATOR", "PROJECTION_OPERATOR", "TARGET_OPERATOR", "DISTINCT_OPERATOR", "SORT_OPERATOR", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "SOURCE_OPERATOR", "FILTER_OPERATOR", "JOINER_OPERATOR", "AGGREGATOR_OPERATOR", "PROJECTION_OPERATOR", "TARGET_OPERATOR", "DISTINCT_OPERATOR", "SORT_OPERATOR", "UNION_OPERATOR", "INTERSECT_OPERATOR", "MINUS_OPERATOR", "MERGE_OPERATOR", "START_OPERATOR", "END_OPERATOR", "PIPELINE_OPERATOR", "REST_OPERATOR", "TASK_OPERATOR", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -221,7 +285,7 @@ class Operator(object):
         :param model_type: The model_type of this Operator.
         :type: str
         """
-        allowed_values = ["SOURCE_OPERATOR", "FILTER_OPERATOR", "JOINER_OPERATOR", "AGGREGATOR_OPERATOR", "PROJECTION_OPERATOR", "TARGET_OPERATOR", "DISTINCT_OPERATOR", "SORT_OPERATOR"]
+        allowed_values = ["SOURCE_OPERATOR", "FILTER_OPERATOR", "JOINER_OPERATOR", "AGGREGATOR_OPERATOR", "PROJECTION_OPERATOR", "TARGET_OPERATOR", "DISTINCT_OPERATOR", "SORT_OPERATOR", "UNION_OPERATOR", "INTERSECT_OPERATOR", "MINUS_OPERATOR", "MERGE_OPERATOR", "START_OPERATOR", "END_OPERATOR", "PIPELINE_OPERATOR", "REST_OPERATOR", "TASK_OPERATOR"]
         if not value_allowed_none_or_none_sentinel(model_type, allowed_values):
             model_type = 'UNKNOWN_ENUM_VALUE'
         self._model_type = model_type

--- a/src/oci/data_integration/models/patch_change_summary.py
+++ b/src/oci/data_integration/models/patch_change_summary.py
@@ -21,6 +21,10 @@ class PatchChangeSummary(object):
     #: This constant has a value of "DATA_LOADER_TASK"
     TYPE_DATA_LOADER_TASK = "DATA_LOADER_TASK"
 
+    #: A constant which can be used with the type property of a PatchChangeSummary.
+    #: This constant has a value of "PIPELINE_TASK"
+    TYPE_PIPELINE_TASK = "PIPELINE_TASK"
+
     #: A constant which can be used with the action property of a PatchChangeSummary.
     #: This constant has a value of "CREATED"
     ACTION_CREATED = "CREATED"
@@ -52,7 +56,7 @@ class PatchChangeSummary(object):
 
         :param type:
             The value to assign to the type property of this PatchChangeSummary.
-            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type type: str
 
@@ -177,7 +181,7 @@ class PatchChangeSummary(object):
         Gets the type of this PatchChangeSummary.
         The type of the object in patch.
 
-        Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -196,7 +200,7 @@ class PatchChangeSummary(object):
         :param type: The type of this PatchChangeSummary.
         :type: str
         """
-        allowed_values = ["INTEGRATION_TASK", "DATA_LOADER_TASK"]
+        allowed_values = ["INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK"]
         if not value_allowed_none_or_none_sentinel(type, allowed_values):
             type = 'UNKNOWN_ENUM_VALUE'
         self._type = type

--- a/src/oci/data_integration/models/patch_object_metadata.py
+++ b/src/oci/data_integration/models/patch_object_metadata.py
@@ -21,6 +21,10 @@ class PatchObjectMetadata(object):
     #: This constant has a value of "DATA_LOADER_TASK"
     TYPE_DATA_LOADER_TASK = "DATA_LOADER_TASK"
 
+    #: A constant which can be used with the type property of a PatchObjectMetadata.
+    #: This constant has a value of "PIPELINE_TASK"
+    TYPE_PIPELINE_TASK = "PIPELINE_TASK"
+
     #: A constant which can be used with the action property of a PatchObjectMetadata.
     #: This constant has a value of "CREATED"
     ACTION_CREATED = "CREATED"
@@ -52,7 +56,7 @@ class PatchObjectMetadata(object):
 
         :param type:
             The value to assign to the type property of this PatchObjectMetadata.
-            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type type: str
 
@@ -177,7 +181,7 @@ class PatchObjectMetadata(object):
         Gets the type of this PatchObjectMetadata.
         The type of the object in patch.
 
-        Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -196,7 +200,7 @@ class PatchObjectMetadata(object):
         :param type: The type of this PatchObjectMetadata.
         :type: str
         """
-        allowed_values = ["INTEGRATION_TASK", "DATA_LOADER_TASK"]
+        allowed_values = ["INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK"]
         if not value_allowed_none_or_none_sentinel(type, allowed_values):
             type = 'UNKNOWN_ENUM_VALUE'
         self._type = type

--- a/src/oci/data_integration/models/pipeline.py
+++ b/src/oci/data_integration/models/pipeline.py
@@ -1,0 +1,461 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class Pipeline(object):
+    """
+    A pipeline is a logical grouping of tasks that together perform a higher level operation. For example, a pipeline could contain a set of tasks that load and clean data, then execute a dataflow to analyze the data. The pipeline allows you to manage the activities as a unit instead of individually. Users can also schedule the pipeline instead of the tasks independently.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new Pipeline object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param key:
+            The value to assign to the key property of this Pipeline.
+        :type key: str
+
+        :param model_version:
+            The value to assign to the model_version property of this Pipeline.
+        :type model_version: str
+
+        :param parent_ref:
+            The value to assign to the parent_ref property of this Pipeline.
+        :type parent_ref: oci.data_integration.models.ParentReference
+
+        :param name:
+            The value to assign to the name property of this Pipeline.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this Pipeline.
+        :type description: str
+
+        :param model_type:
+            The value to assign to the model_type property of this Pipeline.
+        :type model_type: str
+
+        :param object_version:
+            The value to assign to the object_version property of this Pipeline.
+        :type object_version: int
+
+        :param object_status:
+            The value to assign to the object_status property of this Pipeline.
+        :type object_status: int
+
+        :param identifier:
+            The value to assign to the identifier property of this Pipeline.
+        :type identifier: str
+
+        :param nodes:
+            The value to assign to the nodes property of this Pipeline.
+        :type nodes: list[oci.data_integration.models.FlowNode]
+
+        :param parameters:
+            The value to assign to the parameters property of this Pipeline.
+        :type parameters: list[oci.data_integration.models.Parameter]
+
+        :param flow_config_values:
+            The value to assign to the flow_config_values property of this Pipeline.
+        :type flow_config_values: oci.data_integration.models.ConfigValues
+
+        :param variables:
+            The value to assign to the variables property of this Pipeline.
+        :type variables: list[oci.data_integration.models.Variable]
+
+        :param metadata:
+            The value to assign to the metadata property of this Pipeline.
+        :type metadata: oci.data_integration.models.ObjectMetadata
+
+        """
+        self.swagger_types = {
+            'key': 'str',
+            'model_version': 'str',
+            'parent_ref': 'ParentReference',
+            'name': 'str',
+            'description': 'str',
+            'model_type': 'str',
+            'object_version': 'int',
+            'object_status': 'int',
+            'identifier': 'str',
+            'nodes': 'list[FlowNode]',
+            'parameters': 'list[Parameter]',
+            'flow_config_values': 'ConfigValues',
+            'variables': 'list[Variable]',
+            'metadata': 'ObjectMetadata'
+        }
+
+        self.attribute_map = {
+            'key': 'key',
+            'model_version': 'modelVersion',
+            'parent_ref': 'parentRef',
+            'name': 'name',
+            'description': 'description',
+            'model_type': 'modelType',
+            'object_version': 'objectVersion',
+            'object_status': 'objectStatus',
+            'identifier': 'identifier',
+            'nodes': 'nodes',
+            'parameters': 'parameters',
+            'flow_config_values': 'flowConfigValues',
+            'variables': 'variables',
+            'metadata': 'metadata'
+        }
+
+        self._key = None
+        self._model_version = None
+        self._parent_ref = None
+        self._name = None
+        self._description = None
+        self._model_type = None
+        self._object_version = None
+        self._object_status = None
+        self._identifier = None
+        self._nodes = None
+        self._parameters = None
+        self._flow_config_values = None
+        self._variables = None
+        self._metadata = None
+
+    @property
+    def key(self):
+        """
+        Gets the key of this Pipeline.
+        Generated key that can be used in API calls to identify pipeline. On scenarios where reference to the pipeline is needed, a value can be passed in create.
+
+
+        :return: The key of this Pipeline.
+        :rtype: str
+        """
+        return self._key
+
+    @key.setter
+    def key(self, key):
+        """
+        Sets the key of this Pipeline.
+        Generated key that can be used in API calls to identify pipeline. On scenarios where reference to the pipeline is needed, a value can be passed in create.
+
+
+        :param key: The key of this Pipeline.
+        :type: str
+        """
+        self._key = key
+
+    @property
+    def model_version(self):
+        """
+        Gets the model_version of this Pipeline.
+        This is a version number that is used by the service to upgrade objects if needed through releases of the service.
+
+
+        :return: The model_version of this Pipeline.
+        :rtype: str
+        """
+        return self._model_version
+
+    @model_version.setter
+    def model_version(self, model_version):
+        """
+        Sets the model_version of this Pipeline.
+        This is a version number that is used by the service to upgrade objects if needed through releases of the service.
+
+
+        :param model_version: The model_version of this Pipeline.
+        :type: str
+        """
+        self._model_version = model_version
+
+    @property
+    def parent_ref(self):
+        """
+        Gets the parent_ref of this Pipeline.
+
+        :return: The parent_ref of this Pipeline.
+        :rtype: oci.data_integration.models.ParentReference
+        """
+        return self._parent_ref
+
+    @parent_ref.setter
+    def parent_ref(self, parent_ref):
+        """
+        Sets the parent_ref of this Pipeline.
+
+        :param parent_ref: The parent_ref of this Pipeline.
+        :type: oci.data_integration.models.ParentReference
+        """
+        self._parent_ref = parent_ref
+
+    @property
+    def name(self):
+        """
+        Gets the name of this Pipeline.
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
+
+
+        :return: The name of this Pipeline.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this Pipeline.
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
+
+
+        :param name: The name of this Pipeline.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def description(self):
+        """
+        Gets the description of this Pipeline.
+        Detailed description for the object.
+
+
+        :return: The description of this Pipeline.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this Pipeline.
+        Detailed description for the object.
+
+
+        :param description: The description of this Pipeline.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def model_type(self):
+        """
+        Gets the model_type of this Pipeline.
+        The type of the object.
+
+
+        :return: The model_type of this Pipeline.
+        :rtype: str
+        """
+        return self._model_type
+
+    @model_type.setter
+    def model_type(self, model_type):
+        """
+        Sets the model_type of this Pipeline.
+        The type of the object.
+
+
+        :param model_type: The model_type of this Pipeline.
+        :type: str
+        """
+        self._model_type = model_type
+
+    @property
+    def object_version(self):
+        """
+        Gets the object_version of this Pipeline.
+        This is used by the service for optimistic locking of the object, to prevent multiple users from simultaneously updating the object.
+
+
+        :return: The object_version of this Pipeline.
+        :rtype: int
+        """
+        return self._object_version
+
+    @object_version.setter
+    def object_version(self, object_version):
+        """
+        Sets the object_version of this Pipeline.
+        This is used by the service for optimistic locking of the object, to prevent multiple users from simultaneously updating the object.
+
+
+        :param object_version: The object_version of this Pipeline.
+        :type: int
+        """
+        self._object_version = object_version
+
+    @property
+    def object_status(self):
+        """
+        Gets the object_status of this Pipeline.
+        The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+
+
+        :return: The object_status of this Pipeline.
+        :rtype: int
+        """
+        return self._object_status
+
+    @object_status.setter
+    def object_status(self, object_status):
+        """
+        Sets the object_status of this Pipeline.
+        The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+
+
+        :param object_status: The object_status of this Pipeline.
+        :type: int
+        """
+        self._object_status = object_status
+
+    @property
+    def identifier(self):
+        """
+        Gets the identifier of this Pipeline.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
+
+
+        :return: The identifier of this Pipeline.
+        :rtype: str
+        """
+        return self._identifier
+
+    @identifier.setter
+    def identifier(self, identifier):
+        """
+        Sets the identifier of this Pipeline.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
+
+
+        :param identifier: The identifier of this Pipeline.
+        :type: str
+        """
+        self._identifier = identifier
+
+    @property
+    def nodes(self):
+        """
+        Gets the nodes of this Pipeline.
+        A list of nodes attached to the pipeline.
+
+
+        :return: The nodes of this Pipeline.
+        :rtype: list[oci.data_integration.models.FlowNode]
+        """
+        return self._nodes
+
+    @nodes.setter
+    def nodes(self, nodes):
+        """
+        Sets the nodes of this Pipeline.
+        A list of nodes attached to the pipeline.
+
+
+        :param nodes: The nodes of this Pipeline.
+        :type: list[oci.data_integration.models.FlowNode]
+        """
+        self._nodes = nodes
+
+    @property
+    def parameters(self):
+        """
+        Gets the parameters of this Pipeline.
+        A list of parameters for the pipeline, this allows certain aspects of the pipeline to be configured when the pipeline is executed.
+
+
+        :return: The parameters of this Pipeline.
+        :rtype: list[oci.data_integration.models.Parameter]
+        """
+        return self._parameters
+
+    @parameters.setter
+    def parameters(self, parameters):
+        """
+        Sets the parameters of this Pipeline.
+        A list of parameters for the pipeline, this allows certain aspects of the pipeline to be configured when the pipeline is executed.
+
+
+        :param parameters: The parameters of this Pipeline.
+        :type: list[oci.data_integration.models.Parameter]
+        """
+        self._parameters = parameters
+
+    @property
+    def flow_config_values(self):
+        """
+        Gets the flow_config_values of this Pipeline.
+
+        :return: The flow_config_values of this Pipeline.
+        :rtype: oci.data_integration.models.ConfigValues
+        """
+        return self._flow_config_values
+
+    @flow_config_values.setter
+    def flow_config_values(self, flow_config_values):
+        """
+        Sets the flow_config_values of this Pipeline.
+
+        :param flow_config_values: The flow_config_values of this Pipeline.
+        :type: oci.data_integration.models.ConfigValues
+        """
+        self._flow_config_values = flow_config_values
+
+    @property
+    def variables(self):
+        """
+        Gets the variables of this Pipeline.
+        The list of variables required in pipeline, variables can be used to store values that can be used as inputs to tasks in the pipeline.
+
+
+        :return: The variables of this Pipeline.
+        :rtype: list[oci.data_integration.models.Variable]
+        """
+        return self._variables
+
+    @variables.setter
+    def variables(self, variables):
+        """
+        Sets the variables of this Pipeline.
+        The list of variables required in pipeline, variables can be used to store values that can be used as inputs to tasks in the pipeline.
+
+
+        :param variables: The variables of this Pipeline.
+        :type: list[oci.data_integration.models.Variable]
+        """
+        self._variables = variables
+
+    @property
+    def metadata(self):
+        """
+        Gets the metadata of this Pipeline.
+
+        :return: The metadata of this Pipeline.
+        :rtype: oci.data_integration.models.ObjectMetadata
+        """
+        return self._metadata
+
+    @metadata.setter
+    def metadata(self, metadata):
+        """
+        Sets the metadata of this Pipeline.
+
+        :param metadata: The metadata of this Pipeline.
+        :type: oci.data_integration.models.ObjectMetadata
+        """
+        self._metadata = metadata
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/pipeline_summary.py
+++ b/src/oci/data_integration/models/pipeline_summary.py
@@ -1,0 +1,461 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class PipelineSummary(object):
+    """
+    The pipeline summary type contains the audit summary information and the definition of the pipeline.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new PipelineSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param key:
+            The value to assign to the key property of this PipelineSummary.
+        :type key: str
+
+        :param model_version:
+            The value to assign to the model_version property of this PipelineSummary.
+        :type model_version: str
+
+        :param parent_ref:
+            The value to assign to the parent_ref property of this PipelineSummary.
+        :type parent_ref: oci.data_integration.models.ParentReference
+
+        :param name:
+            The value to assign to the name property of this PipelineSummary.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this PipelineSummary.
+        :type description: str
+
+        :param model_type:
+            The value to assign to the model_type property of this PipelineSummary.
+        :type model_type: str
+
+        :param object_version:
+            The value to assign to the object_version property of this PipelineSummary.
+        :type object_version: int
+
+        :param object_status:
+            The value to assign to the object_status property of this PipelineSummary.
+        :type object_status: int
+
+        :param identifier:
+            The value to assign to the identifier property of this PipelineSummary.
+        :type identifier: str
+
+        :param nodes:
+            The value to assign to the nodes property of this PipelineSummary.
+        :type nodes: list[oci.data_integration.models.FlowNode]
+
+        :param parameters:
+            The value to assign to the parameters property of this PipelineSummary.
+        :type parameters: list[oci.data_integration.models.Parameter]
+
+        :param flow_config_values:
+            The value to assign to the flow_config_values property of this PipelineSummary.
+        :type flow_config_values: oci.data_integration.models.ConfigValues
+
+        :param variables:
+            The value to assign to the variables property of this PipelineSummary.
+        :type variables: list[oci.data_integration.models.Variable]
+
+        :param metadata:
+            The value to assign to the metadata property of this PipelineSummary.
+        :type metadata: oci.data_integration.models.ObjectMetadata
+
+        """
+        self.swagger_types = {
+            'key': 'str',
+            'model_version': 'str',
+            'parent_ref': 'ParentReference',
+            'name': 'str',
+            'description': 'str',
+            'model_type': 'str',
+            'object_version': 'int',
+            'object_status': 'int',
+            'identifier': 'str',
+            'nodes': 'list[FlowNode]',
+            'parameters': 'list[Parameter]',
+            'flow_config_values': 'ConfigValues',
+            'variables': 'list[Variable]',
+            'metadata': 'ObjectMetadata'
+        }
+
+        self.attribute_map = {
+            'key': 'key',
+            'model_version': 'modelVersion',
+            'parent_ref': 'parentRef',
+            'name': 'name',
+            'description': 'description',
+            'model_type': 'modelType',
+            'object_version': 'objectVersion',
+            'object_status': 'objectStatus',
+            'identifier': 'identifier',
+            'nodes': 'nodes',
+            'parameters': 'parameters',
+            'flow_config_values': 'flowConfigValues',
+            'variables': 'variables',
+            'metadata': 'metadata'
+        }
+
+        self._key = None
+        self._model_version = None
+        self._parent_ref = None
+        self._name = None
+        self._description = None
+        self._model_type = None
+        self._object_version = None
+        self._object_status = None
+        self._identifier = None
+        self._nodes = None
+        self._parameters = None
+        self._flow_config_values = None
+        self._variables = None
+        self._metadata = None
+
+    @property
+    def key(self):
+        """
+        Gets the key of this PipelineSummary.
+        Generated key that can be used in API calls to identify pipeline. On scenarios where reference to the pipeline is needed, a value can be passed in create.
+
+
+        :return: The key of this PipelineSummary.
+        :rtype: str
+        """
+        return self._key
+
+    @key.setter
+    def key(self, key):
+        """
+        Sets the key of this PipelineSummary.
+        Generated key that can be used in API calls to identify pipeline. On scenarios where reference to the pipeline is needed, a value can be passed in create.
+
+
+        :param key: The key of this PipelineSummary.
+        :type: str
+        """
+        self._key = key
+
+    @property
+    def model_version(self):
+        """
+        Gets the model_version of this PipelineSummary.
+        This is a version number that is used by the service to upgrade objects if needed through releases of the service.
+
+
+        :return: The model_version of this PipelineSummary.
+        :rtype: str
+        """
+        return self._model_version
+
+    @model_version.setter
+    def model_version(self, model_version):
+        """
+        Sets the model_version of this PipelineSummary.
+        This is a version number that is used by the service to upgrade objects if needed through releases of the service.
+
+
+        :param model_version: The model_version of this PipelineSummary.
+        :type: str
+        """
+        self._model_version = model_version
+
+    @property
+    def parent_ref(self):
+        """
+        Gets the parent_ref of this PipelineSummary.
+
+        :return: The parent_ref of this PipelineSummary.
+        :rtype: oci.data_integration.models.ParentReference
+        """
+        return self._parent_ref
+
+    @parent_ref.setter
+    def parent_ref(self, parent_ref):
+        """
+        Sets the parent_ref of this PipelineSummary.
+
+        :param parent_ref: The parent_ref of this PipelineSummary.
+        :type: oci.data_integration.models.ParentReference
+        """
+        self._parent_ref = parent_ref
+
+    @property
+    def name(self):
+        """
+        Gets the name of this PipelineSummary.
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
+
+
+        :return: The name of this PipelineSummary.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this PipelineSummary.
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
+
+
+        :param name: The name of this PipelineSummary.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def description(self):
+        """
+        Gets the description of this PipelineSummary.
+        Detailed description for the object.
+
+
+        :return: The description of this PipelineSummary.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this PipelineSummary.
+        Detailed description for the object.
+
+
+        :param description: The description of this PipelineSummary.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def model_type(self):
+        """
+        Gets the model_type of this PipelineSummary.
+        The type of the object.
+
+
+        :return: The model_type of this PipelineSummary.
+        :rtype: str
+        """
+        return self._model_type
+
+    @model_type.setter
+    def model_type(self, model_type):
+        """
+        Sets the model_type of this PipelineSummary.
+        The type of the object.
+
+
+        :param model_type: The model_type of this PipelineSummary.
+        :type: str
+        """
+        self._model_type = model_type
+
+    @property
+    def object_version(self):
+        """
+        Gets the object_version of this PipelineSummary.
+        This is used by the service for optimistic locking of the object, to prevent multiple users from simultaneously updating the object.
+
+
+        :return: The object_version of this PipelineSummary.
+        :rtype: int
+        """
+        return self._object_version
+
+    @object_version.setter
+    def object_version(self, object_version):
+        """
+        Sets the object_version of this PipelineSummary.
+        This is used by the service for optimistic locking of the object, to prevent multiple users from simultaneously updating the object.
+
+
+        :param object_version: The object_version of this PipelineSummary.
+        :type: int
+        """
+        self._object_version = object_version
+
+    @property
+    def object_status(self):
+        """
+        Gets the object_status of this PipelineSummary.
+        The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+
+
+        :return: The object_status of this PipelineSummary.
+        :rtype: int
+        """
+        return self._object_status
+
+    @object_status.setter
+    def object_status(self, object_status):
+        """
+        Sets the object_status of this PipelineSummary.
+        The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+
+
+        :param object_status: The object_status of this PipelineSummary.
+        :type: int
+        """
+        self._object_status = object_status
+
+    @property
+    def identifier(self):
+        """
+        Gets the identifier of this PipelineSummary.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
+
+
+        :return: The identifier of this PipelineSummary.
+        :rtype: str
+        """
+        return self._identifier
+
+    @identifier.setter
+    def identifier(self, identifier):
+        """
+        Sets the identifier of this PipelineSummary.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
+
+
+        :param identifier: The identifier of this PipelineSummary.
+        :type: str
+        """
+        self._identifier = identifier
+
+    @property
+    def nodes(self):
+        """
+        Gets the nodes of this PipelineSummary.
+        A list of nodes attached to the pipeline.
+
+
+        :return: The nodes of this PipelineSummary.
+        :rtype: list[oci.data_integration.models.FlowNode]
+        """
+        return self._nodes
+
+    @nodes.setter
+    def nodes(self, nodes):
+        """
+        Sets the nodes of this PipelineSummary.
+        A list of nodes attached to the pipeline.
+
+
+        :param nodes: The nodes of this PipelineSummary.
+        :type: list[oci.data_integration.models.FlowNode]
+        """
+        self._nodes = nodes
+
+    @property
+    def parameters(self):
+        """
+        Gets the parameters of this PipelineSummary.
+        A list of parameters for the pipeline, this allows certain aspects of the pipeline to be configured when the pipeline is executed.
+
+
+        :return: The parameters of this PipelineSummary.
+        :rtype: list[oci.data_integration.models.Parameter]
+        """
+        return self._parameters
+
+    @parameters.setter
+    def parameters(self, parameters):
+        """
+        Sets the parameters of this PipelineSummary.
+        A list of parameters for the pipeline, this allows certain aspects of the pipeline to be configured when the pipeline is executed.
+
+
+        :param parameters: The parameters of this PipelineSummary.
+        :type: list[oci.data_integration.models.Parameter]
+        """
+        self._parameters = parameters
+
+    @property
+    def flow_config_values(self):
+        """
+        Gets the flow_config_values of this PipelineSummary.
+
+        :return: The flow_config_values of this PipelineSummary.
+        :rtype: oci.data_integration.models.ConfigValues
+        """
+        return self._flow_config_values
+
+    @flow_config_values.setter
+    def flow_config_values(self, flow_config_values):
+        """
+        Sets the flow_config_values of this PipelineSummary.
+
+        :param flow_config_values: The flow_config_values of this PipelineSummary.
+        :type: oci.data_integration.models.ConfigValues
+        """
+        self._flow_config_values = flow_config_values
+
+    @property
+    def variables(self):
+        """
+        Gets the variables of this PipelineSummary.
+        The list of variables required in pipeline, variables can be used to store values that can be used as inputs to tasks in the pipeline.
+
+
+        :return: The variables of this PipelineSummary.
+        :rtype: list[oci.data_integration.models.Variable]
+        """
+        return self._variables
+
+    @variables.setter
+    def variables(self, variables):
+        """
+        Sets the variables of this PipelineSummary.
+        The list of variables required in pipeline, variables can be used to store values that can be used as inputs to tasks in the pipeline.
+
+
+        :param variables: The variables of this PipelineSummary.
+        :type: list[oci.data_integration.models.Variable]
+        """
+        self._variables = variables
+
+    @property
+    def metadata(self):
+        """
+        Gets the metadata of this PipelineSummary.
+
+        :return: The metadata of this PipelineSummary.
+        :rtype: oci.data_integration.models.ObjectMetadata
+        """
+        return self._metadata
+
+    @metadata.setter
+    def metadata(self, metadata):
+        """
+        Sets the metadata of this PipelineSummary.
+
+        :param metadata: The metadata of this PipelineSummary.
+        :type: oci.data_integration.models.ObjectMetadata
+        """
+        self._metadata = metadata
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/pipeline_summary_collection.py
+++ b/src/oci/data_integration/models/pipeline_summary_collection.py
@@ -1,0 +1,70 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class PipelineSummaryCollection(object):
+    """
+    This is the collection of pipeline summaries, it may be a collection of lightweight details or full definitions.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new PipelineSummaryCollection object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param items:
+            The value to assign to the items property of this PipelineSummaryCollection.
+        :type items: list[oci.data_integration.models.PipelineSummary]
+
+        """
+        self.swagger_types = {
+            'items': 'list[PipelineSummary]'
+        }
+
+        self.attribute_map = {
+            'items': 'items'
+        }
+
+        self._items = None
+
+    @property
+    def items(self):
+        """
+        **[Required]** Gets the items of this PipelineSummaryCollection.
+        The array of pipeline summaries.
+
+
+        :return: The items of this PipelineSummaryCollection.
+        :rtype: list[oci.data_integration.models.PipelineSummary]
+        """
+        return self._items
+
+    @items.setter
+    def items(self, items):
+        """
+        Sets the items of this PipelineSummaryCollection.
+        The array of pipeline summaries.
+
+
+        :param items: The items of this PipelineSummaryCollection.
+        :type: list[oci.data_integration.models.PipelineSummary]
+        """
+        self._items = items
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/pipeline_validation.py
+++ b/src/oci/data_integration/models/pipeline_validation.py
@@ -1,0 +1,496 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class PipelineValidation(object):
+    """
+    The information about a pipeline validation.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new PipelineValidation object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param total_message_count:
+            The value to assign to the total_message_count property of this PipelineValidation.
+        :type total_message_count: int
+
+        :param error_message_count:
+            The value to assign to the error_message_count property of this PipelineValidation.
+        :type error_message_count: int
+
+        :param warn_message_count:
+            The value to assign to the warn_message_count property of this PipelineValidation.
+        :type warn_message_count: int
+
+        :param info_message_count:
+            The value to assign to the info_message_count property of this PipelineValidation.
+        :type info_message_count: int
+
+        :param validation_messages:
+            The value to assign to the validation_messages property of this PipelineValidation.
+        :type validation_messages: dict(str, list[ValidationMessage])
+
+        :param key:
+            The value to assign to the key property of this PipelineValidation.
+        :type key: str
+
+        :param model_type:
+            The value to assign to the model_type property of this PipelineValidation.
+        :type model_type: str
+
+        :param model_version:
+            The value to assign to the model_version property of this PipelineValidation.
+        :type model_version: str
+
+        :param parent_ref:
+            The value to assign to the parent_ref property of this PipelineValidation.
+        :type parent_ref: oci.data_integration.models.ParentReference
+
+        :param name:
+            The value to assign to the name property of this PipelineValidation.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this PipelineValidation.
+        :type description: str
+
+        :param object_version:
+            The value to assign to the object_version property of this PipelineValidation.
+        :type object_version: int
+
+        :param object_status:
+            The value to assign to the object_status property of this PipelineValidation.
+        :type object_status: int
+
+        :param identifier:
+            The value to assign to the identifier property of this PipelineValidation.
+        :type identifier: str
+
+        :param metadata:
+            The value to assign to the metadata property of this PipelineValidation.
+        :type metadata: oci.data_integration.models.ObjectMetadata
+
+        """
+        self.swagger_types = {
+            'total_message_count': 'int',
+            'error_message_count': 'int',
+            'warn_message_count': 'int',
+            'info_message_count': 'int',
+            'validation_messages': 'dict(str, list[ValidationMessage])',
+            'key': 'str',
+            'model_type': 'str',
+            'model_version': 'str',
+            'parent_ref': 'ParentReference',
+            'name': 'str',
+            'description': 'str',
+            'object_version': 'int',
+            'object_status': 'int',
+            'identifier': 'str',
+            'metadata': 'ObjectMetadata'
+        }
+
+        self.attribute_map = {
+            'total_message_count': 'totalMessageCount',
+            'error_message_count': 'errorMessageCount',
+            'warn_message_count': 'warnMessageCount',
+            'info_message_count': 'infoMessageCount',
+            'validation_messages': 'validationMessages',
+            'key': 'key',
+            'model_type': 'modelType',
+            'model_version': 'modelVersion',
+            'parent_ref': 'parentRef',
+            'name': 'name',
+            'description': 'description',
+            'object_version': 'objectVersion',
+            'object_status': 'objectStatus',
+            'identifier': 'identifier',
+            'metadata': 'metadata'
+        }
+
+        self._total_message_count = None
+        self._error_message_count = None
+        self._warn_message_count = None
+        self._info_message_count = None
+        self._validation_messages = None
+        self._key = None
+        self._model_type = None
+        self._model_version = None
+        self._parent_ref = None
+        self._name = None
+        self._description = None
+        self._object_version = None
+        self._object_status = None
+        self._identifier = None
+        self._metadata = None
+
+    @property
+    def total_message_count(self):
+        """
+        Gets the total_message_count of this PipelineValidation.
+        The total number of validation messages.
+
+
+        :return: The total_message_count of this PipelineValidation.
+        :rtype: int
+        """
+        return self._total_message_count
+
+    @total_message_count.setter
+    def total_message_count(self, total_message_count):
+        """
+        Sets the total_message_count of this PipelineValidation.
+        The total number of validation messages.
+
+
+        :param total_message_count: The total_message_count of this PipelineValidation.
+        :type: int
+        """
+        self._total_message_count = total_message_count
+
+    @property
+    def error_message_count(self):
+        """
+        Gets the error_message_count of this PipelineValidation.
+        The total number of validation error messages.
+
+
+        :return: The error_message_count of this PipelineValidation.
+        :rtype: int
+        """
+        return self._error_message_count
+
+    @error_message_count.setter
+    def error_message_count(self, error_message_count):
+        """
+        Sets the error_message_count of this PipelineValidation.
+        The total number of validation error messages.
+
+
+        :param error_message_count: The error_message_count of this PipelineValidation.
+        :type: int
+        """
+        self._error_message_count = error_message_count
+
+    @property
+    def warn_message_count(self):
+        """
+        Gets the warn_message_count of this PipelineValidation.
+        The total number of validation warning messages.
+
+
+        :return: The warn_message_count of this PipelineValidation.
+        :rtype: int
+        """
+        return self._warn_message_count
+
+    @warn_message_count.setter
+    def warn_message_count(self, warn_message_count):
+        """
+        Sets the warn_message_count of this PipelineValidation.
+        The total number of validation warning messages.
+
+
+        :param warn_message_count: The warn_message_count of this PipelineValidation.
+        :type: int
+        """
+        self._warn_message_count = warn_message_count
+
+    @property
+    def info_message_count(self):
+        """
+        Gets the info_message_count of this PipelineValidation.
+        The total number of validation information messages.
+
+
+        :return: The info_message_count of this PipelineValidation.
+        :rtype: int
+        """
+        return self._info_message_count
+
+    @info_message_count.setter
+    def info_message_count(self, info_message_count):
+        """
+        Sets the info_message_count of this PipelineValidation.
+        The total number of validation information messages.
+
+
+        :param info_message_count: The info_message_count of this PipelineValidation.
+        :type: int
+        """
+        self._info_message_count = info_message_count
+
+    @property
+    def validation_messages(self):
+        """
+        Gets the validation_messages of this PipelineValidation.
+        The detailed information of the pipeline object validation.
+
+
+        :return: The validation_messages of this PipelineValidation.
+        :rtype: dict(str, list[ValidationMessage])
+        """
+        return self._validation_messages
+
+    @validation_messages.setter
+    def validation_messages(self, validation_messages):
+        """
+        Sets the validation_messages of this PipelineValidation.
+        The detailed information of the pipeline object validation.
+
+
+        :param validation_messages: The validation_messages of this PipelineValidation.
+        :type: dict(str, list[ValidationMessage])
+        """
+        self._validation_messages = validation_messages
+
+    @property
+    def key(self):
+        """
+        Gets the key of this PipelineValidation.
+        Objects will use a 36 character key as unique ID. It is system generated and cannot be modified.
+
+
+        :return: The key of this PipelineValidation.
+        :rtype: str
+        """
+        return self._key
+
+    @key.setter
+    def key(self, key):
+        """
+        Sets the key of this PipelineValidation.
+        Objects will use a 36 character key as unique ID. It is system generated and cannot be modified.
+
+
+        :param key: The key of this PipelineValidation.
+        :type: str
+        """
+        self._key = key
+
+    @property
+    def model_type(self):
+        """
+        Gets the model_type of this PipelineValidation.
+        The type of the object.
+
+
+        :return: The model_type of this PipelineValidation.
+        :rtype: str
+        """
+        return self._model_type
+
+    @model_type.setter
+    def model_type(self, model_type):
+        """
+        Sets the model_type of this PipelineValidation.
+        The type of the object.
+
+
+        :param model_type: The model_type of this PipelineValidation.
+        :type: str
+        """
+        self._model_type = model_type
+
+    @property
+    def model_version(self):
+        """
+        Gets the model_version of this PipelineValidation.
+        This is a version number that is used by the service to upgrade objects if needed through releases of the service.
+
+
+        :return: The model_version of this PipelineValidation.
+        :rtype: str
+        """
+        return self._model_version
+
+    @model_version.setter
+    def model_version(self, model_version):
+        """
+        Sets the model_version of this PipelineValidation.
+        This is a version number that is used by the service to upgrade objects if needed through releases of the service.
+
+
+        :param model_version: The model_version of this PipelineValidation.
+        :type: str
+        """
+        self._model_version = model_version
+
+    @property
+    def parent_ref(self):
+        """
+        Gets the parent_ref of this PipelineValidation.
+
+        :return: The parent_ref of this PipelineValidation.
+        :rtype: oci.data_integration.models.ParentReference
+        """
+        return self._parent_ref
+
+    @parent_ref.setter
+    def parent_ref(self, parent_ref):
+        """
+        Sets the parent_ref of this PipelineValidation.
+
+        :param parent_ref: The parent_ref of this PipelineValidation.
+        :type: oci.data_integration.models.ParentReference
+        """
+        self._parent_ref = parent_ref
+
+    @property
+    def name(self):
+        """
+        Gets the name of this PipelineValidation.
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
+
+
+        :return: The name of this PipelineValidation.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this PipelineValidation.
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
+
+
+        :param name: The name of this PipelineValidation.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def description(self):
+        """
+        Gets the description of this PipelineValidation.
+        Detailed description for the object.
+
+
+        :return: The description of this PipelineValidation.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this PipelineValidation.
+        Detailed description for the object.
+
+
+        :param description: The description of this PipelineValidation.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def object_version(self):
+        """
+        Gets the object_version of this PipelineValidation.
+        This is used by the service for optimistic locking of the object, to prevent multiple users from simultaneously updating the object.
+
+
+        :return: The object_version of this PipelineValidation.
+        :rtype: int
+        """
+        return self._object_version
+
+    @object_version.setter
+    def object_version(self, object_version):
+        """
+        Sets the object_version of this PipelineValidation.
+        This is used by the service for optimistic locking of the object, to prevent multiple users from simultaneously updating the object.
+
+
+        :param object_version: The object_version of this PipelineValidation.
+        :type: int
+        """
+        self._object_version = object_version
+
+    @property
+    def object_status(self):
+        """
+        Gets the object_status of this PipelineValidation.
+        The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+
+
+        :return: The object_status of this PipelineValidation.
+        :rtype: int
+        """
+        return self._object_status
+
+    @object_status.setter
+    def object_status(self, object_status):
+        """
+        Sets the object_status of this PipelineValidation.
+        The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+
+
+        :param object_status: The object_status of this PipelineValidation.
+        :type: int
+        """
+        self._object_status = object_status
+
+    @property
+    def identifier(self):
+        """
+        Gets the identifier of this PipelineValidation.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
+
+
+        :return: The identifier of this PipelineValidation.
+        :rtype: str
+        """
+        return self._identifier
+
+    @identifier.setter
+    def identifier(self, identifier):
+        """
+        Sets the identifier of this PipelineValidation.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
+
+
+        :param identifier: The identifier of this PipelineValidation.
+        :type: str
+        """
+        self._identifier = identifier
+
+    @property
+    def metadata(self):
+        """
+        Gets the metadata of this PipelineValidation.
+
+        :return: The metadata of this PipelineValidation.
+        :rtype: oci.data_integration.models.ObjectMetadata
+        """
+        return self._metadata
+
+    @metadata.setter
+    def metadata(self, metadata):
+        """
+        Sets the metadata of this PipelineValidation.
+
+        :param metadata: The metadata of this PipelineValidation.
+        :type: oci.data_integration.models.ObjectMetadata
+        """
+        self._metadata = metadata
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/pipeline_validation_summary.py
+++ b/src/oci/data_integration/models/pipeline_validation_summary.py
@@ -1,0 +1,496 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class PipelineValidationSummary(object):
+    """
+    The information about a pipeline validation.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new PipelineValidationSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param total_message_count:
+            The value to assign to the total_message_count property of this PipelineValidationSummary.
+        :type total_message_count: int
+
+        :param error_message_count:
+            The value to assign to the error_message_count property of this PipelineValidationSummary.
+        :type error_message_count: int
+
+        :param warn_message_count:
+            The value to assign to the warn_message_count property of this PipelineValidationSummary.
+        :type warn_message_count: int
+
+        :param info_message_count:
+            The value to assign to the info_message_count property of this PipelineValidationSummary.
+        :type info_message_count: int
+
+        :param validation_messages:
+            The value to assign to the validation_messages property of this PipelineValidationSummary.
+        :type validation_messages: dict(str, list[ValidationMessage])
+
+        :param key:
+            The value to assign to the key property of this PipelineValidationSummary.
+        :type key: str
+
+        :param model_type:
+            The value to assign to the model_type property of this PipelineValidationSummary.
+        :type model_type: str
+
+        :param model_version:
+            The value to assign to the model_version property of this PipelineValidationSummary.
+        :type model_version: str
+
+        :param parent_ref:
+            The value to assign to the parent_ref property of this PipelineValidationSummary.
+        :type parent_ref: oci.data_integration.models.ParentReference
+
+        :param name:
+            The value to assign to the name property of this PipelineValidationSummary.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this PipelineValidationSummary.
+        :type description: str
+
+        :param object_version:
+            The value to assign to the object_version property of this PipelineValidationSummary.
+        :type object_version: int
+
+        :param object_status:
+            The value to assign to the object_status property of this PipelineValidationSummary.
+        :type object_status: int
+
+        :param identifier:
+            The value to assign to the identifier property of this PipelineValidationSummary.
+        :type identifier: str
+
+        :param metadata:
+            The value to assign to the metadata property of this PipelineValidationSummary.
+        :type metadata: oci.data_integration.models.ObjectMetadata
+
+        """
+        self.swagger_types = {
+            'total_message_count': 'int',
+            'error_message_count': 'int',
+            'warn_message_count': 'int',
+            'info_message_count': 'int',
+            'validation_messages': 'dict(str, list[ValidationMessage])',
+            'key': 'str',
+            'model_type': 'str',
+            'model_version': 'str',
+            'parent_ref': 'ParentReference',
+            'name': 'str',
+            'description': 'str',
+            'object_version': 'int',
+            'object_status': 'int',
+            'identifier': 'str',
+            'metadata': 'ObjectMetadata'
+        }
+
+        self.attribute_map = {
+            'total_message_count': 'totalMessageCount',
+            'error_message_count': 'errorMessageCount',
+            'warn_message_count': 'warnMessageCount',
+            'info_message_count': 'infoMessageCount',
+            'validation_messages': 'validationMessages',
+            'key': 'key',
+            'model_type': 'modelType',
+            'model_version': 'modelVersion',
+            'parent_ref': 'parentRef',
+            'name': 'name',
+            'description': 'description',
+            'object_version': 'objectVersion',
+            'object_status': 'objectStatus',
+            'identifier': 'identifier',
+            'metadata': 'metadata'
+        }
+
+        self._total_message_count = None
+        self._error_message_count = None
+        self._warn_message_count = None
+        self._info_message_count = None
+        self._validation_messages = None
+        self._key = None
+        self._model_type = None
+        self._model_version = None
+        self._parent_ref = None
+        self._name = None
+        self._description = None
+        self._object_version = None
+        self._object_status = None
+        self._identifier = None
+        self._metadata = None
+
+    @property
+    def total_message_count(self):
+        """
+        Gets the total_message_count of this PipelineValidationSummary.
+        The total number of validation messages.
+
+
+        :return: The total_message_count of this PipelineValidationSummary.
+        :rtype: int
+        """
+        return self._total_message_count
+
+    @total_message_count.setter
+    def total_message_count(self, total_message_count):
+        """
+        Sets the total_message_count of this PipelineValidationSummary.
+        The total number of validation messages.
+
+
+        :param total_message_count: The total_message_count of this PipelineValidationSummary.
+        :type: int
+        """
+        self._total_message_count = total_message_count
+
+    @property
+    def error_message_count(self):
+        """
+        Gets the error_message_count of this PipelineValidationSummary.
+        The total number of validation error messages.
+
+
+        :return: The error_message_count of this PipelineValidationSummary.
+        :rtype: int
+        """
+        return self._error_message_count
+
+    @error_message_count.setter
+    def error_message_count(self, error_message_count):
+        """
+        Sets the error_message_count of this PipelineValidationSummary.
+        The total number of validation error messages.
+
+
+        :param error_message_count: The error_message_count of this PipelineValidationSummary.
+        :type: int
+        """
+        self._error_message_count = error_message_count
+
+    @property
+    def warn_message_count(self):
+        """
+        Gets the warn_message_count of this PipelineValidationSummary.
+        The total number of validation warning messages.
+
+
+        :return: The warn_message_count of this PipelineValidationSummary.
+        :rtype: int
+        """
+        return self._warn_message_count
+
+    @warn_message_count.setter
+    def warn_message_count(self, warn_message_count):
+        """
+        Sets the warn_message_count of this PipelineValidationSummary.
+        The total number of validation warning messages.
+
+
+        :param warn_message_count: The warn_message_count of this PipelineValidationSummary.
+        :type: int
+        """
+        self._warn_message_count = warn_message_count
+
+    @property
+    def info_message_count(self):
+        """
+        Gets the info_message_count of this PipelineValidationSummary.
+        The total number of validation information messages.
+
+
+        :return: The info_message_count of this PipelineValidationSummary.
+        :rtype: int
+        """
+        return self._info_message_count
+
+    @info_message_count.setter
+    def info_message_count(self, info_message_count):
+        """
+        Sets the info_message_count of this PipelineValidationSummary.
+        The total number of validation information messages.
+
+
+        :param info_message_count: The info_message_count of this PipelineValidationSummary.
+        :type: int
+        """
+        self._info_message_count = info_message_count
+
+    @property
+    def validation_messages(self):
+        """
+        Gets the validation_messages of this PipelineValidationSummary.
+        The detailed information of the pipeline object validation.
+
+
+        :return: The validation_messages of this PipelineValidationSummary.
+        :rtype: dict(str, list[ValidationMessage])
+        """
+        return self._validation_messages
+
+    @validation_messages.setter
+    def validation_messages(self, validation_messages):
+        """
+        Sets the validation_messages of this PipelineValidationSummary.
+        The detailed information of the pipeline object validation.
+
+
+        :param validation_messages: The validation_messages of this PipelineValidationSummary.
+        :type: dict(str, list[ValidationMessage])
+        """
+        self._validation_messages = validation_messages
+
+    @property
+    def key(self):
+        """
+        Gets the key of this PipelineValidationSummary.
+        Objects will use a 36 character key as unique ID. It is system generated and cannot be modified.
+
+
+        :return: The key of this PipelineValidationSummary.
+        :rtype: str
+        """
+        return self._key
+
+    @key.setter
+    def key(self, key):
+        """
+        Sets the key of this PipelineValidationSummary.
+        Objects will use a 36 character key as unique ID. It is system generated and cannot be modified.
+
+
+        :param key: The key of this PipelineValidationSummary.
+        :type: str
+        """
+        self._key = key
+
+    @property
+    def model_type(self):
+        """
+        Gets the model_type of this PipelineValidationSummary.
+        The type of the object.
+
+
+        :return: The model_type of this PipelineValidationSummary.
+        :rtype: str
+        """
+        return self._model_type
+
+    @model_type.setter
+    def model_type(self, model_type):
+        """
+        Sets the model_type of this PipelineValidationSummary.
+        The type of the object.
+
+
+        :param model_type: The model_type of this PipelineValidationSummary.
+        :type: str
+        """
+        self._model_type = model_type
+
+    @property
+    def model_version(self):
+        """
+        Gets the model_version of this PipelineValidationSummary.
+        This is a version number that is used by the service to upgrade objects if needed through releases of the service.
+
+
+        :return: The model_version of this PipelineValidationSummary.
+        :rtype: str
+        """
+        return self._model_version
+
+    @model_version.setter
+    def model_version(self, model_version):
+        """
+        Sets the model_version of this PipelineValidationSummary.
+        This is a version number that is used by the service to upgrade objects if needed through releases of the service.
+
+
+        :param model_version: The model_version of this PipelineValidationSummary.
+        :type: str
+        """
+        self._model_version = model_version
+
+    @property
+    def parent_ref(self):
+        """
+        Gets the parent_ref of this PipelineValidationSummary.
+
+        :return: The parent_ref of this PipelineValidationSummary.
+        :rtype: oci.data_integration.models.ParentReference
+        """
+        return self._parent_ref
+
+    @parent_ref.setter
+    def parent_ref(self, parent_ref):
+        """
+        Sets the parent_ref of this PipelineValidationSummary.
+
+        :param parent_ref: The parent_ref of this PipelineValidationSummary.
+        :type: oci.data_integration.models.ParentReference
+        """
+        self._parent_ref = parent_ref
+
+    @property
+    def name(self):
+        """
+        Gets the name of this PipelineValidationSummary.
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
+
+
+        :return: The name of this PipelineValidationSummary.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this PipelineValidationSummary.
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
+
+
+        :param name: The name of this PipelineValidationSummary.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def description(self):
+        """
+        Gets the description of this PipelineValidationSummary.
+        Detailed description for the object.
+
+
+        :return: The description of this PipelineValidationSummary.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this PipelineValidationSummary.
+        Detailed description for the object.
+
+
+        :param description: The description of this PipelineValidationSummary.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def object_version(self):
+        """
+        Gets the object_version of this PipelineValidationSummary.
+        This is used by the service for optimistic locking of the object, to prevent multiple users from simultaneously updating the object.
+
+
+        :return: The object_version of this PipelineValidationSummary.
+        :rtype: int
+        """
+        return self._object_version
+
+    @object_version.setter
+    def object_version(self, object_version):
+        """
+        Sets the object_version of this PipelineValidationSummary.
+        This is used by the service for optimistic locking of the object, to prevent multiple users from simultaneously updating the object.
+
+
+        :param object_version: The object_version of this PipelineValidationSummary.
+        :type: int
+        """
+        self._object_version = object_version
+
+    @property
+    def object_status(self):
+        """
+        Gets the object_status of this PipelineValidationSummary.
+        The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+
+
+        :return: The object_status of this PipelineValidationSummary.
+        :rtype: int
+        """
+        return self._object_status
+
+    @object_status.setter
+    def object_status(self, object_status):
+        """
+        Sets the object_status of this PipelineValidationSummary.
+        The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+
+
+        :param object_status: The object_status of this PipelineValidationSummary.
+        :type: int
+        """
+        self._object_status = object_status
+
+    @property
+    def identifier(self):
+        """
+        Gets the identifier of this PipelineValidationSummary.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
+
+
+        :return: The identifier of this PipelineValidationSummary.
+        :rtype: str
+        """
+        return self._identifier
+
+    @identifier.setter
+    def identifier(self, identifier):
+        """
+        Sets the identifier of this PipelineValidationSummary.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
+
+
+        :param identifier: The identifier of this PipelineValidationSummary.
+        :type: str
+        """
+        self._identifier = identifier
+
+    @property
+    def metadata(self):
+        """
+        Gets the metadata of this PipelineValidationSummary.
+
+        :return: The metadata of this PipelineValidationSummary.
+        :rtype: oci.data_integration.models.ObjectMetadata
+        """
+        return self._metadata
+
+    @metadata.setter
+    def metadata(self, metadata):
+        """
+        Sets the metadata of this PipelineValidationSummary.
+
+        :param metadata: The metadata of this PipelineValidationSummary.
+        :type: oci.data_integration.models.ObjectMetadata
+        """
+        self._metadata = metadata
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/pipeline_validation_summary_collection.py
+++ b/src/oci/data_integration/models/pipeline_validation_summary_collection.py
@@ -1,0 +1,70 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class PipelineValidationSummaryCollection(object):
+    """
+    A list of pipeline validation summaries.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new PipelineValidationSummaryCollection object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param items:
+            The value to assign to the items property of this PipelineValidationSummaryCollection.
+        :type items: list[oci.data_integration.models.PipelineValidationSummary]
+
+        """
+        self.swagger_types = {
+            'items': 'list[PipelineValidationSummary]'
+        }
+
+        self.attribute_map = {
+            'items': 'items'
+        }
+
+        self._items = None
+
+    @property
+    def items(self):
+        """
+        **[Required]** Gets the items of this PipelineValidationSummaryCollection.
+        The array of validation summaries.
+
+
+        :return: The items of this PipelineValidationSummaryCollection.
+        :rtype: list[oci.data_integration.models.PipelineValidationSummary]
+        """
+        return self._items
+
+    @items.setter
+    def items(self, items):
+        """
+        Sets the items of this PipelineValidationSummaryCollection.
+        The array of validation summaries.
+
+
+        :param items: The items of this PipelineValidationSummaryCollection.
+        :type: list[oci.data_integration.models.PipelineValidationSummary]
+        """
+        self._items = items
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/primary_key.py
+++ b/src/oci/data_integration/models/primary_key.py
@@ -2,21 +2,27 @@
 # Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
 # This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 
-
+from .unique_key import UniqueKey
 from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
 from oci.decorators import init_model_state_from_kwargs
 
 
 @init_model_state_from_kwargs
-class PrimaryKey(object):
+class PrimaryKey(UniqueKey):
     """
     The primary key object.
     """
 
     def __init__(self, **kwargs):
         """
-        Initializes a new PrimaryKey object with values from keyword arguments.
+        Initializes a new PrimaryKey object with values from keyword arguments. The default value of the :py:attr:`~oci.data_integration.models.PrimaryKey.model_type` attribute
+        of this class is ``PRIMARY_KEY`` and it should not be changed.
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param model_type:
+            The value to assign to the model_type property of this PrimaryKey.
+            Allowed values for this property are: "PRIMARY_KEY", "UNIQUE_KEY"
+        :type model_type: str
 
         :param key:
             The value to assign to the key property of this PrimaryKey.
@@ -44,6 +50,7 @@ class PrimaryKey(object):
 
         """
         self.swagger_types = {
+            'model_type': 'str',
             'key': 'str',
             'model_version': 'str',
             'parent_ref': 'ParentReference',
@@ -53,6 +60,7 @@ class PrimaryKey(object):
         }
 
         self.attribute_map = {
+            'model_type': 'modelType',
             'key': 'key',
             'model_version': 'modelVersion',
             'parent_ref': 'parentRef',
@@ -61,152 +69,14 @@ class PrimaryKey(object):
             'object_status': 'objectStatus'
         }
 
+        self._model_type = None
         self._key = None
         self._model_version = None
         self._parent_ref = None
         self._name = None
         self._attribute_refs = None
         self._object_status = None
-
-    @property
-    def key(self):
-        """
-        Gets the key of this PrimaryKey.
-        The object key.
-
-
-        :return: The key of this PrimaryKey.
-        :rtype: str
-        """
-        return self._key
-
-    @key.setter
-    def key(self, key):
-        """
-        Sets the key of this PrimaryKey.
-        The object key.
-
-
-        :param key: The key of this PrimaryKey.
-        :type: str
-        """
-        self._key = key
-
-    @property
-    def model_version(self):
-        """
-        Gets the model_version of this PrimaryKey.
-        The object's model version.
-
-
-        :return: The model_version of this PrimaryKey.
-        :rtype: str
-        """
-        return self._model_version
-
-    @model_version.setter
-    def model_version(self, model_version):
-        """
-        Sets the model_version of this PrimaryKey.
-        The object's model version.
-
-
-        :param model_version: The model_version of this PrimaryKey.
-        :type: str
-        """
-        self._model_version = model_version
-
-    @property
-    def parent_ref(self):
-        """
-        Gets the parent_ref of this PrimaryKey.
-
-        :return: The parent_ref of this PrimaryKey.
-        :rtype: oci.data_integration.models.ParentReference
-        """
-        return self._parent_ref
-
-    @parent_ref.setter
-    def parent_ref(self, parent_ref):
-        """
-        Sets the parent_ref of this PrimaryKey.
-
-        :param parent_ref: The parent_ref of this PrimaryKey.
-        :type: oci.data_integration.models.ParentReference
-        """
-        self._parent_ref = parent_ref
-
-    @property
-    def name(self):
-        """
-        Gets the name of this PrimaryKey.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
-
-
-        :return: The name of this PrimaryKey.
-        :rtype: str
-        """
-        return self._name
-
-    @name.setter
-    def name(self, name):
-        """
-        Sets the name of this PrimaryKey.
-        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
-
-
-        :param name: The name of this PrimaryKey.
-        :type: str
-        """
-        self._name = name
-
-    @property
-    def attribute_refs(self):
-        """
-        Gets the attribute_refs of this PrimaryKey.
-        An array of attribute references.
-
-
-        :return: The attribute_refs of this PrimaryKey.
-        :rtype: list[oci.data_integration.models.KeyAttribute]
-        """
-        return self._attribute_refs
-
-    @attribute_refs.setter
-    def attribute_refs(self, attribute_refs):
-        """
-        Sets the attribute_refs of this PrimaryKey.
-        An array of attribute references.
-
-
-        :param attribute_refs: The attribute_refs of this PrimaryKey.
-        :type: list[oci.data_integration.models.KeyAttribute]
-        """
-        self._attribute_refs = attribute_refs
-
-    @property
-    def object_status(self):
-        """
-        Gets the object_status of this PrimaryKey.
-        The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
-
-
-        :return: The object_status of this PrimaryKey.
-        :rtype: int
-        """
-        return self._object_status
-
-    @object_status.setter
-    def object_status(self, object_status):
-        """
-        Sets the object_status of this PrimaryKey.
-        The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
-
-
-        :param object_status: The object_status of this PrimaryKey.
-        :type: int
-        """
-        self._object_status = object_status
+        self._model_type = 'PRIMARY_KEY'
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/data_integration/models/projection.py
+++ b/src/oci/data_integration/models/projection.py
@@ -21,7 +21,7 @@ class Projection(Operator):
 
         :param model_type:
             The value to assign to the model_type property of this Projection.
-            Allowed values for this property are: "SOURCE_OPERATOR", "FILTER_OPERATOR", "JOINER_OPERATOR", "AGGREGATOR_OPERATOR", "PROJECTION_OPERATOR", "TARGET_OPERATOR", "DISTINCT_OPERATOR", "SORT_OPERATOR"
+            Allowed values for this property are: "SOURCE_OPERATOR", "FILTER_OPERATOR", "JOINER_OPERATOR", "AGGREGATOR_OPERATOR", "PROJECTION_OPERATOR", "TARGET_OPERATOR", "DISTINCT_OPERATOR", "SORT_OPERATOR", "UNION_OPERATOR", "INTERSECT_OPERATOR", "MINUS_OPERATOR", "MERGE_OPERATOR", "START_OPERATOR", "END_OPERATOR", "PIPELINE_OPERATOR", "REST_OPERATOR", "TASK_OPERATOR"
         :type model_type: str
 
         :param key:

--- a/src/oci/data_integration/models/published_object.py
+++ b/src/oci/data_integration/models/published_object.py
@@ -21,19 +21,24 @@ class PublishedObject(object):
     #: This constant has a value of "DATA_LOADER_TASK"
     MODEL_TYPE_DATA_LOADER_TASK = "DATA_LOADER_TASK"
 
+    #: A constant which can be used with the model_type property of a PublishedObject.
+    #: This constant has a value of "PIPELINE_TASK"
+    MODEL_TYPE_PIPELINE_TASK = "PIPELINE_TASK"
+
     def __init__(self, **kwargs):
         """
         Initializes a new PublishedObject object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
         to a service operations then you should favor using a subclass over the base class:
 
         * :class:`~oci.data_integration.models.PublishedObjectFromDataLoaderTask`
+        * :class:`~oci.data_integration.models.PublishedObjectFromPipelineTask`
         * :class:`~oci.data_integration.models.PublishedObjectFromIntegrationTask`
 
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
         :param model_type:
             The value to assign to the model_type property of this PublishedObject.
-            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type model_type: str
 
@@ -115,6 +120,9 @@ class PublishedObject(object):
         if type == 'DATA_LOADER_TASK':
             return 'PublishedObjectFromDataLoaderTask'
 
+        if type == 'PIPELINE_TASK':
+            return 'PublishedObjectFromPipelineTask'
+
         if type == 'INTEGRATION_TASK':
             return 'PublishedObjectFromIntegrationTask'
         else:
@@ -126,7 +134,7 @@ class PublishedObject(object):
         **[Required]** Gets the model_type of this PublishedObject.
         The type of the published object.
 
-        Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -145,7 +153,7 @@ class PublishedObject(object):
         :param model_type: The model_type of this PublishedObject.
         :type: str
         """
-        allowed_values = ["INTEGRATION_TASK", "DATA_LOADER_TASK"]
+        allowed_values = ["INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK"]
         if not value_allowed_none_or_none_sentinel(model_type, allowed_values):
             model_type = 'UNKNOWN_ENUM_VALUE'
         self._model_type = model_type

--- a/src/oci/data_integration/models/published_object_from_data_loader_task.py
+++ b/src/oci/data_integration/models/published_object_from_data_loader_task.py
@@ -21,7 +21,7 @@ class PublishedObjectFromDataLoaderTask(PublishedObject):
 
         :param model_type:
             The value to assign to the model_type property of this PublishedObjectFromDataLoaderTask.
-            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK"
+            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK"
         :type model_type: str
 
         :param key:

--- a/src/oci/data_integration/models/published_object_from_integration_task.py
+++ b/src/oci/data_integration/models/published_object_from_integration_task.py
@@ -21,7 +21,7 @@ class PublishedObjectFromIntegrationTask(PublishedObject):
 
         :param model_type:
             The value to assign to the model_type property of this PublishedObjectFromIntegrationTask.
-            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK"
+            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK"
         :type model_type: str
 
         :param key:

--- a/src/oci/data_integration/models/published_object_from_pipeline_task.py
+++ b/src/oci/data_integration/models/published_object_from_pipeline_task.py
@@ -1,0 +1,279 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .published_object import PublishedObject
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class PublishedObjectFromPipelineTask(PublishedObject):
+    """
+    The pipeline task published object.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new PublishedObjectFromPipelineTask object with values from keyword arguments. The default value of the :py:attr:`~oci.data_integration.models.PublishedObjectFromPipelineTask.model_type` attribute
+        of this class is ``PIPELINE_TASK`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param model_type:
+            The value to assign to the model_type property of this PublishedObjectFromPipelineTask.
+            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK"
+        :type model_type: str
+
+        :param key:
+            The value to assign to the key property of this PublishedObjectFromPipelineTask.
+        :type key: str
+
+        :param model_version:
+            The value to assign to the model_version property of this PublishedObjectFromPipelineTask.
+        :type model_version: str
+
+        :param parent_ref:
+            The value to assign to the parent_ref property of this PublishedObjectFromPipelineTask.
+        :type parent_ref: oci.data_integration.models.ParentReference
+
+        :param name:
+            The value to assign to the name property of this PublishedObjectFromPipelineTask.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this PublishedObjectFromPipelineTask.
+        :type description: str
+
+        :param object_version:
+            The value to assign to the object_version property of this PublishedObjectFromPipelineTask.
+        :type object_version: int
+
+        :param object_status:
+            The value to assign to the object_status property of this PublishedObjectFromPipelineTask.
+        :type object_status: int
+
+        :param identifier:
+            The value to assign to the identifier property of this PublishedObjectFromPipelineTask.
+        :type identifier: str
+
+        :param input_ports:
+            The value to assign to the input_ports property of this PublishedObjectFromPipelineTask.
+        :type input_ports: list[oci.data_integration.models.InputPort]
+
+        :param output_ports:
+            The value to assign to the output_ports property of this PublishedObjectFromPipelineTask.
+        :type output_ports: list[oci.data_integration.models.OutputPort]
+
+        :param parameters:
+            The value to assign to the parameters property of this PublishedObjectFromPipelineTask.
+        :type parameters: list[oci.data_integration.models.Parameter]
+
+        :param op_config_values:
+            The value to assign to the op_config_values property of this PublishedObjectFromPipelineTask.
+        :type op_config_values: oci.data_integration.models.ConfigValues
+
+        :param config_provider_delegate:
+            The value to assign to the config_provider_delegate property of this PublishedObjectFromPipelineTask.
+        :type config_provider_delegate: oci.data_integration.models.ConfigProvider
+
+        :param pipeline:
+            The value to assign to the pipeline property of this PublishedObjectFromPipelineTask.
+        :type pipeline: oci.data_integration.models.Pipeline
+
+        """
+        self.swagger_types = {
+            'model_type': 'str',
+            'key': 'str',
+            'model_version': 'str',
+            'parent_ref': 'ParentReference',
+            'name': 'str',
+            'description': 'str',
+            'object_version': 'int',
+            'object_status': 'int',
+            'identifier': 'str',
+            'input_ports': 'list[InputPort]',
+            'output_ports': 'list[OutputPort]',
+            'parameters': 'list[Parameter]',
+            'op_config_values': 'ConfigValues',
+            'config_provider_delegate': 'ConfigProvider',
+            'pipeline': 'Pipeline'
+        }
+
+        self.attribute_map = {
+            'model_type': 'modelType',
+            'key': 'key',
+            'model_version': 'modelVersion',
+            'parent_ref': 'parentRef',
+            'name': 'name',
+            'description': 'description',
+            'object_version': 'objectVersion',
+            'object_status': 'objectStatus',
+            'identifier': 'identifier',
+            'input_ports': 'inputPorts',
+            'output_ports': 'outputPorts',
+            'parameters': 'parameters',
+            'op_config_values': 'opConfigValues',
+            'config_provider_delegate': 'configProviderDelegate',
+            'pipeline': 'pipeline'
+        }
+
+        self._model_type = None
+        self._key = None
+        self._model_version = None
+        self._parent_ref = None
+        self._name = None
+        self._description = None
+        self._object_version = None
+        self._object_status = None
+        self._identifier = None
+        self._input_ports = None
+        self._output_ports = None
+        self._parameters = None
+        self._op_config_values = None
+        self._config_provider_delegate = None
+        self._pipeline = None
+        self._model_type = 'PIPELINE_TASK'
+
+    @property
+    def input_ports(self):
+        """
+        Gets the input_ports of this PublishedObjectFromPipelineTask.
+        An array of input ports.
+
+
+        :return: The input_ports of this PublishedObjectFromPipelineTask.
+        :rtype: list[oci.data_integration.models.InputPort]
+        """
+        return self._input_ports
+
+    @input_ports.setter
+    def input_ports(self, input_ports):
+        """
+        Sets the input_ports of this PublishedObjectFromPipelineTask.
+        An array of input ports.
+
+
+        :param input_ports: The input_ports of this PublishedObjectFromPipelineTask.
+        :type: list[oci.data_integration.models.InputPort]
+        """
+        self._input_ports = input_ports
+
+    @property
+    def output_ports(self):
+        """
+        Gets the output_ports of this PublishedObjectFromPipelineTask.
+        An array of output ports.
+
+
+        :return: The output_ports of this PublishedObjectFromPipelineTask.
+        :rtype: list[oci.data_integration.models.OutputPort]
+        """
+        return self._output_ports
+
+    @output_ports.setter
+    def output_ports(self, output_ports):
+        """
+        Sets the output_ports of this PublishedObjectFromPipelineTask.
+        An array of output ports.
+
+
+        :param output_ports: The output_ports of this PublishedObjectFromPipelineTask.
+        :type: list[oci.data_integration.models.OutputPort]
+        """
+        self._output_ports = output_ports
+
+    @property
+    def parameters(self):
+        """
+        Gets the parameters of this PublishedObjectFromPipelineTask.
+        An array of parameters.
+
+
+        :return: The parameters of this PublishedObjectFromPipelineTask.
+        :rtype: list[oci.data_integration.models.Parameter]
+        """
+        return self._parameters
+
+    @parameters.setter
+    def parameters(self, parameters):
+        """
+        Sets the parameters of this PublishedObjectFromPipelineTask.
+        An array of parameters.
+
+
+        :param parameters: The parameters of this PublishedObjectFromPipelineTask.
+        :type: list[oci.data_integration.models.Parameter]
+        """
+        self._parameters = parameters
+
+    @property
+    def op_config_values(self):
+        """
+        Gets the op_config_values of this PublishedObjectFromPipelineTask.
+
+        :return: The op_config_values of this PublishedObjectFromPipelineTask.
+        :rtype: oci.data_integration.models.ConfigValues
+        """
+        return self._op_config_values
+
+    @op_config_values.setter
+    def op_config_values(self, op_config_values):
+        """
+        Sets the op_config_values of this PublishedObjectFromPipelineTask.
+
+        :param op_config_values: The op_config_values of this PublishedObjectFromPipelineTask.
+        :type: oci.data_integration.models.ConfigValues
+        """
+        self._op_config_values = op_config_values
+
+    @property
+    def config_provider_delegate(self):
+        """
+        Gets the config_provider_delegate of this PublishedObjectFromPipelineTask.
+
+        :return: The config_provider_delegate of this PublishedObjectFromPipelineTask.
+        :rtype: oci.data_integration.models.ConfigProvider
+        """
+        return self._config_provider_delegate
+
+    @config_provider_delegate.setter
+    def config_provider_delegate(self, config_provider_delegate):
+        """
+        Sets the config_provider_delegate of this PublishedObjectFromPipelineTask.
+
+        :param config_provider_delegate: The config_provider_delegate of this PublishedObjectFromPipelineTask.
+        :type: oci.data_integration.models.ConfigProvider
+        """
+        self._config_provider_delegate = config_provider_delegate
+
+    @property
+    def pipeline(self):
+        """
+        Gets the pipeline of this PublishedObjectFromPipelineTask.
+
+        :return: The pipeline of this PublishedObjectFromPipelineTask.
+        :rtype: oci.data_integration.models.Pipeline
+        """
+        return self._pipeline
+
+    @pipeline.setter
+    def pipeline(self, pipeline):
+        """
+        Sets the pipeline of this PublishedObjectFromPipelineTask.
+
+        :param pipeline: The pipeline of this PublishedObjectFromPipelineTask.
+        :type: oci.data_integration.models.Pipeline
+        """
+        self._pipeline = pipeline
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/published_object_from_pipeline_task_summary.py
+++ b/src/oci/data_integration/models/published_object_from_pipeline_task_summary.py
@@ -1,0 +1,286 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .published_object_summary import PublishedObjectSummary
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class PublishedObjectFromPipelineTaskSummary(PublishedObjectSummary):
+    """
+    The pipeline task published object summary.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new PublishedObjectFromPipelineTaskSummary object with values from keyword arguments. The default value of the :py:attr:`~oci.data_integration.models.PublishedObjectFromPipelineTaskSummary.model_type` attribute
+        of this class is ``PIPELINE_TASK`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param model_type:
+            The value to assign to the model_type property of this PublishedObjectFromPipelineTaskSummary.
+            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK"
+        :type model_type: str
+
+        :param key:
+            The value to assign to the key property of this PublishedObjectFromPipelineTaskSummary.
+        :type key: str
+
+        :param model_version:
+            The value to assign to the model_version property of this PublishedObjectFromPipelineTaskSummary.
+        :type model_version: str
+
+        :param parent_ref:
+            The value to assign to the parent_ref property of this PublishedObjectFromPipelineTaskSummary.
+        :type parent_ref: oci.data_integration.models.ParentReference
+
+        :param name:
+            The value to assign to the name property of this PublishedObjectFromPipelineTaskSummary.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this PublishedObjectFromPipelineTaskSummary.
+        :type description: str
+
+        :param object_version:
+            The value to assign to the object_version property of this PublishedObjectFromPipelineTaskSummary.
+        :type object_version: int
+
+        :param object_status:
+            The value to assign to the object_status property of this PublishedObjectFromPipelineTaskSummary.
+        :type object_status: int
+
+        :param identifier:
+            The value to assign to the identifier property of this PublishedObjectFromPipelineTaskSummary.
+        :type identifier: str
+
+        :param metadata:
+            The value to assign to the metadata property of this PublishedObjectFromPipelineTaskSummary.
+        :type metadata: oci.data_integration.models.ObjectMetadata
+
+        :param input_ports:
+            The value to assign to the input_ports property of this PublishedObjectFromPipelineTaskSummary.
+        :type input_ports: list[oci.data_integration.models.InputPort]
+
+        :param output_ports:
+            The value to assign to the output_ports property of this PublishedObjectFromPipelineTaskSummary.
+        :type output_ports: list[oci.data_integration.models.OutputPort]
+
+        :param parameters:
+            The value to assign to the parameters property of this PublishedObjectFromPipelineTaskSummary.
+        :type parameters: list[oci.data_integration.models.Parameter]
+
+        :param op_config_values:
+            The value to assign to the op_config_values property of this PublishedObjectFromPipelineTaskSummary.
+        :type op_config_values: oci.data_integration.models.ConfigValues
+
+        :param config_provider_delegate:
+            The value to assign to the config_provider_delegate property of this PublishedObjectFromPipelineTaskSummary.
+        :type config_provider_delegate: oci.data_integration.models.ConfigProvider
+
+        :param pipeline:
+            The value to assign to the pipeline property of this PublishedObjectFromPipelineTaskSummary.
+        :type pipeline: oci.data_integration.models.Pipeline
+
+        """
+        self.swagger_types = {
+            'model_type': 'str',
+            'key': 'str',
+            'model_version': 'str',
+            'parent_ref': 'ParentReference',
+            'name': 'str',
+            'description': 'str',
+            'object_version': 'int',
+            'object_status': 'int',
+            'identifier': 'str',
+            'metadata': 'ObjectMetadata',
+            'input_ports': 'list[InputPort]',
+            'output_ports': 'list[OutputPort]',
+            'parameters': 'list[Parameter]',
+            'op_config_values': 'ConfigValues',
+            'config_provider_delegate': 'ConfigProvider',
+            'pipeline': 'Pipeline'
+        }
+
+        self.attribute_map = {
+            'model_type': 'modelType',
+            'key': 'key',
+            'model_version': 'modelVersion',
+            'parent_ref': 'parentRef',
+            'name': 'name',
+            'description': 'description',
+            'object_version': 'objectVersion',
+            'object_status': 'objectStatus',
+            'identifier': 'identifier',
+            'metadata': 'metadata',
+            'input_ports': 'inputPorts',
+            'output_ports': 'outputPorts',
+            'parameters': 'parameters',
+            'op_config_values': 'opConfigValues',
+            'config_provider_delegate': 'configProviderDelegate',
+            'pipeline': 'pipeline'
+        }
+
+        self._model_type = None
+        self._key = None
+        self._model_version = None
+        self._parent_ref = None
+        self._name = None
+        self._description = None
+        self._object_version = None
+        self._object_status = None
+        self._identifier = None
+        self._metadata = None
+        self._input_ports = None
+        self._output_ports = None
+        self._parameters = None
+        self._op_config_values = None
+        self._config_provider_delegate = None
+        self._pipeline = None
+        self._model_type = 'PIPELINE_TASK'
+
+    @property
+    def input_ports(self):
+        """
+        Gets the input_ports of this PublishedObjectFromPipelineTaskSummary.
+        An array of input ports.
+
+
+        :return: The input_ports of this PublishedObjectFromPipelineTaskSummary.
+        :rtype: list[oci.data_integration.models.InputPort]
+        """
+        return self._input_ports
+
+    @input_ports.setter
+    def input_ports(self, input_ports):
+        """
+        Sets the input_ports of this PublishedObjectFromPipelineTaskSummary.
+        An array of input ports.
+
+
+        :param input_ports: The input_ports of this PublishedObjectFromPipelineTaskSummary.
+        :type: list[oci.data_integration.models.InputPort]
+        """
+        self._input_ports = input_ports
+
+    @property
+    def output_ports(self):
+        """
+        Gets the output_ports of this PublishedObjectFromPipelineTaskSummary.
+        An array of output ports.
+
+
+        :return: The output_ports of this PublishedObjectFromPipelineTaskSummary.
+        :rtype: list[oci.data_integration.models.OutputPort]
+        """
+        return self._output_ports
+
+    @output_ports.setter
+    def output_ports(self, output_ports):
+        """
+        Sets the output_ports of this PublishedObjectFromPipelineTaskSummary.
+        An array of output ports.
+
+
+        :param output_ports: The output_ports of this PublishedObjectFromPipelineTaskSummary.
+        :type: list[oci.data_integration.models.OutputPort]
+        """
+        self._output_ports = output_ports
+
+    @property
+    def parameters(self):
+        """
+        Gets the parameters of this PublishedObjectFromPipelineTaskSummary.
+        An array of parameters.
+
+
+        :return: The parameters of this PublishedObjectFromPipelineTaskSummary.
+        :rtype: list[oci.data_integration.models.Parameter]
+        """
+        return self._parameters
+
+    @parameters.setter
+    def parameters(self, parameters):
+        """
+        Sets the parameters of this PublishedObjectFromPipelineTaskSummary.
+        An array of parameters.
+
+
+        :param parameters: The parameters of this PublishedObjectFromPipelineTaskSummary.
+        :type: list[oci.data_integration.models.Parameter]
+        """
+        self._parameters = parameters
+
+    @property
+    def op_config_values(self):
+        """
+        Gets the op_config_values of this PublishedObjectFromPipelineTaskSummary.
+
+        :return: The op_config_values of this PublishedObjectFromPipelineTaskSummary.
+        :rtype: oci.data_integration.models.ConfigValues
+        """
+        return self._op_config_values
+
+    @op_config_values.setter
+    def op_config_values(self, op_config_values):
+        """
+        Sets the op_config_values of this PublishedObjectFromPipelineTaskSummary.
+
+        :param op_config_values: The op_config_values of this PublishedObjectFromPipelineTaskSummary.
+        :type: oci.data_integration.models.ConfigValues
+        """
+        self._op_config_values = op_config_values
+
+    @property
+    def config_provider_delegate(self):
+        """
+        Gets the config_provider_delegate of this PublishedObjectFromPipelineTaskSummary.
+
+        :return: The config_provider_delegate of this PublishedObjectFromPipelineTaskSummary.
+        :rtype: oci.data_integration.models.ConfigProvider
+        """
+        return self._config_provider_delegate
+
+    @config_provider_delegate.setter
+    def config_provider_delegate(self, config_provider_delegate):
+        """
+        Sets the config_provider_delegate of this PublishedObjectFromPipelineTaskSummary.
+
+        :param config_provider_delegate: The config_provider_delegate of this PublishedObjectFromPipelineTaskSummary.
+        :type: oci.data_integration.models.ConfigProvider
+        """
+        self._config_provider_delegate = config_provider_delegate
+
+    @property
+    def pipeline(self):
+        """
+        Gets the pipeline of this PublishedObjectFromPipelineTaskSummary.
+
+        :return: The pipeline of this PublishedObjectFromPipelineTaskSummary.
+        :rtype: oci.data_integration.models.Pipeline
+        """
+        return self._pipeline
+
+    @pipeline.setter
+    def pipeline(self, pipeline):
+        """
+        Sets the pipeline of this PublishedObjectFromPipelineTaskSummary.
+
+        :param pipeline: The pipeline of this PublishedObjectFromPipelineTaskSummary.
+        :type: oci.data_integration.models.Pipeline
+        """
+        self._pipeline = pipeline
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/published_object_summary.py
+++ b/src/oci/data_integration/models/published_object_summary.py
@@ -21,11 +21,16 @@ class PublishedObjectSummary(object):
     #: This constant has a value of "DATA_LOADER_TASK"
     MODEL_TYPE_DATA_LOADER_TASK = "DATA_LOADER_TASK"
 
+    #: A constant which can be used with the model_type property of a PublishedObjectSummary.
+    #: This constant has a value of "PIPELINE_TASK"
+    MODEL_TYPE_PIPELINE_TASK = "PIPELINE_TASK"
+
     def __init__(self, **kwargs):
         """
         Initializes a new PublishedObjectSummary object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
         to a service operations then you should favor using a subclass over the base class:
 
+        * :class:`~oci.data_integration.models.PublishedObjectFromPipelineTaskSummary`
         * :class:`~oci.data_integration.models.PublishedObjectSummaryFromIntegrationTask`
         * :class:`~oci.data_integration.models.PublishedObjectSummaryFromDataLoaderTask`
 
@@ -33,7 +38,7 @@ class PublishedObjectSummary(object):
 
         :param model_type:
             The value to assign to the model_type property of this PublishedObjectSummary.
-            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type model_type: str
 
@@ -119,6 +124,9 @@ class PublishedObjectSummary(object):
         """
         type = object_dictionary['modelType']
 
+        if type == 'PIPELINE_TASK':
+            return 'PublishedObjectFromPipelineTaskSummary'
+
         if type == 'INTEGRATION_TASK':
             return 'PublishedObjectSummaryFromIntegrationTask'
 
@@ -133,7 +141,7 @@ class PublishedObjectSummary(object):
         **[Required]** Gets the model_type of this PublishedObjectSummary.
         The type of the published object.
 
-        Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -152,7 +160,7 @@ class PublishedObjectSummary(object):
         :param model_type: The model_type of this PublishedObjectSummary.
         :type: str
         """
-        allowed_values = ["INTEGRATION_TASK", "DATA_LOADER_TASK"]
+        allowed_values = ["INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK"]
         if not value_allowed_none_or_none_sentinel(model_type, allowed_values):
             model_type = 'UNKNOWN_ENUM_VALUE'
         self._model_type = model_type

--- a/src/oci/data_integration/models/published_object_summary_from_data_loader_task.py
+++ b/src/oci/data_integration/models/published_object_summary_from_data_loader_task.py
@@ -21,7 +21,7 @@ class PublishedObjectSummaryFromDataLoaderTask(PublishedObjectSummary):
 
         :param model_type:
             The value to assign to the model_type property of this PublishedObjectSummaryFromDataLoaderTask.
-            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK"
+            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK"
         :type model_type: str
 
         :param key:

--- a/src/oci/data_integration/models/published_object_summary_from_integration_task.py
+++ b/src/oci/data_integration/models/published_object_summary_from_integration_task.py
@@ -21,7 +21,7 @@ class PublishedObjectSummaryFromIntegrationTask(PublishedObjectSummary):
 
         :param model_type:
             The value to assign to the model_type property of this PublishedObjectSummaryFromIntegrationTask.
-            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK"
+            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK"
         :type model_type: str
 
         :param key:

--- a/src/oci/data_integration/models/schedule.py
+++ b/src/oci/data_integration/models/schedule.py
@@ -1,0 +1,430 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class Schedule(object):
+    """
+    The schedule object
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new Schedule object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param key:
+            The value to assign to the key property of this Schedule.
+        :type key: str
+
+        :param model_version:
+            The value to assign to the model_version property of this Schedule.
+        :type model_version: str
+
+        :param model_type:
+            The value to assign to the model_type property of this Schedule.
+        :type model_type: str
+
+        :param parent_ref:
+            The value to assign to the parent_ref property of this Schedule.
+        :type parent_ref: oci.data_integration.models.ParentReference
+
+        :param name:
+            The value to assign to the name property of this Schedule.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this Schedule.
+        :type description: str
+
+        :param object_version:
+            The value to assign to the object_version property of this Schedule.
+        :type object_version: int
+
+        :param object_status:
+            The value to assign to the object_status property of this Schedule.
+        :type object_status: int
+
+        :param identifier:
+            The value to assign to the identifier property of this Schedule.
+        :type identifier: str
+
+        :param frequency_details:
+            The value to assign to the frequency_details property of this Schedule.
+        :type frequency_details: oci.data_integration.models.AbstractFrequencyDetails
+
+        :param timezone:
+            The value to assign to the timezone property of this Schedule.
+        :type timezone: str
+
+        :param is_daylight_adjustment_enabled:
+            The value to assign to the is_daylight_adjustment_enabled property of this Schedule.
+        :type is_daylight_adjustment_enabled: bool
+
+        :param metadata:
+            The value to assign to the metadata property of this Schedule.
+        :type metadata: oci.data_integration.models.ObjectMetadata
+
+        """
+        self.swagger_types = {
+            'key': 'str',
+            'model_version': 'str',
+            'model_type': 'str',
+            'parent_ref': 'ParentReference',
+            'name': 'str',
+            'description': 'str',
+            'object_version': 'int',
+            'object_status': 'int',
+            'identifier': 'str',
+            'frequency_details': 'AbstractFrequencyDetails',
+            'timezone': 'str',
+            'is_daylight_adjustment_enabled': 'bool',
+            'metadata': 'ObjectMetadata'
+        }
+
+        self.attribute_map = {
+            'key': 'key',
+            'model_version': 'modelVersion',
+            'model_type': 'modelType',
+            'parent_ref': 'parentRef',
+            'name': 'name',
+            'description': 'description',
+            'object_version': 'objectVersion',
+            'object_status': 'objectStatus',
+            'identifier': 'identifier',
+            'frequency_details': 'frequencyDetails',
+            'timezone': 'timezone',
+            'is_daylight_adjustment_enabled': 'isDaylightAdjustmentEnabled',
+            'metadata': 'metadata'
+        }
+
+        self._key = None
+        self._model_version = None
+        self._model_type = None
+        self._parent_ref = None
+        self._name = None
+        self._description = None
+        self._object_version = None
+        self._object_status = None
+        self._identifier = None
+        self._frequency_details = None
+        self._timezone = None
+        self._is_daylight_adjustment_enabled = None
+        self._metadata = None
+
+    @property
+    def key(self):
+        """
+        Gets the key of this Schedule.
+        Generated key that can be used in API calls to identify schedule. On scenarios where reference to the schedule is needed, a value can be passed in create.
+
+
+        :return: The key of this Schedule.
+        :rtype: str
+        """
+        return self._key
+
+    @key.setter
+    def key(self, key):
+        """
+        Sets the key of this Schedule.
+        Generated key that can be used in API calls to identify schedule. On scenarios where reference to the schedule is needed, a value can be passed in create.
+
+
+        :param key: The key of this Schedule.
+        :type: str
+        """
+        self._key = key
+
+    @property
+    def model_version(self):
+        """
+        Gets the model_version of this Schedule.
+        This is a version number that is used by the service to upgrade objects if needed through releases of the service.
+
+
+        :return: The model_version of this Schedule.
+        :rtype: str
+        """
+        return self._model_version
+
+    @model_version.setter
+    def model_version(self, model_version):
+        """
+        Sets the model_version of this Schedule.
+        This is a version number that is used by the service to upgrade objects if needed through releases of the service.
+
+
+        :param model_version: The model_version of this Schedule.
+        :type: str
+        """
+        self._model_version = model_version
+
+    @property
+    def model_type(self):
+        """
+        Gets the model_type of this Schedule.
+        The type of the object.
+
+
+        :return: The model_type of this Schedule.
+        :rtype: str
+        """
+        return self._model_type
+
+    @model_type.setter
+    def model_type(self, model_type):
+        """
+        Sets the model_type of this Schedule.
+        The type of the object.
+
+
+        :param model_type: The model_type of this Schedule.
+        :type: str
+        """
+        self._model_type = model_type
+
+    @property
+    def parent_ref(self):
+        """
+        Gets the parent_ref of this Schedule.
+
+        :return: The parent_ref of this Schedule.
+        :rtype: oci.data_integration.models.ParentReference
+        """
+        return self._parent_ref
+
+    @parent_ref.setter
+    def parent_ref(self, parent_ref):
+        """
+        Sets the parent_ref of this Schedule.
+
+        :param parent_ref: The parent_ref of this Schedule.
+        :type: oci.data_integration.models.ParentReference
+        """
+        self._parent_ref = parent_ref
+
+    @property
+    def name(self):
+        """
+        Gets the name of this Schedule.
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
+
+
+        :return: The name of this Schedule.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this Schedule.
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
+
+
+        :param name: The name of this Schedule.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def description(self):
+        """
+        Gets the description of this Schedule.
+        Detailed description for the object.
+
+
+        :return: The description of this Schedule.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this Schedule.
+        Detailed description for the object.
+
+
+        :param description: The description of this Schedule.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def object_version(self):
+        """
+        Gets the object_version of this Schedule.
+        This is used by the service for optimistic locking of the object, to prevent multiple users from simultaneously updating the object.
+
+
+        :return: The object_version of this Schedule.
+        :rtype: int
+        """
+        return self._object_version
+
+    @object_version.setter
+    def object_version(self, object_version):
+        """
+        Sets the object_version of this Schedule.
+        This is used by the service for optimistic locking of the object, to prevent multiple users from simultaneously updating the object.
+
+
+        :param object_version: The object_version of this Schedule.
+        :type: int
+        """
+        self._object_version = object_version
+
+    @property
+    def object_status(self):
+        """
+        Gets the object_status of this Schedule.
+        The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+
+
+        :return: The object_status of this Schedule.
+        :rtype: int
+        """
+        return self._object_status
+
+    @object_status.setter
+    def object_status(self, object_status):
+        """
+        Sets the object_status of this Schedule.
+        The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+
+
+        :param object_status: The object_status of this Schedule.
+        :type: int
+        """
+        self._object_status = object_status
+
+    @property
+    def identifier(self):
+        """
+        Gets the identifier of this Schedule.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
+
+
+        :return: The identifier of this Schedule.
+        :rtype: str
+        """
+        return self._identifier
+
+    @identifier.setter
+    def identifier(self, identifier):
+        """
+        Sets the identifier of this Schedule.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
+
+
+        :param identifier: The identifier of this Schedule.
+        :type: str
+        """
+        self._identifier = identifier
+
+    @property
+    def frequency_details(self):
+        """
+        Gets the frequency_details of this Schedule.
+
+        :return: The frequency_details of this Schedule.
+        :rtype: oci.data_integration.models.AbstractFrequencyDetails
+        """
+        return self._frequency_details
+
+    @frequency_details.setter
+    def frequency_details(self, frequency_details):
+        """
+        Sets the frequency_details of this Schedule.
+
+        :param frequency_details: The frequency_details of this Schedule.
+        :type: oci.data_integration.models.AbstractFrequencyDetails
+        """
+        self._frequency_details = frequency_details
+
+    @property
+    def timezone(self):
+        """
+        Gets the timezone of this Schedule.
+        The timezone for the schedule.
+
+
+        :return: The timezone of this Schedule.
+        :rtype: str
+        """
+        return self._timezone
+
+    @timezone.setter
+    def timezone(self, timezone):
+        """
+        Sets the timezone of this Schedule.
+        The timezone for the schedule.
+
+
+        :param timezone: The timezone of this Schedule.
+        :type: str
+        """
+        self._timezone = timezone
+
+    @property
+    def is_daylight_adjustment_enabled(self):
+        """
+        Gets the is_daylight_adjustment_enabled of this Schedule.
+        A flag to indicate daylight saving.
+
+
+        :return: The is_daylight_adjustment_enabled of this Schedule.
+        :rtype: bool
+        """
+        return self._is_daylight_adjustment_enabled
+
+    @is_daylight_adjustment_enabled.setter
+    def is_daylight_adjustment_enabled(self, is_daylight_adjustment_enabled):
+        """
+        Sets the is_daylight_adjustment_enabled of this Schedule.
+        A flag to indicate daylight saving.
+
+
+        :param is_daylight_adjustment_enabled: The is_daylight_adjustment_enabled of this Schedule.
+        :type: bool
+        """
+        self._is_daylight_adjustment_enabled = is_daylight_adjustment_enabled
+
+    @property
+    def metadata(self):
+        """
+        Gets the metadata of this Schedule.
+
+        :return: The metadata of this Schedule.
+        :rtype: oci.data_integration.models.ObjectMetadata
+        """
+        return self._metadata
+
+    @metadata.setter
+    def metadata(self, metadata):
+        """
+        Sets the metadata of this Schedule.
+
+        :param metadata: The metadata of this Schedule.
+        :type: oci.data_integration.models.ObjectMetadata
+        """
+        self._metadata = metadata
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/schema_drift_config.py
+++ b/src/oci/data_integration/models/schema_drift_config.py
@@ -1,0 +1,223 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class SchemaDriftConfig(object):
+    """
+    The configuration for handling schema drift in a Source or Target operator.
+    """
+
+    #: A constant which can be used with the extra_column_handling property of a SchemaDriftConfig.
+    #: This constant has a value of "ALLOW"
+    EXTRA_COLUMN_HANDLING_ALLOW = "ALLOW"
+
+    #: A constant which can be used with the extra_column_handling property of a SchemaDriftConfig.
+    #: This constant has a value of "NULL_FILLUP"
+    EXTRA_COLUMN_HANDLING_NULL_FILLUP = "NULL_FILLUP"
+
+    #: A constant which can be used with the extra_column_handling property of a SchemaDriftConfig.
+    #: This constant has a value of "DO_NOT_ALLOW"
+    EXTRA_COLUMN_HANDLING_DO_NOT_ALLOW = "DO_NOT_ALLOW"
+
+    #: A constant which can be used with the missing_column_handling property of a SchemaDriftConfig.
+    #: This constant has a value of "ALLOW"
+    MISSING_COLUMN_HANDLING_ALLOW = "ALLOW"
+
+    #: A constant which can be used with the missing_column_handling property of a SchemaDriftConfig.
+    #: This constant has a value of "NULL_SELECT"
+    MISSING_COLUMN_HANDLING_NULL_SELECT = "NULL_SELECT"
+
+    #: A constant which can be used with the missing_column_handling property of a SchemaDriftConfig.
+    #: This constant has a value of "DO_NOT_ALLOW"
+    MISSING_COLUMN_HANDLING_DO_NOT_ALLOW = "DO_NOT_ALLOW"
+
+    #: A constant which can be used with the data_type_change_handling property of a SchemaDriftConfig.
+    #: This constant has a value of "ALLOW"
+    DATA_TYPE_CHANGE_HANDLING_ALLOW = "ALLOW"
+
+    #: A constant which can be used with the data_type_change_handling property of a SchemaDriftConfig.
+    #: This constant has a value of "DO_CAST_IF_POSSIBLE"
+    DATA_TYPE_CHANGE_HANDLING_DO_CAST_IF_POSSIBLE = "DO_CAST_IF_POSSIBLE"
+
+    #: A constant which can be used with the data_type_change_handling property of a SchemaDriftConfig.
+    #: This constant has a value of "DO_NOT_ALLOW"
+    DATA_TYPE_CHANGE_HANDLING_DO_NOT_ALLOW = "DO_NOT_ALLOW"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new SchemaDriftConfig object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param extra_column_handling:
+            The value to assign to the extra_column_handling property of this SchemaDriftConfig.
+            Allowed values for this property are: "ALLOW", "NULL_FILLUP", "DO_NOT_ALLOW", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type extra_column_handling: str
+
+        :param missing_column_handling:
+            The value to assign to the missing_column_handling property of this SchemaDriftConfig.
+            Allowed values for this property are: "ALLOW", "NULL_SELECT", "DO_NOT_ALLOW", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type missing_column_handling: str
+
+        :param data_type_change_handling:
+            The value to assign to the data_type_change_handling property of this SchemaDriftConfig.
+            Allowed values for this property are: "ALLOW", "DO_CAST_IF_POSSIBLE", "DO_NOT_ALLOW", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type data_type_change_handling: str
+
+        :param is_validation_warning_if_allowed:
+            The value to assign to the is_validation_warning_if_allowed property of this SchemaDriftConfig.
+        :type is_validation_warning_if_allowed: bool
+
+        """
+        self.swagger_types = {
+            'extra_column_handling': 'str',
+            'missing_column_handling': 'str',
+            'data_type_change_handling': 'str',
+            'is_validation_warning_if_allowed': 'bool'
+        }
+
+        self.attribute_map = {
+            'extra_column_handling': 'extraColumnHandling',
+            'missing_column_handling': 'missingColumnHandling',
+            'data_type_change_handling': 'dataTypeChangeHandling',
+            'is_validation_warning_if_allowed': 'isValidationWarningIfAllowed'
+        }
+
+        self._extra_column_handling = None
+        self._missing_column_handling = None
+        self._data_type_change_handling = None
+        self._is_validation_warning_if_allowed = None
+
+    @property
+    def extra_column_handling(self):
+        """
+        Gets the extra_column_handling of this SchemaDriftConfig.
+        The setting for how to handle extra columns/fields.  NULL_FILLUP means that nulls will be loaded into the target for extra columns.
+
+        Allowed values for this property are: "ALLOW", "NULL_FILLUP", "DO_NOT_ALLOW", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The extra_column_handling of this SchemaDriftConfig.
+        :rtype: str
+        """
+        return self._extra_column_handling
+
+    @extra_column_handling.setter
+    def extra_column_handling(self, extra_column_handling):
+        """
+        Sets the extra_column_handling of this SchemaDriftConfig.
+        The setting for how to handle extra columns/fields.  NULL_FILLUP means that nulls will be loaded into the target for extra columns.
+
+
+        :param extra_column_handling: The extra_column_handling of this SchemaDriftConfig.
+        :type: str
+        """
+        allowed_values = ["ALLOW", "NULL_FILLUP", "DO_NOT_ALLOW"]
+        if not value_allowed_none_or_none_sentinel(extra_column_handling, allowed_values):
+            extra_column_handling = 'UNKNOWN_ENUM_VALUE'
+        self._extra_column_handling = extra_column_handling
+
+    @property
+    def missing_column_handling(self):
+        """
+        Gets the missing_column_handling of this SchemaDriftConfig.
+        The setting for how to handle missing columns/fields.  NULL_SELECT means that null values will be selected from the source for missing columns.
+
+        Allowed values for this property are: "ALLOW", "NULL_SELECT", "DO_NOT_ALLOW", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The missing_column_handling of this SchemaDriftConfig.
+        :rtype: str
+        """
+        return self._missing_column_handling
+
+    @missing_column_handling.setter
+    def missing_column_handling(self, missing_column_handling):
+        """
+        Sets the missing_column_handling of this SchemaDriftConfig.
+        The setting for how to handle missing columns/fields.  NULL_SELECT means that null values will be selected from the source for missing columns.
+
+
+        :param missing_column_handling: The missing_column_handling of this SchemaDriftConfig.
+        :type: str
+        """
+        allowed_values = ["ALLOW", "NULL_SELECT", "DO_NOT_ALLOW"]
+        if not value_allowed_none_or_none_sentinel(missing_column_handling, allowed_values):
+            missing_column_handling = 'UNKNOWN_ENUM_VALUE'
+        self._missing_column_handling = missing_column_handling
+
+    @property
+    def data_type_change_handling(self):
+        """
+        Gets the data_type_change_handling of this SchemaDriftConfig.
+        The setting for how to handle columns/fields with changed data types.
+
+        Allowed values for this property are: "ALLOW", "DO_CAST_IF_POSSIBLE", "DO_NOT_ALLOW", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The data_type_change_handling of this SchemaDriftConfig.
+        :rtype: str
+        """
+        return self._data_type_change_handling
+
+    @data_type_change_handling.setter
+    def data_type_change_handling(self, data_type_change_handling):
+        """
+        Sets the data_type_change_handling of this SchemaDriftConfig.
+        The setting for how to handle columns/fields with changed data types.
+
+
+        :param data_type_change_handling: The data_type_change_handling of this SchemaDriftConfig.
+        :type: str
+        """
+        allowed_values = ["ALLOW", "DO_CAST_IF_POSSIBLE", "DO_NOT_ALLOW"]
+        if not value_allowed_none_or_none_sentinel(data_type_change_handling, allowed_values):
+            data_type_change_handling = 'UNKNOWN_ENUM_VALUE'
+        self._data_type_change_handling = data_type_change_handling
+
+    @property
+    def is_validation_warning_if_allowed(self):
+        """
+        Gets the is_validation_warning_if_allowed of this SchemaDriftConfig.
+        If true, display a validation warning for schema changes, even if they are allowed.
+
+
+        :return: The is_validation_warning_if_allowed of this SchemaDriftConfig.
+        :rtype: bool
+        """
+        return self._is_validation_warning_if_allowed
+
+    @is_validation_warning_if_allowed.setter
+    def is_validation_warning_if_allowed(self, is_validation_warning_if_allowed):
+        """
+        Sets the is_validation_warning_if_allowed of this SchemaDriftConfig.
+        If true, display a validation warning for schema changes, even if they are allowed.
+
+
+        :param is_validation_warning_if_allowed: The is_validation_warning_if_allowed of this SchemaDriftConfig.
+        :type: bool
+        """
+        self._is_validation_warning_if_allowed = is_validation_warning_if_allowed
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/secret_config.py
+++ b/src/oci/data_integration/models/secret_config.py
@@ -1,0 +1,99 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class SecretConfig(object):
+    """
+    Secret configuration if used for storing sensitive info
+    """
+
+    #: A constant which can be used with the model_type property of a SecretConfig.
+    #: This constant has a value of "OCI_VAULT_SECRET_CONFIG"
+    MODEL_TYPE_OCI_VAULT_SECRET_CONFIG = "OCI_VAULT_SECRET_CONFIG"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new SecretConfig object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
+        to a service operations then you should favor using a subclass over the base class:
+
+        * :class:`~oci.data_integration.models.OciVaultSecretConfig`
+
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param model_type:
+            The value to assign to the model_type property of this SecretConfig.
+            Allowed values for this property are: "OCI_VAULT_SECRET_CONFIG", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type model_type: str
+
+        """
+        self.swagger_types = {
+            'model_type': 'str'
+        }
+
+        self.attribute_map = {
+            'model_type': 'modelType'
+        }
+
+        self._model_type = None
+
+    @staticmethod
+    def get_subtype(object_dictionary):
+        """
+        Given the hash representation of a subtype of this class,
+        use the info in the hash to return the class of the subtype.
+        """
+        type = object_dictionary['modelType']
+
+        if type == 'OCI_VAULT_SECRET_CONFIG':
+            return 'OciVaultSecretConfig'
+        else:
+            return 'SecretConfig'
+
+    @property
+    def model_type(self):
+        """
+        **[Required]** Gets the model_type of this SecretConfig.
+        If OCI vault is used for storing sensitive info
+
+        Allowed values for this property are: "OCI_VAULT_SECRET_CONFIG", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The model_type of this SecretConfig.
+        :rtype: str
+        """
+        return self._model_type
+
+    @model_type.setter
+    def model_type(self, model_type):
+        """
+        Sets the model_type of this SecretConfig.
+        If OCI vault is used for storing sensitive info
+
+
+        :param model_type: The model_type of this SecretConfig.
+        :type: str
+        """
+        allowed_values = ["OCI_VAULT_SECRET_CONFIG"]
+        if not value_allowed_none_or_none_sentinel(model_type, allowed_values):
+            model_type = 'UNKNOWN_ENUM_VALUE'
+        self._model_type = model_type
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/sensitive_attribute.py
+++ b/src/oci/data_integration/models/sensitive_attribute.py
@@ -1,0 +1,97 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class SensitiveAttribute(object):
+    """
+    The sensitive attribute to be used for sensitive content (for password/wallet).
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new SensitiveAttribute object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param secret_config:
+            The value to assign to the secret_config property of this SensitiveAttribute.
+        :type secret_config: oci.data_integration.models.SecretConfig
+
+        :param value:
+            The value to assign to the value property of this SensitiveAttribute.
+        :type value: str
+
+        """
+        self.swagger_types = {
+            'secret_config': 'SecretConfig',
+            'value': 'str'
+        }
+
+        self.attribute_map = {
+            'secret_config': 'secretConfig',
+            'value': 'value'
+        }
+
+        self._secret_config = None
+        self._value = None
+
+    @property
+    def secret_config(self):
+        """
+        Gets the secret_config of this SensitiveAttribute.
+
+        :return: The secret_config of this SensitiveAttribute.
+        :rtype: oci.data_integration.models.SecretConfig
+        """
+        return self._secret_config
+
+    @secret_config.setter
+    def secret_config(self, secret_config):
+        """
+        Sets the secret_config of this SensitiveAttribute.
+
+        :param secret_config: The secret_config of this SensitiveAttribute.
+        :type: oci.data_integration.models.SecretConfig
+        """
+        self._secret_config = secret_config
+
+    @property
+    def value(self):
+        """
+        Gets the value of this SensitiveAttribute.
+        Attribute to provide sensitive content.
+
+
+        :return: The value of this SensitiveAttribute.
+        :rtype: str
+        """
+        return self._value
+
+    @value.setter
+    def value(self, value):
+        """
+        Sets the value of this SensitiveAttribute.
+        Attribute to provide sensitive content.
+
+
+        :param value: The value of this SensitiveAttribute.
+        :type: str
+        """
+        self._value = value
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/sort_oper.py
+++ b/src/oci/data_integration/models/sort_oper.py
@@ -21,7 +21,7 @@ class SortOper(Operator):
 
         :param model_type:
             The value to assign to the model_type property of this SortOper.
-            Allowed values for this property are: "SOURCE_OPERATOR", "FILTER_OPERATOR", "JOINER_OPERATOR", "AGGREGATOR_OPERATOR", "PROJECTION_OPERATOR", "TARGET_OPERATOR", "DISTINCT_OPERATOR", "SORT_OPERATOR"
+            Allowed values for this property are: "SOURCE_OPERATOR", "FILTER_OPERATOR", "JOINER_OPERATOR", "AGGREGATOR_OPERATOR", "PROJECTION_OPERATOR", "TARGET_OPERATOR", "DISTINCT_OPERATOR", "SORT_OPERATOR", "UNION_OPERATOR", "INTERSECT_OPERATOR", "MINUS_OPERATOR", "MERGE_OPERATOR", "START_OPERATOR", "END_OPERATOR", "PIPELINE_OPERATOR", "REST_OPERATOR", "TASK_OPERATOR"
         :type model_type: str
 
         :param key:

--- a/src/oci/data_integration/models/source.py
+++ b/src/oci/data_integration/models/source.py
@@ -21,7 +21,7 @@ class Source(Operator):
 
         :param model_type:
             The value to assign to the model_type property of this Source.
-            Allowed values for this property are: "SOURCE_OPERATOR", "FILTER_OPERATOR", "JOINER_OPERATOR", "AGGREGATOR_OPERATOR", "PROJECTION_OPERATOR", "TARGET_OPERATOR", "DISTINCT_OPERATOR", "SORT_OPERATOR", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "SOURCE_OPERATOR", "FILTER_OPERATOR", "JOINER_OPERATOR", "AGGREGATOR_OPERATOR", "PROJECTION_OPERATOR", "TARGET_OPERATOR", "DISTINCT_OPERATOR", "SORT_OPERATOR", "UNION_OPERATOR", "INTERSECT_OPERATOR", "MINUS_OPERATOR", "MERGE_OPERATOR", "START_OPERATOR", "END_OPERATOR", "PIPELINE_OPERATOR", "REST_OPERATOR", "TASK_OPERATOR", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type model_type: str
 
@@ -89,6 +89,14 @@ class Source(Operator):
             The value to assign to the is_predefined_shape property of this Source.
         :type is_predefined_shape: bool
 
+        :param schema_drift_config:
+            The value to assign to the schema_drift_config property of this Source.
+        :type schema_drift_config: oci.data_integration.models.SchemaDriftConfig
+
+        :param fixed_data_shape:
+            The value to assign to the fixed_data_shape property of this Source.
+        :type fixed_data_shape: oci.data_integration.models.Shape
+
         :param read_operation_config:
             The value to assign to the read_operation_config property of this Source.
         :type read_operation_config: oci.data_integration.models.ReadOperationConfig
@@ -112,6 +120,8 @@ class Source(Operator):
             'is_read_access': 'bool',
             'is_copy_fields': 'bool',
             'is_predefined_shape': 'bool',
+            'schema_drift_config': 'SchemaDriftConfig',
+            'fixed_data_shape': 'Shape',
             'read_operation_config': 'ReadOperationConfig'
         }
 
@@ -133,6 +143,8 @@ class Source(Operator):
             'is_read_access': 'isReadAccess',
             'is_copy_fields': 'isCopyFields',
             'is_predefined_shape': 'isPredefinedShape',
+            'schema_drift_config': 'schemaDriftConfig',
+            'fixed_data_shape': 'fixedDataShape',
             'read_operation_config': 'readOperationConfig'
         }
 
@@ -153,6 +165,8 @@ class Source(Operator):
         self._is_read_access = None
         self._is_copy_fields = None
         self._is_predefined_shape = None
+        self._schema_drift_config = None
+        self._fixed_data_shape = None
         self._read_operation_config = None
         self._model_type = 'SOURCE_OPERATOR'
 
@@ -247,6 +261,46 @@ class Source(Operator):
         :type: bool
         """
         self._is_predefined_shape = is_predefined_shape
+
+    @property
+    def schema_drift_config(self):
+        """
+        Gets the schema_drift_config of this Source.
+
+        :return: The schema_drift_config of this Source.
+        :rtype: oci.data_integration.models.SchemaDriftConfig
+        """
+        return self._schema_drift_config
+
+    @schema_drift_config.setter
+    def schema_drift_config(self, schema_drift_config):
+        """
+        Sets the schema_drift_config of this Source.
+
+        :param schema_drift_config: The schema_drift_config of this Source.
+        :type: oci.data_integration.models.SchemaDriftConfig
+        """
+        self._schema_drift_config = schema_drift_config
+
+    @property
+    def fixed_data_shape(self):
+        """
+        Gets the fixed_data_shape of this Source.
+
+        :return: The fixed_data_shape of this Source.
+        :rtype: oci.data_integration.models.Shape
+        """
+        return self._fixed_data_shape
+
+    @fixed_data_shape.setter
+    def fixed_data_shape(self, fixed_data_shape):
+        """
+        Sets the fixed_data_shape of this Source.
+
+        :param fixed_data_shape: The fixed_data_shape of this Source.
+        :type: oci.data_integration.models.Shape
+        """
+        self._fixed_data_shape = fixed_data_shape
 
     @property
     def read_operation_config(self):

--- a/src/oci/data_integration/models/start_operator.py
+++ b/src/oci/data_integration/models/start_operator.py
@@ -1,0 +1,133 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .operator import Operator
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class StartOperator(Operator):
+    """
+    Represents the start of a pipeline.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new StartOperator object with values from keyword arguments. The default value of the :py:attr:`~oci.data_integration.models.StartOperator.model_type` attribute
+        of this class is ``START_OPERATOR`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param model_type:
+            The value to assign to the model_type property of this StartOperator.
+            Allowed values for this property are: "SOURCE_OPERATOR", "FILTER_OPERATOR", "JOINER_OPERATOR", "AGGREGATOR_OPERATOR", "PROJECTION_OPERATOR", "TARGET_OPERATOR", "DISTINCT_OPERATOR", "SORT_OPERATOR", "UNION_OPERATOR", "INTERSECT_OPERATOR", "MINUS_OPERATOR", "MERGE_OPERATOR", "START_OPERATOR", "END_OPERATOR", "PIPELINE_OPERATOR", "REST_OPERATOR", "TASK_OPERATOR"
+        :type model_type: str
+
+        :param key:
+            The value to assign to the key property of this StartOperator.
+        :type key: str
+
+        :param model_version:
+            The value to assign to the model_version property of this StartOperator.
+        :type model_version: str
+
+        :param parent_ref:
+            The value to assign to the parent_ref property of this StartOperator.
+        :type parent_ref: oci.data_integration.models.ParentReference
+
+        :param name:
+            The value to assign to the name property of this StartOperator.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this StartOperator.
+        :type description: str
+
+        :param object_version:
+            The value to assign to the object_version property of this StartOperator.
+        :type object_version: int
+
+        :param input_ports:
+            The value to assign to the input_ports property of this StartOperator.
+        :type input_ports: list[oci.data_integration.models.InputPort]
+
+        :param output_ports:
+            The value to assign to the output_ports property of this StartOperator.
+        :type output_ports: list[oci.data_integration.models.OutputPort]
+
+        :param object_status:
+            The value to assign to the object_status property of this StartOperator.
+        :type object_status: int
+
+        :param identifier:
+            The value to assign to the identifier property of this StartOperator.
+        :type identifier: str
+
+        :param parameters:
+            The value to assign to the parameters property of this StartOperator.
+        :type parameters: list[oci.data_integration.models.Parameter]
+
+        :param op_config_values:
+            The value to assign to the op_config_values property of this StartOperator.
+        :type op_config_values: oci.data_integration.models.ConfigValues
+
+        """
+        self.swagger_types = {
+            'model_type': 'str',
+            'key': 'str',
+            'model_version': 'str',
+            'parent_ref': 'ParentReference',
+            'name': 'str',
+            'description': 'str',
+            'object_version': 'int',
+            'input_ports': 'list[InputPort]',
+            'output_ports': 'list[OutputPort]',
+            'object_status': 'int',
+            'identifier': 'str',
+            'parameters': 'list[Parameter]',
+            'op_config_values': 'ConfigValues'
+        }
+
+        self.attribute_map = {
+            'model_type': 'modelType',
+            'key': 'key',
+            'model_version': 'modelVersion',
+            'parent_ref': 'parentRef',
+            'name': 'name',
+            'description': 'description',
+            'object_version': 'objectVersion',
+            'input_ports': 'inputPorts',
+            'output_ports': 'outputPorts',
+            'object_status': 'objectStatus',
+            'identifier': 'identifier',
+            'parameters': 'parameters',
+            'op_config_values': 'opConfigValues'
+        }
+
+        self._model_type = None
+        self._key = None
+        self._model_version = None
+        self._parent_ref = None
+        self._name = None
+        self._description = None
+        self._object_version = None
+        self._input_ports = None
+        self._output_ports = None
+        self._object_status = None
+        self._identifier = None
+        self._parameters = None
+        self._op_config_values = None
+        self._model_type = 'START_OPERATOR'
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/target.py
+++ b/src/oci/data_integration/models/target.py
@@ -45,7 +45,7 @@ class Target(Operator):
 
         :param model_type:
             The value to assign to the model_type property of this Target.
-            Allowed values for this property are: "SOURCE_OPERATOR", "FILTER_OPERATOR", "JOINER_OPERATOR", "AGGREGATOR_OPERATOR", "PROJECTION_OPERATOR", "TARGET_OPERATOR", "DISTINCT_OPERATOR", "SORT_OPERATOR", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "SOURCE_OPERATOR", "FILTER_OPERATOR", "JOINER_OPERATOR", "AGGREGATOR_OPERATOR", "PROJECTION_OPERATOR", "TARGET_OPERATOR", "DISTINCT_OPERATOR", "SORT_OPERATOR", "UNION_OPERATOR", "INTERSECT_OPERATOR", "MINUS_OPERATOR", "MERGE_OPERATOR", "START_OPERATOR", "END_OPERATOR", "PIPELINE_OPERATOR", "REST_OPERATOR", "TASK_OPERATOR", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type model_type: str
 
@@ -119,6 +119,14 @@ class Target(Operator):
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type data_property: str
 
+        :param schema_drift_config:
+            The value to assign to the schema_drift_config property of this Target.
+        :type schema_drift_config: oci.data_integration.models.SchemaDriftConfig
+
+        :param fixed_data_shape:
+            The value to assign to the fixed_data_shape property of this Target.
+        :type fixed_data_shape: oci.data_integration.models.Shape
+
         :param write_operation_config:
             The value to assign to the write_operation_config property of this Target.
         :type write_operation_config: oci.data_integration.models.WriteOperationConfig
@@ -143,6 +151,8 @@ class Target(Operator):
             'is_copy_fields': 'bool',
             'is_predefined_shape': 'bool',
             'data_property': 'str',
+            'schema_drift_config': 'SchemaDriftConfig',
+            'fixed_data_shape': 'Shape',
             'write_operation_config': 'WriteOperationConfig'
         }
 
@@ -165,6 +175,8 @@ class Target(Operator):
             'is_copy_fields': 'isCopyFields',
             'is_predefined_shape': 'isPredefinedShape',
             'data_property': 'dataProperty',
+            'schema_drift_config': 'schemaDriftConfig',
+            'fixed_data_shape': 'fixedDataShape',
             'write_operation_config': 'writeOperationConfig'
         }
 
@@ -186,6 +198,8 @@ class Target(Operator):
         self._is_copy_fields = None
         self._is_predefined_shape = None
         self._data_property = None
+        self._schema_drift_config = None
+        self._fixed_data_shape = None
         self._write_operation_config = None
         self._model_type = 'TARGET_OPERATOR'
 
@@ -310,6 +324,46 @@ class Target(Operator):
         if not value_allowed_none_or_none_sentinel(data_property, allowed_values):
             data_property = 'UNKNOWN_ENUM_VALUE'
         self._data_property = data_property
+
+    @property
+    def schema_drift_config(self):
+        """
+        Gets the schema_drift_config of this Target.
+
+        :return: The schema_drift_config of this Target.
+        :rtype: oci.data_integration.models.SchemaDriftConfig
+        """
+        return self._schema_drift_config
+
+    @schema_drift_config.setter
+    def schema_drift_config(self, schema_drift_config):
+        """
+        Sets the schema_drift_config of this Target.
+
+        :param schema_drift_config: The schema_drift_config of this Target.
+        :type: oci.data_integration.models.SchemaDriftConfig
+        """
+        self._schema_drift_config = schema_drift_config
+
+    @property
+    def fixed_data_shape(self):
+        """
+        Gets the fixed_data_shape of this Target.
+
+        :return: The fixed_data_shape of this Target.
+        :rtype: oci.data_integration.models.Shape
+        """
+        return self._fixed_data_shape
+
+    @fixed_data_shape.setter
+    def fixed_data_shape(self, fixed_data_shape):
+        """
+        Sets the fixed_data_shape of this Target.
+
+        :param fixed_data_shape: The fixed_data_shape of this Target.
+        :type: oci.data_integration.models.Shape
+        """
+        self._fixed_data_shape = fixed_data_shape
 
     @property
     def write_operation_config(self):

--- a/src/oci/data_integration/models/task.py
+++ b/src/oci/data_integration/models/task.py
@@ -21,11 +21,16 @@ class Task(object):
     #: This constant has a value of "DATA_LOADER_TASK"
     MODEL_TYPE_DATA_LOADER_TASK = "DATA_LOADER_TASK"
 
+    #: A constant which can be used with the model_type property of a Task.
+    #: This constant has a value of "PIPELINE_TASK"
+    MODEL_TYPE_PIPELINE_TASK = "PIPELINE_TASK"
+
     def __init__(self, **kwargs):
         """
         Initializes a new Task object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
         to a service operations then you should favor using a subclass over the base class:
 
+        * :class:`~oci.data_integration.models.TaskFromPipelineTaskDetails`
         * :class:`~oci.data_integration.models.TaskFromIntegrationTaskDetails`
         * :class:`~oci.data_integration.models.TaskFromDataLoaderTaskDetails`
 
@@ -33,7 +38,7 @@ class Task(object):
 
         :param model_type:
             The value to assign to the model_type property of this Task.
-            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type model_type: str
 
@@ -161,6 +166,9 @@ class Task(object):
         """
         type = object_dictionary['modelType']
 
+        if type == 'PIPELINE_TASK':
+            return 'TaskFromPipelineTaskDetails'
+
         if type == 'INTEGRATION_TASK':
             return 'TaskFromIntegrationTaskDetails'
 
@@ -175,7 +183,7 @@ class Task(object):
         Gets the model_type of this Task.
         The type of the task.
 
-        Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -194,7 +202,7 @@ class Task(object):
         :param model_type: The model_type of this Task.
         :type: str
         """
-        allowed_values = ["INTEGRATION_TASK", "DATA_LOADER_TASK"]
+        allowed_values = ["INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK"]
         if not value_allowed_none_or_none_sentinel(model_type, allowed_values):
             model_type = 'UNKNOWN_ENUM_VALUE'
         self._model_type = model_type

--- a/src/oci/data_integration/models/task_from_data_loader_task_details.py
+++ b/src/oci/data_integration/models/task_from_data_loader_task_details.py
@@ -21,7 +21,7 @@ class TaskFromDataLoaderTaskDetails(Task):
 
         :param model_type:
             The value to assign to the model_type property of this TaskFromDataLoaderTaskDetails.
-            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK"
+            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK"
         :type model_type: str
 
         :param key:

--- a/src/oci/data_integration/models/task_from_integration_task_details.py
+++ b/src/oci/data_integration/models/task_from_integration_task_details.py
@@ -21,7 +21,7 @@ class TaskFromIntegrationTaskDetails(Task):
 
         :param model_type:
             The value to assign to the model_type property of this TaskFromIntegrationTaskDetails.
-            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK"
+            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK"
         :type model_type: str
 
         :param key:

--- a/src/oci/data_integration/models/task_from_pipeline_task_details.py
+++ b/src/oci/data_integration/models/task_from_pipeline_task_details.py
@@ -1,0 +1,181 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .task import Task
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class TaskFromPipelineTaskDetails(Task):
+    """
+    The information about the pipeline task.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new TaskFromPipelineTaskDetails object with values from keyword arguments. The default value of the :py:attr:`~oci.data_integration.models.TaskFromPipelineTaskDetails.model_type` attribute
+        of this class is ``PIPELINE_TASK`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param model_type:
+            The value to assign to the model_type property of this TaskFromPipelineTaskDetails.
+            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK"
+        :type model_type: str
+
+        :param key:
+            The value to assign to the key property of this TaskFromPipelineTaskDetails.
+        :type key: str
+
+        :param model_version:
+            The value to assign to the model_version property of this TaskFromPipelineTaskDetails.
+        :type model_version: str
+
+        :param parent_ref:
+            The value to assign to the parent_ref property of this TaskFromPipelineTaskDetails.
+        :type parent_ref: oci.data_integration.models.ParentReference
+
+        :param name:
+            The value to assign to the name property of this TaskFromPipelineTaskDetails.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this TaskFromPipelineTaskDetails.
+        :type description: str
+
+        :param object_version:
+            The value to assign to the object_version property of this TaskFromPipelineTaskDetails.
+        :type object_version: int
+
+        :param object_status:
+            The value to assign to the object_status property of this TaskFromPipelineTaskDetails.
+        :type object_status: int
+
+        :param identifier:
+            The value to assign to the identifier property of this TaskFromPipelineTaskDetails.
+        :type identifier: str
+
+        :param input_ports:
+            The value to assign to the input_ports property of this TaskFromPipelineTaskDetails.
+        :type input_ports: list[oci.data_integration.models.InputPort]
+
+        :param output_ports:
+            The value to assign to the output_ports property of this TaskFromPipelineTaskDetails.
+        :type output_ports: list[oci.data_integration.models.OutputPort]
+
+        :param parameters:
+            The value to assign to the parameters property of this TaskFromPipelineTaskDetails.
+        :type parameters: list[oci.data_integration.models.Parameter]
+
+        :param op_config_values:
+            The value to assign to the op_config_values property of this TaskFromPipelineTaskDetails.
+        :type op_config_values: oci.data_integration.models.ConfigValues
+
+        :param config_provider_delegate:
+            The value to assign to the config_provider_delegate property of this TaskFromPipelineTaskDetails.
+        :type config_provider_delegate: oci.data_integration.models.ConfigProvider
+
+        :param metadata:
+            The value to assign to the metadata property of this TaskFromPipelineTaskDetails.
+        :type metadata: oci.data_integration.models.ObjectMetadata
+
+        :param key_map:
+            The value to assign to the key_map property of this TaskFromPipelineTaskDetails.
+        :type key_map: dict(str, str)
+
+        :param pipeline:
+            The value to assign to the pipeline property of this TaskFromPipelineTaskDetails.
+        :type pipeline: oci.data_integration.models.Pipeline
+
+        """
+        self.swagger_types = {
+            'model_type': 'str',
+            'key': 'str',
+            'model_version': 'str',
+            'parent_ref': 'ParentReference',
+            'name': 'str',
+            'description': 'str',
+            'object_version': 'int',
+            'object_status': 'int',
+            'identifier': 'str',
+            'input_ports': 'list[InputPort]',
+            'output_ports': 'list[OutputPort]',
+            'parameters': 'list[Parameter]',
+            'op_config_values': 'ConfigValues',
+            'config_provider_delegate': 'ConfigProvider',
+            'metadata': 'ObjectMetadata',
+            'key_map': 'dict(str, str)',
+            'pipeline': 'Pipeline'
+        }
+
+        self.attribute_map = {
+            'model_type': 'modelType',
+            'key': 'key',
+            'model_version': 'modelVersion',
+            'parent_ref': 'parentRef',
+            'name': 'name',
+            'description': 'description',
+            'object_version': 'objectVersion',
+            'object_status': 'objectStatus',
+            'identifier': 'identifier',
+            'input_ports': 'inputPorts',
+            'output_ports': 'outputPorts',
+            'parameters': 'parameters',
+            'op_config_values': 'opConfigValues',
+            'config_provider_delegate': 'configProviderDelegate',
+            'metadata': 'metadata',
+            'key_map': 'keyMap',
+            'pipeline': 'pipeline'
+        }
+
+        self._model_type = None
+        self._key = None
+        self._model_version = None
+        self._parent_ref = None
+        self._name = None
+        self._description = None
+        self._object_version = None
+        self._object_status = None
+        self._identifier = None
+        self._input_ports = None
+        self._output_ports = None
+        self._parameters = None
+        self._op_config_values = None
+        self._config_provider_delegate = None
+        self._metadata = None
+        self._key_map = None
+        self._pipeline = None
+        self._model_type = 'PIPELINE_TASK'
+
+    @property
+    def pipeline(self):
+        """
+        Gets the pipeline of this TaskFromPipelineTaskDetails.
+
+        :return: The pipeline of this TaskFromPipelineTaskDetails.
+        :rtype: oci.data_integration.models.Pipeline
+        """
+        return self._pipeline
+
+    @pipeline.setter
+    def pipeline(self, pipeline):
+        """
+        Sets the pipeline of this TaskFromPipelineTaskDetails.
+
+        :param pipeline: The pipeline of this TaskFromPipelineTaskDetails.
+        :type: oci.data_integration.models.Pipeline
+        """
+        self._pipeline = pipeline
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/task_operator.py
+++ b/src/oci/data_integration/models/task_operator.py
@@ -1,0 +1,499 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .operator import Operator
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class TaskOperator(Operator):
+    """
+    An operator for task
+    """
+
+    #: A constant which can be used with the retry_delay_unit property of a TaskOperator.
+    #: This constant has a value of "SECONDS"
+    RETRY_DELAY_UNIT_SECONDS = "SECONDS"
+
+    #: A constant which can be used with the retry_delay_unit property of a TaskOperator.
+    #: This constant has a value of "MINUTES"
+    RETRY_DELAY_UNIT_MINUTES = "MINUTES"
+
+    #: A constant which can be used with the retry_delay_unit property of a TaskOperator.
+    #: This constant has a value of "HOURS"
+    RETRY_DELAY_UNIT_HOURS = "HOURS"
+
+    #: A constant which can be used with the retry_delay_unit property of a TaskOperator.
+    #: This constant has a value of "DAYS"
+    RETRY_DELAY_UNIT_DAYS = "DAYS"
+
+    #: A constant which can be used with the expected_duration_unit property of a TaskOperator.
+    #: This constant has a value of "SECONDS"
+    EXPECTED_DURATION_UNIT_SECONDS = "SECONDS"
+
+    #: A constant which can be used with the expected_duration_unit property of a TaskOperator.
+    #: This constant has a value of "MINUTES"
+    EXPECTED_DURATION_UNIT_MINUTES = "MINUTES"
+
+    #: A constant which can be used with the expected_duration_unit property of a TaskOperator.
+    #: This constant has a value of "HOURS"
+    EXPECTED_DURATION_UNIT_HOURS = "HOURS"
+
+    #: A constant which can be used with the expected_duration_unit property of a TaskOperator.
+    #: This constant has a value of "DAYS"
+    EXPECTED_DURATION_UNIT_DAYS = "DAYS"
+
+    #: A constant which can be used with the task_type property of a TaskOperator.
+    #: This constant has a value of "PIPELINE_TASK"
+    TASK_TYPE_PIPELINE_TASK = "PIPELINE_TASK"
+
+    #: A constant which can be used with the task_type property of a TaskOperator.
+    #: This constant has a value of "INTEGRATION_TASK"
+    TASK_TYPE_INTEGRATION_TASK = "INTEGRATION_TASK"
+
+    #: A constant which can be used with the task_type property of a TaskOperator.
+    #: This constant has a value of "DATA_LOADER_TASK"
+    TASK_TYPE_DATA_LOADER_TASK = "DATA_LOADER_TASK"
+
+    #: A constant which can be used with the trigger_rule property of a TaskOperator.
+    #: This constant has a value of "ALL_SUCCESS"
+    TRIGGER_RULE_ALL_SUCCESS = "ALL_SUCCESS"
+
+    #: A constant which can be used with the trigger_rule property of a TaskOperator.
+    #: This constant has a value of "ALL_FAILED"
+    TRIGGER_RULE_ALL_FAILED = "ALL_FAILED"
+
+    #: A constant which can be used with the trigger_rule property of a TaskOperator.
+    #: This constant has a value of "ALL_COMPLETE"
+    TRIGGER_RULE_ALL_COMPLETE = "ALL_COMPLETE"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new TaskOperator object with values from keyword arguments. The default value of the :py:attr:`~oci.data_integration.models.TaskOperator.model_type` attribute
+        of this class is ``TASK_OPERATOR`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param model_type:
+            The value to assign to the model_type property of this TaskOperator.
+            Allowed values for this property are: "SOURCE_OPERATOR", "FILTER_OPERATOR", "JOINER_OPERATOR", "AGGREGATOR_OPERATOR", "PROJECTION_OPERATOR", "TARGET_OPERATOR", "DISTINCT_OPERATOR", "SORT_OPERATOR", "UNION_OPERATOR", "INTERSECT_OPERATOR", "MINUS_OPERATOR", "MERGE_OPERATOR", "START_OPERATOR", "END_OPERATOR", "PIPELINE_OPERATOR", "REST_OPERATOR", "TASK_OPERATOR", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type model_type: str
+
+        :param key:
+            The value to assign to the key property of this TaskOperator.
+        :type key: str
+
+        :param model_version:
+            The value to assign to the model_version property of this TaskOperator.
+        :type model_version: str
+
+        :param parent_ref:
+            The value to assign to the parent_ref property of this TaskOperator.
+        :type parent_ref: oci.data_integration.models.ParentReference
+
+        :param name:
+            The value to assign to the name property of this TaskOperator.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this TaskOperator.
+        :type description: str
+
+        :param object_version:
+            The value to assign to the object_version property of this TaskOperator.
+        :type object_version: int
+
+        :param input_ports:
+            The value to assign to the input_ports property of this TaskOperator.
+        :type input_ports: list[oci.data_integration.models.InputPort]
+
+        :param output_ports:
+            The value to assign to the output_ports property of this TaskOperator.
+        :type output_ports: list[oci.data_integration.models.OutputPort]
+
+        :param object_status:
+            The value to assign to the object_status property of this TaskOperator.
+        :type object_status: int
+
+        :param identifier:
+            The value to assign to the identifier property of this TaskOperator.
+        :type identifier: str
+
+        :param parameters:
+            The value to assign to the parameters property of this TaskOperator.
+        :type parameters: list[oci.data_integration.models.Parameter]
+
+        :param op_config_values:
+            The value to assign to the op_config_values property of this TaskOperator.
+        :type op_config_values: oci.data_integration.models.ConfigValues
+
+        :param retry_attempts:
+            The value to assign to the retry_attempts property of this TaskOperator.
+        :type retry_attempts: int
+
+        :param retry_delay_unit:
+            The value to assign to the retry_delay_unit property of this TaskOperator.
+            Allowed values for this property are: "SECONDS", "MINUTES", "HOURS", "DAYS", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type retry_delay_unit: str
+
+        :param retry_delay:
+            The value to assign to the retry_delay property of this TaskOperator.
+        :type retry_delay: float
+
+        :param expected_duration:
+            The value to assign to the expected_duration property of this TaskOperator.
+        :type expected_duration: float
+
+        :param expected_duration_unit:
+            The value to assign to the expected_duration_unit property of this TaskOperator.
+            Allowed values for this property are: "SECONDS", "MINUTES", "HOURS", "DAYS", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type expected_duration_unit: str
+
+        :param task_type:
+            The value to assign to the task_type property of this TaskOperator.
+            Allowed values for this property are: "PIPELINE_TASK", "INTEGRATION_TASK", "DATA_LOADER_TASK", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type task_type: str
+
+        :param task:
+            The value to assign to the task property of this TaskOperator.
+        :type task: oci.data_integration.models.Task
+
+        :param trigger_rule:
+            The value to assign to the trigger_rule property of this TaskOperator.
+            Allowed values for this property are: "ALL_SUCCESS", "ALL_FAILED", "ALL_COMPLETE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type trigger_rule: str
+
+        :param config_provider_delegate:
+            The value to assign to the config_provider_delegate property of this TaskOperator.
+        :type config_provider_delegate: oci.data_integration.models.ConfigProvider
+
+        """
+        self.swagger_types = {
+            'model_type': 'str',
+            'key': 'str',
+            'model_version': 'str',
+            'parent_ref': 'ParentReference',
+            'name': 'str',
+            'description': 'str',
+            'object_version': 'int',
+            'input_ports': 'list[InputPort]',
+            'output_ports': 'list[OutputPort]',
+            'object_status': 'int',
+            'identifier': 'str',
+            'parameters': 'list[Parameter]',
+            'op_config_values': 'ConfigValues',
+            'retry_attempts': 'int',
+            'retry_delay_unit': 'str',
+            'retry_delay': 'float',
+            'expected_duration': 'float',
+            'expected_duration_unit': 'str',
+            'task_type': 'str',
+            'task': 'Task',
+            'trigger_rule': 'str',
+            'config_provider_delegate': 'ConfigProvider'
+        }
+
+        self.attribute_map = {
+            'model_type': 'modelType',
+            'key': 'key',
+            'model_version': 'modelVersion',
+            'parent_ref': 'parentRef',
+            'name': 'name',
+            'description': 'description',
+            'object_version': 'objectVersion',
+            'input_ports': 'inputPorts',
+            'output_ports': 'outputPorts',
+            'object_status': 'objectStatus',
+            'identifier': 'identifier',
+            'parameters': 'parameters',
+            'op_config_values': 'opConfigValues',
+            'retry_attempts': 'retryAttempts',
+            'retry_delay_unit': 'retryDelayUnit',
+            'retry_delay': 'retryDelay',
+            'expected_duration': 'expectedDuration',
+            'expected_duration_unit': 'expectedDurationUnit',
+            'task_type': 'taskType',
+            'task': 'task',
+            'trigger_rule': 'triggerRule',
+            'config_provider_delegate': 'configProviderDelegate'
+        }
+
+        self._model_type = None
+        self._key = None
+        self._model_version = None
+        self._parent_ref = None
+        self._name = None
+        self._description = None
+        self._object_version = None
+        self._input_ports = None
+        self._output_ports = None
+        self._object_status = None
+        self._identifier = None
+        self._parameters = None
+        self._op_config_values = None
+        self._retry_attempts = None
+        self._retry_delay_unit = None
+        self._retry_delay = None
+        self._expected_duration = None
+        self._expected_duration_unit = None
+        self._task_type = None
+        self._task = None
+        self._trigger_rule = None
+        self._config_provider_delegate = None
+        self._model_type = 'TASK_OPERATOR'
+
+    @property
+    def retry_attempts(self):
+        """
+        Gets the retry_attempts of this TaskOperator.
+        The number of retry attempts.
+
+
+        :return: The retry_attempts of this TaskOperator.
+        :rtype: int
+        """
+        return self._retry_attempts
+
+    @retry_attempts.setter
+    def retry_attempts(self, retry_attempts):
+        """
+        Sets the retry_attempts of this TaskOperator.
+        The number of retry attempts.
+
+
+        :param retry_attempts: The retry_attempts of this TaskOperator.
+        :type: int
+        """
+        self._retry_attempts = retry_attempts
+
+    @property
+    def retry_delay_unit(self):
+        """
+        Gets the retry_delay_unit of this TaskOperator.
+        The unit for the retry delay.
+
+        Allowed values for this property are: "SECONDS", "MINUTES", "HOURS", "DAYS", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The retry_delay_unit of this TaskOperator.
+        :rtype: str
+        """
+        return self._retry_delay_unit
+
+    @retry_delay_unit.setter
+    def retry_delay_unit(self, retry_delay_unit):
+        """
+        Sets the retry_delay_unit of this TaskOperator.
+        The unit for the retry delay.
+
+
+        :param retry_delay_unit: The retry_delay_unit of this TaskOperator.
+        :type: str
+        """
+        allowed_values = ["SECONDS", "MINUTES", "HOURS", "DAYS"]
+        if not value_allowed_none_or_none_sentinel(retry_delay_unit, allowed_values):
+            retry_delay_unit = 'UNKNOWN_ENUM_VALUE'
+        self._retry_delay_unit = retry_delay_unit
+
+    @property
+    def retry_delay(self):
+        """
+        Gets the retry_delay of this TaskOperator.
+        The retry delay, the unit for measurement is in the property retry delay unit.
+
+
+        :return: The retry_delay of this TaskOperator.
+        :rtype: float
+        """
+        return self._retry_delay
+
+    @retry_delay.setter
+    def retry_delay(self, retry_delay):
+        """
+        Sets the retry_delay of this TaskOperator.
+        The retry delay, the unit for measurement is in the property retry delay unit.
+
+
+        :param retry_delay: The retry_delay of this TaskOperator.
+        :type: float
+        """
+        self._retry_delay = retry_delay
+
+    @property
+    def expected_duration(self):
+        """
+        Gets the expected_duration of this TaskOperator.
+        The expected duration for the task run.
+
+
+        :return: The expected_duration of this TaskOperator.
+        :rtype: float
+        """
+        return self._expected_duration
+
+    @expected_duration.setter
+    def expected_duration(self, expected_duration):
+        """
+        Sets the expected_duration of this TaskOperator.
+        The expected duration for the task run.
+
+
+        :param expected_duration: The expected_duration of this TaskOperator.
+        :type: float
+        """
+        self._expected_duration = expected_duration
+
+    @property
+    def expected_duration_unit(self):
+        """
+        Gets the expected_duration_unit of this TaskOperator.
+        The expected duration unit of measure.
+
+        Allowed values for this property are: "SECONDS", "MINUTES", "HOURS", "DAYS", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The expected_duration_unit of this TaskOperator.
+        :rtype: str
+        """
+        return self._expected_duration_unit
+
+    @expected_duration_unit.setter
+    def expected_duration_unit(self, expected_duration_unit):
+        """
+        Sets the expected_duration_unit of this TaskOperator.
+        The expected duration unit of measure.
+
+
+        :param expected_duration_unit: The expected_duration_unit of this TaskOperator.
+        :type: str
+        """
+        allowed_values = ["SECONDS", "MINUTES", "HOURS", "DAYS"]
+        if not value_allowed_none_or_none_sentinel(expected_duration_unit, allowed_values):
+            expected_duration_unit = 'UNKNOWN_ENUM_VALUE'
+        self._expected_duration_unit = expected_duration_unit
+
+    @property
+    def task_type(self):
+        """
+        Gets the task_type of this TaskOperator.
+        The type of the task referenced in the task property.
+
+        Allowed values for this property are: "PIPELINE_TASK", "INTEGRATION_TASK", "DATA_LOADER_TASK", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The task_type of this TaskOperator.
+        :rtype: str
+        """
+        return self._task_type
+
+    @task_type.setter
+    def task_type(self, task_type):
+        """
+        Sets the task_type of this TaskOperator.
+        The type of the task referenced in the task property.
+
+
+        :param task_type: The task_type of this TaskOperator.
+        :type: str
+        """
+        allowed_values = ["PIPELINE_TASK", "INTEGRATION_TASK", "DATA_LOADER_TASK"]
+        if not value_allowed_none_or_none_sentinel(task_type, allowed_values):
+            task_type = 'UNKNOWN_ENUM_VALUE'
+        self._task_type = task_type
+
+    @property
+    def task(self):
+        """
+        Gets the task of this TaskOperator.
+
+        :return: The task of this TaskOperator.
+        :rtype: oci.data_integration.models.Task
+        """
+        return self._task
+
+    @task.setter
+    def task(self, task):
+        """
+        Sets the task of this TaskOperator.
+
+        :param task: The task of this TaskOperator.
+        :type: oci.data_integration.models.Task
+        """
+        self._task = task
+
+    @property
+    def trigger_rule(self):
+        """
+        Gets the trigger_rule of this TaskOperator.
+        The merge condition. The conditions are
+        ALL_SUCCESS - All the preceeding operators need to be successful.
+        ALL_FAILED - All the preceeding operators should have failed.
+        ALL_COMPLETE - All the preceeding operators should have completed. It could have executed successfully or failed.
+
+        Allowed values for this property are: "ALL_SUCCESS", "ALL_FAILED", "ALL_COMPLETE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The trigger_rule of this TaskOperator.
+        :rtype: str
+        """
+        return self._trigger_rule
+
+    @trigger_rule.setter
+    def trigger_rule(self, trigger_rule):
+        """
+        Sets the trigger_rule of this TaskOperator.
+        The merge condition. The conditions are
+        ALL_SUCCESS - All the preceeding operators need to be successful.
+        ALL_FAILED - All the preceeding operators should have failed.
+        ALL_COMPLETE - All the preceeding operators should have completed. It could have executed successfully or failed.
+
+
+        :param trigger_rule: The trigger_rule of this TaskOperator.
+        :type: str
+        """
+        allowed_values = ["ALL_SUCCESS", "ALL_FAILED", "ALL_COMPLETE"]
+        if not value_allowed_none_or_none_sentinel(trigger_rule, allowed_values):
+            trigger_rule = 'UNKNOWN_ENUM_VALUE'
+        self._trigger_rule = trigger_rule
+
+    @property
+    def config_provider_delegate(self):
+        """
+        Gets the config_provider_delegate of this TaskOperator.
+
+        :return: The config_provider_delegate of this TaskOperator.
+        :rtype: oci.data_integration.models.ConfigProvider
+        """
+        return self._config_provider_delegate
+
+    @config_provider_delegate.setter
+    def config_provider_delegate(self, config_provider_delegate):
+        """
+        Sets the config_provider_delegate of this TaskOperator.
+
+        :param config_provider_delegate: The config_provider_delegate of this TaskOperator.
+        :type: oci.data_integration.models.ConfigProvider
+        """
+        self._config_provider_delegate = config_provider_delegate
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/task_run.py
+++ b/src/oci/data_integration/models/task_run.py
@@ -41,6 +41,22 @@ class TaskRun(object):
     #: This constant has a value of "ERROR"
     STATUS_ERROR = "ERROR"
 
+    #: A constant which can be used with the expected_duration_unit property of a TaskRun.
+    #: This constant has a value of "SECONDS"
+    EXPECTED_DURATION_UNIT_SECONDS = "SECONDS"
+
+    #: A constant which can be used with the expected_duration_unit property of a TaskRun.
+    #: This constant has a value of "MINUTES"
+    EXPECTED_DURATION_UNIT_MINUTES = "MINUTES"
+
+    #: A constant which can be used with the expected_duration_unit property of a TaskRun.
+    #: This constant has a value of "HOURS"
+    EXPECTED_DURATION_UNIT_HOURS = "HOURS"
+
+    #: A constant which can be used with the expected_duration_unit property of a TaskRun.
+    #: This constant has a value of "DAYS"
+    EXPECTED_DURATION_UNIT_DAYS = "DAYS"
+
     #: A constant which can be used with the task_type property of a TaskRun.
     #: This constant has a value of "INTEGRATION_TASK"
     TASK_TYPE_INTEGRATION_TASK = "INTEGRATION_TASK"
@@ -48,6 +64,10 @@ class TaskRun(object):
     #: A constant which can be used with the task_type property of a TaskRun.
     #: This constant has a value of "DATA_LOADER_TASK"
     TASK_TYPE_DATA_LOADER_TASK = "DATA_LOADER_TASK"
+
+    #: A constant which can be used with the task_type property of a TaskRun.
+    #: This constant has a value of "PIPELINE_TASK"
+    TASK_TYPE_PIPELINE_TASK = "PIPELINE_TASK"
 
     def __init__(self, **kwargs):
         """
@@ -116,6 +136,40 @@ class TaskRun(object):
             The value to assign to the error_message property of this TaskRun.
         :type error_message: str
 
+        :param expected_duration:
+            The value to assign to the expected_duration property of this TaskRun.
+        :type expected_duration: float
+
+        :param expected_duration_unit:
+            The value to assign to the expected_duration_unit property of this TaskRun.
+            Allowed values for this property are: "SECONDS", "MINUTES", "HOURS", "DAYS", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type expected_duration_unit: str
+
+        :param task_key:
+            The value to assign to the task_key property of this TaskRun.
+        :type task_key: str
+
+        :param retry_attempt:
+            The value to assign to the retry_attempt property of this TaskRun.
+        :type retry_attempt: int
+
+        :param task_schedule:
+            The value to assign to the task_schedule property of this TaskRun.
+        :type task_schedule: oci.data_integration.models.TaskSchedule
+
+        :param metrics:
+            The value to assign to the metrics property of this TaskRun.
+        :type metrics: dict(str, float)
+
+        :param execution_errors:
+            The value to assign to the execution_errors property of this TaskRun.
+        :type execution_errors: list[str]
+
+        :param termination_errors:
+            The value to assign to the termination_errors property of this TaskRun.
+        :type termination_errors: list[str]
+
         :param opc_request_id:
             The value to assign to the opc_request_id property of this TaskRun.
         :type opc_request_id: str
@@ -126,7 +180,7 @@ class TaskRun(object):
 
         :param task_type:
             The value to assign to the task_type property of this TaskRun.
-            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type task_type: str
 
@@ -159,6 +213,14 @@ class TaskRun(object):
             'records_written': 'int',
             'bytes_processed': 'int',
             'error_message': 'str',
+            'expected_duration': 'float',
+            'expected_duration_unit': 'str',
+            'task_key': 'str',
+            'retry_attempt': 'int',
+            'task_schedule': 'TaskSchedule',
+            'metrics': 'dict(str, float)',
+            'execution_errors': 'list[str]',
+            'termination_errors': 'list[str]',
             'opc_request_id': 'str',
             'object_status': 'int',
             'task_type': 'str',
@@ -183,6 +245,14 @@ class TaskRun(object):
             'records_written': 'recordsWritten',
             'bytes_processed': 'bytesProcessed',
             'error_message': 'errorMessage',
+            'expected_duration': 'expectedDuration',
+            'expected_duration_unit': 'expectedDurationUnit',
+            'task_key': 'taskKey',
+            'retry_attempt': 'retryAttempt',
+            'task_schedule': 'taskSchedule',
+            'metrics': 'metrics',
+            'execution_errors': 'executionErrors',
+            'termination_errors': 'terminationErrors',
             'opc_request_id': 'opcRequestId',
             'object_status': 'objectStatus',
             'task_type': 'taskType',
@@ -206,6 +276,14 @@ class TaskRun(object):
         self._records_written = None
         self._bytes_processed = None
         self._error_message = None
+        self._expected_duration = None
+        self._expected_duration_unit = None
+        self._task_key = None
+        self._retry_attempt = None
+        self._task_schedule = None
+        self._metrics = None
+        self._execution_errors = None
+        self._termination_errors = None
         self._opc_request_id = None
         self._object_status = None
         self._task_type = None
@@ -572,6 +650,200 @@ class TaskRun(object):
         self._error_message = error_message
 
     @property
+    def expected_duration(self):
+        """
+        Gets the expected_duration of this TaskRun.
+        The expected duration for the task run.
+
+
+        :return: The expected_duration of this TaskRun.
+        :rtype: float
+        """
+        return self._expected_duration
+
+    @expected_duration.setter
+    def expected_duration(self, expected_duration):
+        """
+        Sets the expected_duration of this TaskRun.
+        The expected duration for the task run.
+
+
+        :param expected_duration: The expected_duration of this TaskRun.
+        :type: float
+        """
+        self._expected_duration = expected_duration
+
+    @property
+    def expected_duration_unit(self):
+        """
+        Gets the expected_duration_unit of this TaskRun.
+        The expected duration unit of measure.
+
+        Allowed values for this property are: "SECONDS", "MINUTES", "HOURS", "DAYS", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The expected_duration_unit of this TaskRun.
+        :rtype: str
+        """
+        return self._expected_duration_unit
+
+    @expected_duration_unit.setter
+    def expected_duration_unit(self, expected_duration_unit):
+        """
+        Sets the expected_duration_unit of this TaskRun.
+        The expected duration unit of measure.
+
+
+        :param expected_duration_unit: The expected_duration_unit of this TaskRun.
+        :type: str
+        """
+        allowed_values = ["SECONDS", "MINUTES", "HOURS", "DAYS"]
+        if not value_allowed_none_or_none_sentinel(expected_duration_unit, allowed_values):
+            expected_duration_unit = 'UNKNOWN_ENUM_VALUE'
+        self._expected_duration_unit = expected_duration_unit
+
+    @property
+    def task_key(self):
+        """
+        Gets the task_key of this TaskRun.
+        Task Key of the task for which TaskRun is being created. If not specified, the AggregatorKey in RegistryMetadata will be assumed to be the TaskKey
+
+
+        :return: The task_key of this TaskRun.
+        :rtype: str
+        """
+        return self._task_key
+
+    @task_key.setter
+    def task_key(self, task_key):
+        """
+        Sets the task_key of this TaskRun.
+        Task Key of the task for which TaskRun is being created. If not specified, the AggregatorKey in RegistryMetadata will be assumed to be the TaskKey
+
+
+        :param task_key: The task_key of this TaskRun.
+        :type: str
+        """
+        self._task_key = task_key
+
+    @property
+    def retry_attempt(self):
+        """
+        Gets the retry_attempt of this TaskRun.
+        Holds the particular attempt number.
+
+
+        :return: The retry_attempt of this TaskRun.
+        :rtype: int
+        """
+        return self._retry_attempt
+
+    @retry_attempt.setter
+    def retry_attempt(self, retry_attempt):
+        """
+        Sets the retry_attempt of this TaskRun.
+        Holds the particular attempt number.
+
+
+        :param retry_attempt: The retry_attempt of this TaskRun.
+        :type: int
+        """
+        self._retry_attempt = retry_attempt
+
+    @property
+    def task_schedule(self):
+        """
+        Gets the task_schedule of this TaskRun.
+
+        :return: The task_schedule of this TaskRun.
+        :rtype: oci.data_integration.models.TaskSchedule
+        """
+        return self._task_schedule
+
+    @task_schedule.setter
+    def task_schedule(self, task_schedule):
+        """
+        Sets the task_schedule of this TaskRun.
+
+        :param task_schedule: The task_schedule of this TaskRun.
+        :type: oci.data_integration.models.TaskSchedule
+        """
+        self._task_schedule = task_schedule
+
+    @property
+    def metrics(self):
+        """
+        Gets the metrics of this TaskRun.
+        A map of metrics for the run.
+
+
+        :return: The metrics of this TaskRun.
+        :rtype: dict(str, float)
+        """
+        return self._metrics
+
+    @metrics.setter
+    def metrics(self, metrics):
+        """
+        Sets the metrics of this TaskRun.
+        A map of metrics for the run.
+
+
+        :param metrics: The metrics of this TaskRun.
+        :type: dict(str, float)
+        """
+        self._metrics = metrics
+
+    @property
+    def execution_errors(self):
+        """
+        Gets the execution_errors of this TaskRun.
+        An array of execution errors from the run.
+
+
+        :return: The execution_errors of this TaskRun.
+        :rtype: list[str]
+        """
+        return self._execution_errors
+
+    @execution_errors.setter
+    def execution_errors(self, execution_errors):
+        """
+        Sets the execution_errors of this TaskRun.
+        An array of execution errors from the run.
+
+
+        :param execution_errors: The execution_errors of this TaskRun.
+        :type: list[str]
+        """
+        self._execution_errors = execution_errors
+
+    @property
+    def termination_errors(self):
+        """
+        Gets the termination_errors of this TaskRun.
+        An array of termination errors from the run.
+
+
+        :return: The termination_errors of this TaskRun.
+        :rtype: list[str]
+        """
+        return self._termination_errors
+
+    @termination_errors.setter
+    def termination_errors(self, termination_errors):
+        """
+        Sets the termination_errors of this TaskRun.
+        An array of termination errors from the run.
+
+
+        :param termination_errors: The termination_errors of this TaskRun.
+        :type: list[str]
+        """
+        self._termination_errors = termination_errors
+
+    @property
     def opc_request_id(self):
         """
         Gets the opc_request_id of this TaskRun.
@@ -625,7 +897,7 @@ class TaskRun(object):
         Gets the task_type of this TaskRun.
         The type of task run.
 
-        Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -644,7 +916,7 @@ class TaskRun(object):
         :param task_type: The task_type of this TaskRun.
         :type: str
         """
-        allowed_values = ["INTEGRATION_TASK", "DATA_LOADER_TASK"]
+        allowed_values = ["INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK"]
         if not value_allowed_none_or_none_sentinel(task_type, allowed_values):
             task_type = 'UNKNOWN_ENUM_VALUE'
         self._task_type = task_type

--- a/src/oci/data_integration/models/task_run_details.py
+++ b/src/oci/data_integration/models/task_run_details.py
@@ -49,6 +49,10 @@ class TaskRunDetails(object):
     #: This constant has a value of "DATA_LOADER_TASK"
     TASK_TYPE_DATA_LOADER_TASK = "DATA_LOADER_TASK"
 
+    #: A constant which can be used with the task_type property of a TaskRunDetails.
+    #: This constant has a value of "PIPELINE_TASK"
+    TASK_TYPE_PIPELINE_TASK = "PIPELINE_TASK"
+
     def __init__(self, **kwargs):
         """
         Initializes a new TaskRunDetails object with values from keyword arguments.
@@ -114,7 +118,7 @@ class TaskRunDetails(object):
 
         :param task_type:
             The value to assign to the task_type property of this TaskRunDetails.
-            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type task_type: str
 
@@ -529,7 +533,7 @@ class TaskRunDetails(object):
         Gets the task_type of this TaskRunDetails.
         The type of the task for the run.
 
-        Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -548,7 +552,7 @@ class TaskRunDetails(object):
         :param task_type: The task_type of this TaskRunDetails.
         :type: str
         """
-        allowed_values = ["INTEGRATION_TASK", "DATA_LOADER_TASK"]
+        allowed_values = ["INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK"]
         if not value_allowed_none_or_none_sentinel(task_type, allowed_values):
             task_type = 'UNKNOWN_ENUM_VALUE'
         self._task_type = task_type

--- a/src/oci/data_integration/models/task_run_summary.py
+++ b/src/oci/data_integration/models/task_run_summary.py
@@ -49,6 +49,10 @@ class TaskRunSummary(object):
     #: This constant has a value of "DATA_LOADER_TASK"
     TASK_TYPE_DATA_LOADER_TASK = "DATA_LOADER_TASK"
 
+    #: A constant which can be used with the task_type property of a TaskRunSummary.
+    #: This constant has a value of "PIPELINE_TASK"
+    TASK_TYPE_PIPELINE_TASK = "PIPELINE_TASK"
+
     def __init__(self, **kwargs):
         """
         Initializes a new TaskRunSummary object with values from keyword arguments.
@@ -114,7 +118,7 @@ class TaskRunSummary(object):
 
         :param task_type:
             The value to assign to the task_type property of this TaskRunSummary.
-            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type task_type: str
 
@@ -529,7 +533,7 @@ class TaskRunSummary(object):
         Gets the task_type of this TaskRunSummary.
         The type of the task for the run.
 
-        Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -548,7 +552,7 @@ class TaskRunSummary(object):
         :param task_type: The task_type of this TaskRunSummary.
         :type: str
         """
-        allowed_values = ["INTEGRATION_TASK", "DATA_LOADER_TASK"]
+        allowed_values = ["INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK"]
         if not value_allowed_none_or_none_sentinel(task_type, allowed_values):
             task_type = 'UNKNOWN_ENUM_VALUE'
         self._task_type = task_type

--- a/src/oci/data_integration/models/task_schedule.py
+++ b/src/oci/data_integration/models/task_schedule.py
@@ -1,0 +1,831 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class TaskSchedule(object):
+    """
+    A model that holds Schedule and other information required for scheduling a task.
+    """
+
+    #: A constant which can be used with the retry_delay_unit property of a TaskSchedule.
+    #: This constant has a value of "SECONDS"
+    RETRY_DELAY_UNIT_SECONDS = "SECONDS"
+
+    #: A constant which can be used with the retry_delay_unit property of a TaskSchedule.
+    #: This constant has a value of "MINUTES"
+    RETRY_DELAY_UNIT_MINUTES = "MINUTES"
+
+    #: A constant which can be used with the retry_delay_unit property of a TaskSchedule.
+    #: This constant has a value of "HOURS"
+    RETRY_DELAY_UNIT_HOURS = "HOURS"
+
+    #: A constant which can be used with the retry_delay_unit property of a TaskSchedule.
+    #: This constant has a value of "DAYS"
+    RETRY_DELAY_UNIT_DAYS = "DAYS"
+
+    #: A constant which can be used with the auth_mode property of a TaskSchedule.
+    #: This constant has a value of "OBO"
+    AUTH_MODE_OBO = "OBO"
+
+    #: A constant which can be used with the auth_mode property of a TaskSchedule.
+    #: This constant has a value of "RESOURCE_PRINCIPAL"
+    AUTH_MODE_RESOURCE_PRINCIPAL = "RESOURCE_PRINCIPAL"
+
+    #: A constant which can be used with the auth_mode property of a TaskSchedule.
+    #: This constant has a value of "USER_CERTIFICATE"
+    AUTH_MODE_USER_CERTIFICATE = "USER_CERTIFICATE"
+
+    #: A constant which can be used with the expected_duration_unit property of a TaskSchedule.
+    #: This constant has a value of "SECONDS"
+    EXPECTED_DURATION_UNIT_SECONDS = "SECONDS"
+
+    #: A constant which can be used with the expected_duration_unit property of a TaskSchedule.
+    #: This constant has a value of "MINUTES"
+    EXPECTED_DURATION_UNIT_MINUTES = "MINUTES"
+
+    #: A constant which can be used with the expected_duration_unit property of a TaskSchedule.
+    #: This constant has a value of "HOURS"
+    EXPECTED_DURATION_UNIT_HOURS = "HOURS"
+
+    #: A constant which can be used with the expected_duration_unit property of a TaskSchedule.
+    #: This constant has a value of "DAYS"
+    EXPECTED_DURATION_UNIT_DAYS = "DAYS"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new TaskSchedule object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param key:
+            The value to assign to the key property of this TaskSchedule.
+        :type key: str
+
+        :param model_version:
+            The value to assign to the model_version property of this TaskSchedule.
+        :type model_version: str
+
+        :param model_type:
+            The value to assign to the model_type property of this TaskSchedule.
+        :type model_type: str
+
+        :param parent_ref:
+            The value to assign to the parent_ref property of this TaskSchedule.
+        :type parent_ref: oci.data_integration.models.ParentReference
+
+        :param name:
+            The value to assign to the name property of this TaskSchedule.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this TaskSchedule.
+        :type description: str
+
+        :param object_version:
+            The value to assign to the object_version property of this TaskSchedule.
+        :type object_version: int
+
+        :param object_status:
+            The value to assign to the object_status property of this TaskSchedule.
+        :type object_status: int
+
+        :param identifier:
+            The value to assign to the identifier property of this TaskSchedule.
+        :type identifier: str
+
+        :param schedule_ref:
+            The value to assign to the schedule_ref property of this TaskSchedule.
+        :type schedule_ref: oci.data_integration.models.Schedule
+
+        :param config_provider_delegate:
+            The value to assign to the config_provider_delegate property of this TaskSchedule.
+        :type config_provider_delegate: oci.data_integration.models.ConfigProvider
+
+        :param is_enabled:
+            The value to assign to the is_enabled property of this TaskSchedule.
+        :type is_enabled: bool
+
+        :param retry_attempts:
+            The value to assign to the retry_attempts property of this TaskSchedule.
+        :type retry_attempts: int
+
+        :param retry_delay_unit:
+            The value to assign to the retry_delay_unit property of this TaskSchedule.
+            Allowed values for this property are: "SECONDS", "MINUTES", "HOURS", "DAYS", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type retry_delay_unit: str
+
+        :param retry_delay:
+            The value to assign to the retry_delay property of this TaskSchedule.
+        :type retry_delay: float
+
+        :param start_time_millis:
+            The value to assign to the start_time_millis property of this TaskSchedule.
+        :type start_time_millis: int
+
+        :param end_time_millis:
+            The value to assign to the end_time_millis property of this TaskSchedule.
+        :type end_time_millis: int
+
+        :param is_concurrent_allowed:
+            The value to assign to the is_concurrent_allowed property of this TaskSchedule.
+        :type is_concurrent_allowed: bool
+
+        :param is_backfill_enabled:
+            The value to assign to the is_backfill_enabled property of this TaskSchedule.
+        :type is_backfill_enabled: bool
+
+        :param auth_mode:
+            The value to assign to the auth_mode property of this TaskSchedule.
+            Allowed values for this property are: "OBO", "RESOURCE_PRINCIPAL", "USER_CERTIFICATE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type auth_mode: str
+
+        :param expected_duration:
+            The value to assign to the expected_duration property of this TaskSchedule.
+        :type expected_duration: float
+
+        :param expected_duration_unit:
+            The value to assign to the expected_duration_unit property of this TaskSchedule.
+            Allowed values for this property are: "SECONDS", "MINUTES", "HOURS", "DAYS", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type expected_duration_unit: str
+
+        :param last_run_details:
+            The value to assign to the last_run_details property of this TaskSchedule.
+        :type last_run_details: oci.data_integration.models.LastRunDetails
+
+        :param metadata:
+            The value to assign to the metadata property of this TaskSchedule.
+        :type metadata: oci.data_integration.models.ObjectMetadata
+
+        """
+        self.swagger_types = {
+            'key': 'str',
+            'model_version': 'str',
+            'model_type': 'str',
+            'parent_ref': 'ParentReference',
+            'name': 'str',
+            'description': 'str',
+            'object_version': 'int',
+            'object_status': 'int',
+            'identifier': 'str',
+            'schedule_ref': 'Schedule',
+            'config_provider_delegate': 'ConfigProvider',
+            'is_enabled': 'bool',
+            'retry_attempts': 'int',
+            'retry_delay_unit': 'str',
+            'retry_delay': 'float',
+            'start_time_millis': 'int',
+            'end_time_millis': 'int',
+            'is_concurrent_allowed': 'bool',
+            'is_backfill_enabled': 'bool',
+            'auth_mode': 'str',
+            'expected_duration': 'float',
+            'expected_duration_unit': 'str',
+            'last_run_details': 'LastRunDetails',
+            'metadata': 'ObjectMetadata'
+        }
+
+        self.attribute_map = {
+            'key': 'key',
+            'model_version': 'modelVersion',
+            'model_type': 'modelType',
+            'parent_ref': 'parentRef',
+            'name': 'name',
+            'description': 'description',
+            'object_version': 'objectVersion',
+            'object_status': 'objectStatus',
+            'identifier': 'identifier',
+            'schedule_ref': 'scheduleRef',
+            'config_provider_delegate': 'configProviderDelegate',
+            'is_enabled': 'isEnabled',
+            'retry_attempts': 'retryAttempts',
+            'retry_delay_unit': 'retryDelayUnit',
+            'retry_delay': 'retryDelay',
+            'start_time_millis': 'startTimeMillis',
+            'end_time_millis': 'endTimeMillis',
+            'is_concurrent_allowed': 'isConcurrentAllowed',
+            'is_backfill_enabled': 'isBackfillEnabled',
+            'auth_mode': 'authMode',
+            'expected_duration': 'expectedDuration',
+            'expected_duration_unit': 'expectedDurationUnit',
+            'last_run_details': 'lastRunDetails',
+            'metadata': 'metadata'
+        }
+
+        self._key = None
+        self._model_version = None
+        self._model_type = None
+        self._parent_ref = None
+        self._name = None
+        self._description = None
+        self._object_version = None
+        self._object_status = None
+        self._identifier = None
+        self._schedule_ref = None
+        self._config_provider_delegate = None
+        self._is_enabled = None
+        self._retry_attempts = None
+        self._retry_delay_unit = None
+        self._retry_delay = None
+        self._start_time_millis = None
+        self._end_time_millis = None
+        self._is_concurrent_allowed = None
+        self._is_backfill_enabled = None
+        self._auth_mode = None
+        self._expected_duration = None
+        self._expected_duration_unit = None
+        self._last_run_details = None
+        self._metadata = None
+
+    @property
+    def key(self):
+        """
+        Gets the key of this TaskSchedule.
+        Generated key that can be used in API calls to identify taskSchedule. On scenarios where reference to the taskSchedule is needed, a value can be passed in create.
+
+
+        :return: The key of this TaskSchedule.
+        :rtype: str
+        """
+        return self._key
+
+    @key.setter
+    def key(self, key):
+        """
+        Sets the key of this TaskSchedule.
+        Generated key that can be used in API calls to identify taskSchedule. On scenarios where reference to the taskSchedule is needed, a value can be passed in create.
+
+
+        :param key: The key of this TaskSchedule.
+        :type: str
+        """
+        self._key = key
+
+    @property
+    def model_version(self):
+        """
+        Gets the model_version of this TaskSchedule.
+        This is a version number that is used by the service to upgrade objects if needed through releases of the service.
+
+
+        :return: The model_version of this TaskSchedule.
+        :rtype: str
+        """
+        return self._model_version
+
+    @model_version.setter
+    def model_version(self, model_version):
+        """
+        Sets the model_version of this TaskSchedule.
+        This is a version number that is used by the service to upgrade objects if needed through releases of the service.
+
+
+        :param model_version: The model_version of this TaskSchedule.
+        :type: str
+        """
+        self._model_version = model_version
+
+    @property
+    def model_type(self):
+        """
+        Gets the model_type of this TaskSchedule.
+        The type of the object.
+
+
+        :return: The model_type of this TaskSchedule.
+        :rtype: str
+        """
+        return self._model_type
+
+    @model_type.setter
+    def model_type(self, model_type):
+        """
+        Sets the model_type of this TaskSchedule.
+        The type of the object.
+
+
+        :param model_type: The model_type of this TaskSchedule.
+        :type: str
+        """
+        self._model_type = model_type
+
+    @property
+    def parent_ref(self):
+        """
+        Gets the parent_ref of this TaskSchedule.
+
+        :return: The parent_ref of this TaskSchedule.
+        :rtype: oci.data_integration.models.ParentReference
+        """
+        return self._parent_ref
+
+    @parent_ref.setter
+    def parent_ref(self, parent_ref):
+        """
+        Sets the parent_ref of this TaskSchedule.
+
+        :param parent_ref: The parent_ref of this TaskSchedule.
+        :type: oci.data_integration.models.ParentReference
+        """
+        self._parent_ref = parent_ref
+
+    @property
+    def name(self):
+        """
+        Gets the name of this TaskSchedule.
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
+
+
+        :return: The name of this TaskSchedule.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this TaskSchedule.
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
+
+
+        :param name: The name of this TaskSchedule.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def description(self):
+        """
+        Gets the description of this TaskSchedule.
+        Detailed description for the object.
+
+
+        :return: The description of this TaskSchedule.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this TaskSchedule.
+        Detailed description for the object.
+
+
+        :param description: The description of this TaskSchedule.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def object_version(self):
+        """
+        Gets the object_version of this TaskSchedule.
+        This is used by the service for optimistic locking of the object, to prevent multiple users from simultaneously updating the object.
+
+
+        :return: The object_version of this TaskSchedule.
+        :rtype: int
+        """
+        return self._object_version
+
+    @object_version.setter
+    def object_version(self, object_version):
+        """
+        Sets the object_version of this TaskSchedule.
+        This is used by the service for optimistic locking of the object, to prevent multiple users from simultaneously updating the object.
+
+
+        :param object_version: The object_version of this TaskSchedule.
+        :type: int
+        """
+        self._object_version = object_version
+
+    @property
+    def object_status(self):
+        """
+        Gets the object_status of this TaskSchedule.
+        The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+
+
+        :return: The object_status of this TaskSchedule.
+        :rtype: int
+        """
+        return self._object_status
+
+    @object_status.setter
+    def object_status(self, object_status):
+        """
+        Sets the object_status of this TaskSchedule.
+        The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+
+
+        :param object_status: The object_status of this TaskSchedule.
+        :type: int
+        """
+        self._object_status = object_status
+
+    @property
+    def identifier(self):
+        """
+        Gets the identifier of this TaskSchedule.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
+
+
+        :return: The identifier of this TaskSchedule.
+        :rtype: str
+        """
+        return self._identifier
+
+    @identifier.setter
+    def identifier(self, identifier):
+        """
+        Sets the identifier of this TaskSchedule.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
+
+
+        :param identifier: The identifier of this TaskSchedule.
+        :type: str
+        """
+        self._identifier = identifier
+
+    @property
+    def schedule_ref(self):
+        """
+        Gets the schedule_ref of this TaskSchedule.
+
+        :return: The schedule_ref of this TaskSchedule.
+        :rtype: oci.data_integration.models.Schedule
+        """
+        return self._schedule_ref
+
+    @schedule_ref.setter
+    def schedule_ref(self, schedule_ref):
+        """
+        Sets the schedule_ref of this TaskSchedule.
+
+        :param schedule_ref: The schedule_ref of this TaskSchedule.
+        :type: oci.data_integration.models.Schedule
+        """
+        self._schedule_ref = schedule_ref
+
+    @property
+    def config_provider_delegate(self):
+        """
+        Gets the config_provider_delegate of this TaskSchedule.
+
+        :return: The config_provider_delegate of this TaskSchedule.
+        :rtype: oci.data_integration.models.ConfigProvider
+        """
+        return self._config_provider_delegate
+
+    @config_provider_delegate.setter
+    def config_provider_delegate(self, config_provider_delegate):
+        """
+        Sets the config_provider_delegate of this TaskSchedule.
+
+        :param config_provider_delegate: The config_provider_delegate of this TaskSchedule.
+        :type: oci.data_integration.models.ConfigProvider
+        """
+        self._config_provider_delegate = config_provider_delegate
+
+    @property
+    def is_enabled(self):
+        """
+        Gets the is_enabled of this TaskSchedule.
+        Whether the schedule is enabled.
+
+
+        :return: The is_enabled of this TaskSchedule.
+        :rtype: bool
+        """
+        return self._is_enabled
+
+    @is_enabled.setter
+    def is_enabled(self, is_enabled):
+        """
+        Sets the is_enabled of this TaskSchedule.
+        Whether the schedule is enabled.
+
+
+        :param is_enabled: The is_enabled of this TaskSchedule.
+        :type: bool
+        """
+        self._is_enabled = is_enabled
+
+    @property
+    def retry_attempts(self):
+        """
+        Gets the retry_attempts of this TaskSchedule.
+        The number of retry attempts.
+
+
+        :return: The retry_attempts of this TaskSchedule.
+        :rtype: int
+        """
+        return self._retry_attempts
+
+    @retry_attempts.setter
+    def retry_attempts(self, retry_attempts):
+        """
+        Sets the retry_attempts of this TaskSchedule.
+        The number of retry attempts.
+
+
+        :param retry_attempts: The retry_attempts of this TaskSchedule.
+        :type: int
+        """
+        self._retry_attempts = retry_attempts
+
+    @property
+    def retry_delay_unit(self):
+        """
+        Gets the retry_delay_unit of this TaskSchedule.
+        The unit for the retry delay.
+
+        Allowed values for this property are: "SECONDS", "MINUTES", "HOURS", "DAYS", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The retry_delay_unit of this TaskSchedule.
+        :rtype: str
+        """
+        return self._retry_delay_unit
+
+    @retry_delay_unit.setter
+    def retry_delay_unit(self, retry_delay_unit):
+        """
+        Sets the retry_delay_unit of this TaskSchedule.
+        The unit for the retry delay.
+
+
+        :param retry_delay_unit: The retry_delay_unit of this TaskSchedule.
+        :type: str
+        """
+        allowed_values = ["SECONDS", "MINUTES", "HOURS", "DAYS"]
+        if not value_allowed_none_or_none_sentinel(retry_delay_unit, allowed_values):
+            retry_delay_unit = 'UNKNOWN_ENUM_VALUE'
+        self._retry_delay_unit = retry_delay_unit
+
+    @property
+    def retry_delay(self):
+        """
+        Gets the retry_delay of this TaskSchedule.
+        The retry delay, the unit for measurement is in the property retry delay unit.
+
+
+        :return: The retry_delay of this TaskSchedule.
+        :rtype: float
+        """
+        return self._retry_delay
+
+    @retry_delay.setter
+    def retry_delay(self, retry_delay):
+        """
+        Sets the retry_delay of this TaskSchedule.
+        The retry delay, the unit for measurement is in the property retry delay unit.
+
+
+        :param retry_delay: The retry_delay of this TaskSchedule.
+        :type: float
+        """
+        self._retry_delay = retry_delay
+
+    @property
+    def start_time_millis(self):
+        """
+        Gets the start_time_millis of this TaskSchedule.
+        The start time in milliseconds.
+
+
+        :return: The start_time_millis of this TaskSchedule.
+        :rtype: int
+        """
+        return self._start_time_millis
+
+    @start_time_millis.setter
+    def start_time_millis(self, start_time_millis):
+        """
+        Sets the start_time_millis of this TaskSchedule.
+        The start time in milliseconds.
+
+
+        :param start_time_millis: The start_time_millis of this TaskSchedule.
+        :type: int
+        """
+        self._start_time_millis = start_time_millis
+
+    @property
+    def end_time_millis(self):
+        """
+        Gets the end_time_millis of this TaskSchedule.
+        The end time in milliseconds.
+
+
+        :return: The end_time_millis of this TaskSchedule.
+        :rtype: int
+        """
+        return self._end_time_millis
+
+    @end_time_millis.setter
+    def end_time_millis(self, end_time_millis):
+        """
+        Sets the end_time_millis of this TaskSchedule.
+        The end time in milliseconds.
+
+
+        :param end_time_millis: The end_time_millis of this TaskSchedule.
+        :type: int
+        """
+        self._end_time_millis = end_time_millis
+
+    @property
+    def is_concurrent_allowed(self):
+        """
+        Gets the is_concurrent_allowed of this TaskSchedule.
+        Whether the same task can be executed concurrently.
+
+
+        :return: The is_concurrent_allowed of this TaskSchedule.
+        :rtype: bool
+        """
+        return self._is_concurrent_allowed
+
+    @is_concurrent_allowed.setter
+    def is_concurrent_allowed(self, is_concurrent_allowed):
+        """
+        Sets the is_concurrent_allowed of this TaskSchedule.
+        Whether the same task can be executed concurrently.
+
+
+        :param is_concurrent_allowed: The is_concurrent_allowed of this TaskSchedule.
+        :type: bool
+        """
+        self._is_concurrent_allowed = is_concurrent_allowed
+
+    @property
+    def is_backfill_enabled(self):
+        """
+        Gets the is_backfill_enabled of this TaskSchedule.
+        Whether the backfill is enabled
+
+
+        :return: The is_backfill_enabled of this TaskSchedule.
+        :rtype: bool
+        """
+        return self._is_backfill_enabled
+
+    @is_backfill_enabled.setter
+    def is_backfill_enabled(self, is_backfill_enabled):
+        """
+        Sets the is_backfill_enabled of this TaskSchedule.
+        Whether the backfill is enabled
+
+
+        :param is_backfill_enabled: The is_backfill_enabled of this TaskSchedule.
+        :type: bool
+        """
+        self._is_backfill_enabled = is_backfill_enabled
+
+    @property
+    def auth_mode(self):
+        """
+        Gets the auth_mode of this TaskSchedule.
+        The authorization mode for the task.
+
+        Allowed values for this property are: "OBO", "RESOURCE_PRINCIPAL", "USER_CERTIFICATE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The auth_mode of this TaskSchedule.
+        :rtype: str
+        """
+        return self._auth_mode
+
+    @auth_mode.setter
+    def auth_mode(self, auth_mode):
+        """
+        Sets the auth_mode of this TaskSchedule.
+        The authorization mode for the task.
+
+
+        :param auth_mode: The auth_mode of this TaskSchedule.
+        :type: str
+        """
+        allowed_values = ["OBO", "RESOURCE_PRINCIPAL", "USER_CERTIFICATE"]
+        if not value_allowed_none_or_none_sentinel(auth_mode, allowed_values):
+            auth_mode = 'UNKNOWN_ENUM_VALUE'
+        self._auth_mode = auth_mode
+
+    @property
+    def expected_duration(self):
+        """
+        Gets the expected_duration of this TaskSchedule.
+        The expected duration of the task execution.
+
+
+        :return: The expected_duration of this TaskSchedule.
+        :rtype: float
+        """
+        return self._expected_duration
+
+    @expected_duration.setter
+    def expected_duration(self, expected_duration):
+        """
+        Sets the expected_duration of this TaskSchedule.
+        The expected duration of the task execution.
+
+
+        :param expected_duration: The expected_duration of this TaskSchedule.
+        :type: float
+        """
+        self._expected_duration = expected_duration
+
+    @property
+    def expected_duration_unit(self):
+        """
+        Gets the expected_duration_unit of this TaskSchedule.
+        The expected duration unit of the task execution.
+
+        Allowed values for this property are: "SECONDS", "MINUTES", "HOURS", "DAYS", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The expected_duration_unit of this TaskSchedule.
+        :rtype: str
+        """
+        return self._expected_duration_unit
+
+    @expected_duration_unit.setter
+    def expected_duration_unit(self, expected_duration_unit):
+        """
+        Sets the expected_duration_unit of this TaskSchedule.
+        The expected duration unit of the task execution.
+
+
+        :param expected_duration_unit: The expected_duration_unit of this TaskSchedule.
+        :type: str
+        """
+        allowed_values = ["SECONDS", "MINUTES", "HOURS", "DAYS"]
+        if not value_allowed_none_or_none_sentinel(expected_duration_unit, allowed_values):
+            expected_duration_unit = 'UNKNOWN_ENUM_VALUE'
+        self._expected_duration_unit = expected_duration_unit
+
+    @property
+    def last_run_details(self):
+        """
+        Gets the last_run_details of this TaskSchedule.
+
+        :return: The last_run_details of this TaskSchedule.
+        :rtype: oci.data_integration.models.LastRunDetails
+        """
+        return self._last_run_details
+
+    @last_run_details.setter
+    def last_run_details(self, last_run_details):
+        """
+        Sets the last_run_details of this TaskSchedule.
+
+        :param last_run_details: The last_run_details of this TaskSchedule.
+        :type: oci.data_integration.models.LastRunDetails
+        """
+        self._last_run_details = last_run_details
+
+    @property
+    def metadata(self):
+        """
+        Gets the metadata of this TaskSchedule.
+
+        :return: The metadata of this TaskSchedule.
+        :rtype: oci.data_integration.models.ObjectMetadata
+        """
+        return self._metadata
+
+    @metadata.setter
+    def metadata(self, metadata):
+        """
+        Sets the metadata of this TaskSchedule.
+
+        :param metadata: The metadata of this TaskSchedule.
+        :type: oci.data_integration.models.ObjectMetadata
+        """
+        self._metadata = metadata
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/task_summary.py
+++ b/src/oci/data_integration/models/task_summary.py
@@ -21,19 +21,24 @@ class TaskSummary(object):
     #: This constant has a value of "DATA_LOADER_TASK"
     MODEL_TYPE_DATA_LOADER_TASK = "DATA_LOADER_TASK"
 
+    #: A constant which can be used with the model_type property of a TaskSummary.
+    #: This constant has a value of "PIPELINE_TASK"
+    MODEL_TYPE_PIPELINE_TASK = "PIPELINE_TASK"
+
     def __init__(self, **kwargs):
         """
         Initializes a new TaskSummary object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
         to a service operations then you should favor using a subclass over the base class:
 
         * :class:`~oci.data_integration.models.TaskSummaryFromIntegrationTask`
+        * :class:`~oci.data_integration.models.TaskSummaryFromPipelineTask`
         * :class:`~oci.data_integration.models.TaskSummaryFromDataLoaderTask`
 
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
         :param model_type:
             The value to assign to the model_type property of this TaskSummary.
-            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type model_type: str
 
@@ -164,6 +169,9 @@ class TaskSummary(object):
         if type == 'INTEGRATION_TASK':
             return 'TaskSummaryFromIntegrationTask'
 
+        if type == 'PIPELINE_TASK':
+            return 'TaskSummaryFromPipelineTask'
+
         if type == 'DATA_LOADER_TASK':
             return 'TaskSummaryFromDataLoaderTask'
         else:
@@ -175,7 +183,7 @@ class TaskSummary(object):
         Gets the model_type of this TaskSummary.
         The type of task.
 
-        Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -194,7 +202,7 @@ class TaskSummary(object):
         :param model_type: The model_type of this TaskSummary.
         :type: str
         """
-        allowed_values = ["INTEGRATION_TASK", "DATA_LOADER_TASK"]
+        allowed_values = ["INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK"]
         if not value_allowed_none_or_none_sentinel(model_type, allowed_values):
             model_type = 'UNKNOWN_ENUM_VALUE'
         self._model_type = model_type

--- a/src/oci/data_integration/models/task_summary_from_data_loader_task.py
+++ b/src/oci/data_integration/models/task_summary_from_data_loader_task.py
@@ -21,7 +21,7 @@ class TaskSummaryFromDataLoaderTask(TaskSummary):
 
         :param model_type:
             The value to assign to the model_type property of this TaskSummaryFromDataLoaderTask.
-            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK"
+            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK"
         :type model_type: str
 
         :param key:

--- a/src/oci/data_integration/models/task_summary_from_integration_task.py
+++ b/src/oci/data_integration/models/task_summary_from_integration_task.py
@@ -21,7 +21,7 @@ class TaskSummaryFromIntegrationTask(TaskSummary):
 
         :param model_type:
             The value to assign to the model_type property of this TaskSummaryFromIntegrationTask.
-            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK"
+            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK"
         :type model_type: str
 
         :param key:

--- a/src/oci/data_integration/models/task_summary_from_pipeline_task.py
+++ b/src/oci/data_integration/models/task_summary_from_pipeline_task.py
@@ -1,0 +1,181 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .task_summary import TaskSummary
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class TaskSummaryFromPipelineTask(TaskSummary):
+    """
+    The information about the pipeline task.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new TaskSummaryFromPipelineTask object with values from keyword arguments. The default value of the :py:attr:`~oci.data_integration.models.TaskSummaryFromPipelineTask.model_type` attribute
+        of this class is ``PIPELINE_TASK`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param model_type:
+            The value to assign to the model_type property of this TaskSummaryFromPipelineTask.
+            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK"
+        :type model_type: str
+
+        :param key:
+            The value to assign to the key property of this TaskSummaryFromPipelineTask.
+        :type key: str
+
+        :param model_version:
+            The value to assign to the model_version property of this TaskSummaryFromPipelineTask.
+        :type model_version: str
+
+        :param parent_ref:
+            The value to assign to the parent_ref property of this TaskSummaryFromPipelineTask.
+        :type parent_ref: oci.data_integration.models.ParentReference
+
+        :param name:
+            The value to assign to the name property of this TaskSummaryFromPipelineTask.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this TaskSummaryFromPipelineTask.
+        :type description: str
+
+        :param object_version:
+            The value to assign to the object_version property of this TaskSummaryFromPipelineTask.
+        :type object_version: int
+
+        :param object_status:
+            The value to assign to the object_status property of this TaskSummaryFromPipelineTask.
+        :type object_status: int
+
+        :param identifier:
+            The value to assign to the identifier property of this TaskSummaryFromPipelineTask.
+        :type identifier: str
+
+        :param input_ports:
+            The value to assign to the input_ports property of this TaskSummaryFromPipelineTask.
+        :type input_ports: list[oci.data_integration.models.InputPort]
+
+        :param output_ports:
+            The value to assign to the output_ports property of this TaskSummaryFromPipelineTask.
+        :type output_ports: list[oci.data_integration.models.OutputPort]
+
+        :param parameters:
+            The value to assign to the parameters property of this TaskSummaryFromPipelineTask.
+        :type parameters: list[oci.data_integration.models.Parameter]
+
+        :param op_config_values:
+            The value to assign to the op_config_values property of this TaskSummaryFromPipelineTask.
+        :type op_config_values: oci.data_integration.models.ConfigValues
+
+        :param config_provider_delegate:
+            The value to assign to the config_provider_delegate property of this TaskSummaryFromPipelineTask.
+        :type config_provider_delegate: oci.data_integration.models.ConfigProvider
+
+        :param metadata:
+            The value to assign to the metadata property of this TaskSummaryFromPipelineTask.
+        :type metadata: oci.data_integration.models.ObjectMetadata
+
+        :param key_map:
+            The value to assign to the key_map property of this TaskSummaryFromPipelineTask.
+        :type key_map: dict(str, str)
+
+        :param pipeline:
+            The value to assign to the pipeline property of this TaskSummaryFromPipelineTask.
+        :type pipeline: oci.data_integration.models.Pipeline
+
+        """
+        self.swagger_types = {
+            'model_type': 'str',
+            'key': 'str',
+            'model_version': 'str',
+            'parent_ref': 'ParentReference',
+            'name': 'str',
+            'description': 'str',
+            'object_version': 'int',
+            'object_status': 'int',
+            'identifier': 'str',
+            'input_ports': 'list[InputPort]',
+            'output_ports': 'list[OutputPort]',
+            'parameters': 'list[Parameter]',
+            'op_config_values': 'ConfigValues',
+            'config_provider_delegate': 'ConfigProvider',
+            'metadata': 'ObjectMetadata',
+            'key_map': 'dict(str, str)',
+            'pipeline': 'Pipeline'
+        }
+
+        self.attribute_map = {
+            'model_type': 'modelType',
+            'key': 'key',
+            'model_version': 'modelVersion',
+            'parent_ref': 'parentRef',
+            'name': 'name',
+            'description': 'description',
+            'object_version': 'objectVersion',
+            'object_status': 'objectStatus',
+            'identifier': 'identifier',
+            'input_ports': 'inputPorts',
+            'output_ports': 'outputPorts',
+            'parameters': 'parameters',
+            'op_config_values': 'opConfigValues',
+            'config_provider_delegate': 'configProviderDelegate',
+            'metadata': 'metadata',
+            'key_map': 'keyMap',
+            'pipeline': 'pipeline'
+        }
+
+        self._model_type = None
+        self._key = None
+        self._model_version = None
+        self._parent_ref = None
+        self._name = None
+        self._description = None
+        self._object_version = None
+        self._object_status = None
+        self._identifier = None
+        self._input_ports = None
+        self._output_ports = None
+        self._parameters = None
+        self._op_config_values = None
+        self._config_provider_delegate = None
+        self._metadata = None
+        self._key_map = None
+        self._pipeline = None
+        self._model_type = 'PIPELINE_TASK'
+
+    @property
+    def pipeline(self):
+        """
+        Gets the pipeline of this TaskSummaryFromPipelineTask.
+
+        :return: The pipeline of this TaskSummaryFromPipelineTask.
+        :rtype: oci.data_integration.models.Pipeline
+        """
+        return self._pipeline
+
+    @pipeline.setter
+    def pipeline(self, pipeline):
+        """
+        Sets the pipeline of this TaskSummaryFromPipelineTask.
+
+        :param pipeline: The pipeline of this TaskSummaryFromPipelineTask.
+        :type: oci.data_integration.models.Pipeline
+        """
+        self._pipeline = pipeline
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/time.py
+++ b/src/oci/data_integration/models/time.py
@@ -1,0 +1,132 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class Time(object):
+    """
+    A model to hold time in hour:minute:second format.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new Time object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param hour:
+            The value to assign to the hour property of this Time.
+        :type hour: int
+
+        :param minute:
+            The value to assign to the minute property of this Time.
+        :type minute: int
+
+        :param second:
+            The value to assign to the second property of this Time.
+        :type second: int
+
+        """
+        self.swagger_types = {
+            'hour': 'int',
+            'minute': 'int',
+            'second': 'int'
+        }
+
+        self.attribute_map = {
+            'hour': 'hour',
+            'minute': 'minute',
+            'second': 'second'
+        }
+
+        self._hour = None
+        self._minute = None
+        self._second = None
+
+    @property
+    def hour(self):
+        """
+        Gets the hour of this Time.
+        The hour value.
+
+
+        :return: The hour of this Time.
+        :rtype: int
+        """
+        return self._hour
+
+    @hour.setter
+    def hour(self, hour):
+        """
+        Sets the hour of this Time.
+        The hour value.
+
+
+        :param hour: The hour of this Time.
+        :type: int
+        """
+        self._hour = hour
+
+    @property
+    def minute(self):
+        """
+        Gets the minute of this Time.
+        The minute value.
+
+
+        :return: The minute of this Time.
+        :rtype: int
+        """
+        return self._minute
+
+    @minute.setter
+    def minute(self, minute):
+        """
+        Sets the minute of this Time.
+        The minute value.
+
+
+        :param minute: The minute of this Time.
+        :type: int
+        """
+        self._minute = minute
+
+    @property
+    def second(self):
+        """
+        Gets the second of this Time.
+        The second value.
+
+
+        :return: The second of this Time.
+        :rtype: int
+        """
+        return self._second
+
+    @second.setter
+    def second(self, second):
+        """
+        Sets the second of this Time.
+        The second value.
+
+
+        :param second: The second of this Time.
+        :type: int
+        """
+        self._second = second
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/union.py
+++ b/src/oci/data_integration/models/union.py
@@ -1,0 +1,212 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .operator import Operator
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class Union(Operator):
+    """
+    The information about a union object.
+    """
+
+    #: A constant which can be used with the union_type property of a Union.
+    #: This constant has a value of "NAME"
+    UNION_TYPE_NAME = "NAME"
+
+    #: A constant which can be used with the union_type property of a Union.
+    #: This constant has a value of "POSITION"
+    UNION_TYPE_POSITION = "POSITION"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new Union object with values from keyword arguments. The default value of the :py:attr:`~oci.data_integration.models.Union.model_type` attribute
+        of this class is ``UNION_OPERATOR`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param model_type:
+            The value to assign to the model_type property of this Union.
+            Allowed values for this property are: "SOURCE_OPERATOR", "FILTER_OPERATOR", "JOINER_OPERATOR", "AGGREGATOR_OPERATOR", "PROJECTION_OPERATOR", "TARGET_OPERATOR", "DISTINCT_OPERATOR", "SORT_OPERATOR", "UNION_OPERATOR", "INTERSECT_OPERATOR", "MINUS_OPERATOR", "MERGE_OPERATOR", "START_OPERATOR", "END_OPERATOR", "PIPELINE_OPERATOR", "REST_OPERATOR", "TASK_OPERATOR", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type model_type: str
+
+        :param key:
+            The value to assign to the key property of this Union.
+        :type key: str
+
+        :param model_version:
+            The value to assign to the model_version property of this Union.
+        :type model_version: str
+
+        :param parent_ref:
+            The value to assign to the parent_ref property of this Union.
+        :type parent_ref: oci.data_integration.models.ParentReference
+
+        :param name:
+            The value to assign to the name property of this Union.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this Union.
+        :type description: str
+
+        :param object_version:
+            The value to assign to the object_version property of this Union.
+        :type object_version: int
+
+        :param input_ports:
+            The value to assign to the input_ports property of this Union.
+        :type input_ports: list[oci.data_integration.models.InputPort]
+
+        :param output_ports:
+            The value to assign to the output_ports property of this Union.
+        :type output_ports: list[oci.data_integration.models.OutputPort]
+
+        :param object_status:
+            The value to assign to the object_status property of this Union.
+        :type object_status: int
+
+        :param identifier:
+            The value to assign to the identifier property of this Union.
+        :type identifier: str
+
+        :param parameters:
+            The value to assign to the parameters property of this Union.
+        :type parameters: list[oci.data_integration.models.Parameter]
+
+        :param op_config_values:
+            The value to assign to the op_config_values property of this Union.
+        :type op_config_values: oci.data_integration.models.ConfigValues
+
+        :param union_type:
+            The value to assign to the union_type property of this Union.
+            Allowed values for this property are: "NAME", "POSITION", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type union_type: str
+
+        :param is_all:
+            The value to assign to the is_all property of this Union.
+        :type is_all: bool
+
+        """
+        self.swagger_types = {
+            'model_type': 'str',
+            'key': 'str',
+            'model_version': 'str',
+            'parent_ref': 'ParentReference',
+            'name': 'str',
+            'description': 'str',
+            'object_version': 'int',
+            'input_ports': 'list[InputPort]',
+            'output_ports': 'list[OutputPort]',
+            'object_status': 'int',
+            'identifier': 'str',
+            'parameters': 'list[Parameter]',
+            'op_config_values': 'ConfigValues',
+            'union_type': 'str',
+            'is_all': 'bool'
+        }
+
+        self.attribute_map = {
+            'model_type': 'modelType',
+            'key': 'key',
+            'model_version': 'modelVersion',
+            'parent_ref': 'parentRef',
+            'name': 'name',
+            'description': 'description',
+            'object_version': 'objectVersion',
+            'input_ports': 'inputPorts',
+            'output_ports': 'outputPorts',
+            'object_status': 'objectStatus',
+            'identifier': 'identifier',
+            'parameters': 'parameters',
+            'op_config_values': 'opConfigValues',
+            'union_type': 'unionType',
+            'is_all': 'isAll'
+        }
+
+        self._model_type = None
+        self._key = None
+        self._model_version = None
+        self._parent_ref = None
+        self._name = None
+        self._description = None
+        self._object_version = None
+        self._input_ports = None
+        self._output_ports = None
+        self._object_status = None
+        self._identifier = None
+        self._parameters = None
+        self._op_config_values = None
+        self._union_type = None
+        self._is_all = None
+        self._model_type = 'UNION_OPERATOR'
+
+    @property
+    def union_type(self):
+        """
+        Gets the union_type of this Union.
+        unionType
+
+        Allowed values for this property are: "NAME", "POSITION", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The union_type of this Union.
+        :rtype: str
+        """
+        return self._union_type
+
+    @union_type.setter
+    def union_type(self, union_type):
+        """
+        Sets the union_type of this Union.
+        unionType
+
+
+        :param union_type: The union_type of this Union.
+        :type: str
+        """
+        allowed_values = ["NAME", "POSITION"]
+        if not value_allowed_none_or_none_sentinel(union_type, allowed_values):
+            union_type = 'UNKNOWN_ENUM_VALUE'
+        self._union_type = union_type
+
+    @property
+    def is_all(self):
+        """
+        Gets the is_all of this Union.
+        The information about the union all.
+
+
+        :return: The is_all of this Union.
+        :rtype: bool
+        """
+        return self._is_all
+
+    @is_all.setter
+    def is_all(self, is_all):
+        """
+        Sets the is_all of this Union.
+        The information about the union all.
+
+
+        :param is_all: The is_all of this Union.
+        :type: bool
+        """
+        self._is_all = is_all
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/unique_key.py
+++ b/src/oci/data_integration/models/unique_key.py
@@ -2,26 +2,37 @@
 # Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
 # This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 
-from .key import Key
+
 from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
 from oci.decorators import init_model_state_from_kwargs
 
 
 @init_model_state_from_kwargs
-class UniqueKey(Key):
+class UniqueKey(object):
     """
     The unqique key object.
     """
 
+    #: A constant which can be used with the model_type property of a UniqueKey.
+    #: This constant has a value of "PRIMARY_KEY"
+    MODEL_TYPE_PRIMARY_KEY = "PRIMARY_KEY"
+
+    #: A constant which can be used with the model_type property of a UniqueKey.
+    #: This constant has a value of "UNIQUE_KEY"
+    MODEL_TYPE_UNIQUE_KEY = "UNIQUE_KEY"
+
     def __init__(self, **kwargs):
         """
-        Initializes a new UniqueKey object with values from keyword arguments. The default value of the :py:attr:`~oci.data_integration.models.UniqueKey.model_type` attribute
-        of this class is ``UNIQUE_KEY`` and it should not be changed.
+        Initializes a new UniqueKey object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
+        to a service operations then you should favor using a subclass over the base class:
+
+        * :class:`~oci.data_integration.models.PrimaryKey`
+
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
         :param model_type:
             The value to assign to the model_type property of this UniqueKey.
-            Allowed values for this property are: "FOREIGN_KEY", "PRIMARY_KEY", "UNIQUE_KEY", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "PRIMARY_KEY", "UNIQUE_KEY", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type model_type: str
 
@@ -77,7 +88,49 @@ class UniqueKey(Key):
         self._name = None
         self._attribute_refs = None
         self._object_status = None
-        self._model_type = 'UNIQUE_KEY'
+
+    @staticmethod
+    def get_subtype(object_dictionary):
+        """
+        Given the hash representation of a subtype of this class,
+        use the info in the hash to return the class of the subtype.
+        """
+        type = object_dictionary['modelType']
+
+        if type == 'PRIMARY_KEY':
+            return 'PrimaryKey'
+        else:
+            return 'UniqueKey'
+
+    @property
+    def model_type(self):
+        """
+        **[Required]** Gets the model_type of this UniqueKey.
+        The key type.
+
+        Allowed values for this property are: "PRIMARY_KEY", "UNIQUE_KEY", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The model_type of this UniqueKey.
+        :rtype: str
+        """
+        return self._model_type
+
+    @model_type.setter
+    def model_type(self, model_type):
+        """
+        Sets the model_type of this UniqueKey.
+        The key type.
+
+
+        :param model_type: The model_type of this UniqueKey.
+        :type: str
+        """
+        allowed_values = ["PRIMARY_KEY", "UNIQUE_KEY"]
+        if not value_allowed_none_or_none_sentinel(model_type, allowed_values):
+            model_type = 'UNKNOWN_ENUM_VALUE'
+        self._model_type = model_type
 
     @property
     def key(self):

--- a/src/oci/data_integration/models/update_connection_from_adwc.py
+++ b/src/oci/data_integration/models/update_connection_from_adwc.py
@@ -72,6 +72,10 @@ class UpdateConnectionFromAdwc(UpdateConnectionDetails):
             The value to assign to the password property of this UpdateConnectionFromAdwc.
         :type password: str
 
+        :param password_secret:
+            The value to assign to the password_secret property of this UpdateConnectionFromAdwc.
+        :type password_secret: oci.data_integration.models.SensitiveAttribute
+
         """
         self.swagger_types = {
             'model_type': 'str',
@@ -86,7 +90,8 @@ class UpdateConnectionFromAdwc(UpdateConnectionDetails):
             'connection_properties': 'list[ConnectionProperty]',
             'registry_metadata': 'RegistryMetadata',
             'username': 'str',
-            'password': 'str'
+            'password': 'str',
+            'password_secret': 'SensitiveAttribute'
         }
 
         self.attribute_map = {
@@ -102,7 +107,8 @@ class UpdateConnectionFromAdwc(UpdateConnectionDetails):
             'connection_properties': 'connectionProperties',
             'registry_metadata': 'registryMetadata',
             'username': 'username',
-            'password': 'password'
+            'password': 'password',
+            'password_secret': 'passwordSecret'
         }
 
         self._model_type = None
@@ -118,6 +124,7 @@ class UpdateConnectionFromAdwc(UpdateConnectionDetails):
         self._registry_metadata = None
         self._username = None
         self._password = None
+        self._password_secret = None
         self._model_type = 'ORACLE_ADWC_CONNECTION'
 
     @property
@@ -167,6 +174,26 @@ class UpdateConnectionFromAdwc(UpdateConnectionDetails):
         :type: str
         """
         self._password = password
+
+    @property
+    def password_secret(self):
+        """
+        Gets the password_secret of this UpdateConnectionFromAdwc.
+
+        :return: The password_secret of this UpdateConnectionFromAdwc.
+        :rtype: oci.data_integration.models.SensitiveAttribute
+        """
+        return self._password_secret
+
+    @password_secret.setter
+    def password_secret(self, password_secret):
+        """
+        Sets the password_secret of this UpdateConnectionFromAdwc.
+
+        :param password_secret: The password_secret of this UpdateConnectionFromAdwc.
+        :type: oci.data_integration.models.SensitiveAttribute
+        """
+        self._password_secret = password_secret
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/data_integration/models/update_connection_from_atp.py
+++ b/src/oci/data_integration/models/update_connection_from_atp.py
@@ -72,6 +72,10 @@ class UpdateConnectionFromAtp(UpdateConnectionDetails):
             The value to assign to the password property of this UpdateConnectionFromAtp.
         :type password: str
 
+        :param password_secret:
+            The value to assign to the password_secret property of this UpdateConnectionFromAtp.
+        :type password_secret: oci.data_integration.models.SensitiveAttribute
+
         """
         self.swagger_types = {
             'model_type': 'str',
@@ -86,7 +90,8 @@ class UpdateConnectionFromAtp(UpdateConnectionDetails):
             'connection_properties': 'list[ConnectionProperty]',
             'registry_metadata': 'RegistryMetadata',
             'username': 'str',
-            'password': 'str'
+            'password': 'str',
+            'password_secret': 'SensitiveAttribute'
         }
 
         self.attribute_map = {
@@ -102,7 +107,8 @@ class UpdateConnectionFromAtp(UpdateConnectionDetails):
             'connection_properties': 'connectionProperties',
             'registry_metadata': 'registryMetadata',
             'username': 'username',
-            'password': 'password'
+            'password': 'password',
+            'password_secret': 'passwordSecret'
         }
 
         self._model_type = None
@@ -118,6 +124,7 @@ class UpdateConnectionFromAtp(UpdateConnectionDetails):
         self._registry_metadata = None
         self._username = None
         self._password = None
+        self._password_secret = None
         self._model_type = 'ORACLE_ATP_CONNECTION'
 
     @property
@@ -167,6 +174,26 @@ class UpdateConnectionFromAtp(UpdateConnectionDetails):
         :type: str
         """
         self._password = password
+
+    @property
+    def password_secret(self):
+        """
+        Gets the password_secret of this UpdateConnectionFromAtp.
+
+        :return: The password_secret of this UpdateConnectionFromAtp.
+        :rtype: oci.data_integration.models.SensitiveAttribute
+        """
+        return self._password_secret
+
+    @password_secret.setter
+    def password_secret(self, password_secret):
+        """
+        Sets the password_secret of this UpdateConnectionFromAtp.
+
+        :param password_secret: The password_secret of this UpdateConnectionFromAtp.
+        :type: oci.data_integration.models.SensitiveAttribute
+        """
+        self._password_secret = password_secret
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/data_integration/models/update_connection_from_jdbc.py
+++ b/src/oci/data_integration/models/update_connection_from_jdbc.py
@@ -72,6 +72,10 @@ class UpdateConnectionFromJdbc(UpdateConnectionDetails):
             The value to assign to the password property of this UpdateConnectionFromJdbc.
         :type password: str
 
+        :param password_secret:
+            The value to assign to the password_secret property of this UpdateConnectionFromJdbc.
+        :type password_secret: oci.data_integration.models.SensitiveAttribute
+
         """
         self.swagger_types = {
             'model_type': 'str',
@@ -86,7 +90,8 @@ class UpdateConnectionFromJdbc(UpdateConnectionDetails):
             'connection_properties': 'list[ConnectionProperty]',
             'registry_metadata': 'RegistryMetadata',
             'username': 'str',
-            'password': 'str'
+            'password': 'str',
+            'password_secret': 'SensitiveAttribute'
         }
 
         self.attribute_map = {
@@ -102,7 +107,8 @@ class UpdateConnectionFromJdbc(UpdateConnectionDetails):
             'connection_properties': 'connectionProperties',
             'registry_metadata': 'registryMetadata',
             'username': 'username',
-            'password': 'password'
+            'password': 'password',
+            'password_secret': 'passwordSecret'
         }
 
         self._model_type = None
@@ -118,6 +124,7 @@ class UpdateConnectionFromJdbc(UpdateConnectionDetails):
         self._registry_metadata = None
         self._username = None
         self._password = None
+        self._password_secret = None
         self._model_type = 'GENERIC_JDBC_CONNECTION'
 
     @property
@@ -167,6 +174,26 @@ class UpdateConnectionFromJdbc(UpdateConnectionDetails):
         :type: str
         """
         self._password = password
+
+    @property
+    def password_secret(self):
+        """
+        Gets the password_secret of this UpdateConnectionFromJdbc.
+
+        :return: The password_secret of this UpdateConnectionFromJdbc.
+        :rtype: oci.data_integration.models.SensitiveAttribute
+        """
+        return self._password_secret
+
+    @password_secret.setter
+    def password_secret(self, password_secret):
+        """
+        Sets the password_secret of this UpdateConnectionFromJdbc.
+
+        :param password_secret: The password_secret of this UpdateConnectionFromJdbc.
+        :type: oci.data_integration.models.SensitiveAttribute
+        """
+        self._password_secret = password_secret
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/data_integration/models/update_connection_from_my_sql.py
+++ b/src/oci/data_integration/models/update_connection_from_my_sql.py
@@ -72,6 +72,10 @@ class UpdateConnectionFromMySQL(UpdateConnectionDetails):
             The value to assign to the password property of this UpdateConnectionFromMySQL.
         :type password: str
 
+        :param password_secret:
+            The value to assign to the password_secret property of this UpdateConnectionFromMySQL.
+        :type password_secret: oci.data_integration.models.SensitiveAttribute
+
         """
         self.swagger_types = {
             'model_type': 'str',
@@ -86,7 +90,8 @@ class UpdateConnectionFromMySQL(UpdateConnectionDetails):
             'connection_properties': 'list[ConnectionProperty]',
             'registry_metadata': 'RegistryMetadata',
             'username': 'str',
-            'password': 'str'
+            'password': 'str',
+            'password_secret': 'SensitiveAttribute'
         }
 
         self.attribute_map = {
@@ -102,7 +107,8 @@ class UpdateConnectionFromMySQL(UpdateConnectionDetails):
             'connection_properties': 'connectionProperties',
             'registry_metadata': 'registryMetadata',
             'username': 'username',
-            'password': 'password'
+            'password': 'password',
+            'password_secret': 'passwordSecret'
         }
 
         self._model_type = None
@@ -118,6 +124,7 @@ class UpdateConnectionFromMySQL(UpdateConnectionDetails):
         self._registry_metadata = None
         self._username = None
         self._password = None
+        self._password_secret = None
         self._model_type = 'MYSQL_CONNECTION'
 
     @property
@@ -167,6 +174,26 @@ class UpdateConnectionFromMySQL(UpdateConnectionDetails):
         :type: str
         """
         self._password = password
+
+    @property
+    def password_secret(self):
+        """
+        Gets the password_secret of this UpdateConnectionFromMySQL.
+
+        :return: The password_secret of this UpdateConnectionFromMySQL.
+        :rtype: oci.data_integration.models.SensitiveAttribute
+        """
+        return self._password_secret
+
+    @password_secret.setter
+    def password_secret(self, password_secret):
+        """
+        Sets the password_secret of this UpdateConnectionFromMySQL.
+
+        :param password_secret: The password_secret of this UpdateConnectionFromMySQL.
+        :type: oci.data_integration.models.SensitiveAttribute
+        """
+        self._password_secret = password_secret
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/data_integration/models/update_connection_from_oracle.py
+++ b/src/oci/data_integration/models/update_connection_from_oracle.py
@@ -72,6 +72,10 @@ class UpdateConnectionFromOracle(UpdateConnectionDetails):
             The value to assign to the password property of this UpdateConnectionFromOracle.
         :type password: str
 
+        :param password_secret:
+            The value to assign to the password_secret property of this UpdateConnectionFromOracle.
+        :type password_secret: oci.data_integration.models.SensitiveAttribute
+
         """
         self.swagger_types = {
             'model_type': 'str',
@@ -86,7 +90,8 @@ class UpdateConnectionFromOracle(UpdateConnectionDetails):
             'connection_properties': 'list[ConnectionProperty]',
             'registry_metadata': 'RegistryMetadata',
             'username': 'str',
-            'password': 'str'
+            'password': 'str',
+            'password_secret': 'SensitiveAttribute'
         }
 
         self.attribute_map = {
@@ -102,7 +107,8 @@ class UpdateConnectionFromOracle(UpdateConnectionDetails):
             'connection_properties': 'connectionProperties',
             'registry_metadata': 'registryMetadata',
             'username': 'username',
-            'password': 'password'
+            'password': 'password',
+            'password_secret': 'passwordSecret'
         }
 
         self._model_type = None
@@ -118,6 +124,7 @@ class UpdateConnectionFromOracle(UpdateConnectionDetails):
         self._registry_metadata = None
         self._username = None
         self._password = None
+        self._password_secret = None
         self._model_type = 'ORACLEDB_CONNECTION'
 
     @property
@@ -167,6 +174,26 @@ class UpdateConnectionFromOracle(UpdateConnectionDetails):
         :type: str
         """
         self._password = password
+
+    @property
+    def password_secret(self):
+        """
+        Gets the password_secret of this UpdateConnectionFromOracle.
+
+        :return: The password_secret of this UpdateConnectionFromOracle.
+        :rtype: oci.data_integration.models.SensitiveAttribute
+        """
+        return self._password_secret
+
+    @password_secret.setter
+    def password_secret(self, password_secret):
+        """
+        Sets the password_secret of this UpdateConnectionFromOracle.
+
+        :param password_secret: The password_secret of this UpdateConnectionFromOracle.
+        :type: oci.data_integration.models.SensitiveAttribute
+        """
+        self._password_secret = password_secret
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/data_integration/models/update_data_asset_from_adwc.py
+++ b/src/oci/data_integration/models/update_data_asset_from_adwc.py
@@ -76,6 +76,14 @@ class UpdateDataAssetFromAdwc(UpdateDataAssetDetails):
             The value to assign to the credential_file_content property of this UpdateDataAssetFromAdwc.
         :type credential_file_content: str
 
+        :param wallet_secret:
+            The value to assign to the wallet_secret property of this UpdateDataAssetFromAdwc.
+        :type wallet_secret: oci.data_integration.models.SensitiveAttribute
+
+        :param wallet_password_secret:
+            The value to assign to the wallet_password_secret property of this UpdateDataAssetFromAdwc.
+        :type wallet_password_secret: oci.data_integration.models.SensitiveAttribute
+
         :param default_connection:
             The value to assign to the default_connection property of this UpdateDataAssetFromAdwc.
         :type default_connection: oci.data_integration.models.UpdateConnectionFromAdwc
@@ -96,6 +104,8 @@ class UpdateDataAssetFromAdwc(UpdateDataAssetDetails):
             'service_name': 'str',
             'driver_class': 'str',
             'credential_file_content': 'str',
+            'wallet_secret': 'SensitiveAttribute',
+            'wallet_password_secret': 'SensitiveAttribute',
             'default_connection': 'UpdateConnectionFromAdwc'
         }
 
@@ -114,6 +124,8 @@ class UpdateDataAssetFromAdwc(UpdateDataAssetDetails):
             'service_name': 'serviceName',
             'driver_class': 'driverClass',
             'credential_file_content': 'credentialFileContent',
+            'wallet_secret': 'walletSecret',
+            'wallet_password_secret': 'walletPasswordSecret',
             'default_connection': 'defaultConnection'
         }
 
@@ -131,6 +143,8 @@ class UpdateDataAssetFromAdwc(UpdateDataAssetDetails):
         self._service_name = None
         self._driver_class = None
         self._credential_file_content = None
+        self._wallet_secret = None
+        self._wallet_password_secret = None
         self._default_connection = None
         self._model_type = 'ORACLE_ADWC_DATA_ASSET'
 
@@ -205,6 +219,46 @@ class UpdateDataAssetFromAdwc(UpdateDataAssetDetails):
         :type: str
         """
         self._credential_file_content = credential_file_content
+
+    @property
+    def wallet_secret(self):
+        """
+        Gets the wallet_secret of this UpdateDataAssetFromAdwc.
+
+        :return: The wallet_secret of this UpdateDataAssetFromAdwc.
+        :rtype: oci.data_integration.models.SensitiveAttribute
+        """
+        return self._wallet_secret
+
+    @wallet_secret.setter
+    def wallet_secret(self, wallet_secret):
+        """
+        Sets the wallet_secret of this UpdateDataAssetFromAdwc.
+
+        :param wallet_secret: The wallet_secret of this UpdateDataAssetFromAdwc.
+        :type: oci.data_integration.models.SensitiveAttribute
+        """
+        self._wallet_secret = wallet_secret
+
+    @property
+    def wallet_password_secret(self):
+        """
+        Gets the wallet_password_secret of this UpdateDataAssetFromAdwc.
+
+        :return: The wallet_password_secret of this UpdateDataAssetFromAdwc.
+        :rtype: oci.data_integration.models.SensitiveAttribute
+        """
+        return self._wallet_password_secret
+
+    @wallet_password_secret.setter
+    def wallet_password_secret(self, wallet_password_secret):
+        """
+        Sets the wallet_password_secret of this UpdateDataAssetFromAdwc.
+
+        :param wallet_password_secret: The wallet_password_secret of this UpdateDataAssetFromAdwc.
+        :type: oci.data_integration.models.SensitiveAttribute
+        """
+        self._wallet_password_secret = wallet_password_secret
 
     @property
     def default_connection(self):

--- a/src/oci/data_integration/models/update_data_asset_from_atp.py
+++ b/src/oci/data_integration/models/update_data_asset_from_atp.py
@@ -76,6 +76,14 @@ class UpdateDataAssetFromAtp(UpdateDataAssetDetails):
             The value to assign to the credential_file_content property of this UpdateDataAssetFromAtp.
         :type credential_file_content: str
 
+        :param wallet_secret:
+            The value to assign to the wallet_secret property of this UpdateDataAssetFromAtp.
+        :type wallet_secret: oci.data_integration.models.SensitiveAttribute
+
+        :param wallet_password_secret:
+            The value to assign to the wallet_password_secret property of this UpdateDataAssetFromAtp.
+        :type wallet_password_secret: oci.data_integration.models.SensitiveAttribute
+
         :param default_connection:
             The value to assign to the default_connection property of this UpdateDataAssetFromAtp.
         :type default_connection: oci.data_integration.models.UpdateConnectionFromAtp
@@ -96,6 +104,8 @@ class UpdateDataAssetFromAtp(UpdateDataAssetDetails):
             'service_name': 'str',
             'driver_class': 'str',
             'credential_file_content': 'str',
+            'wallet_secret': 'SensitiveAttribute',
+            'wallet_password_secret': 'SensitiveAttribute',
             'default_connection': 'UpdateConnectionFromAtp'
         }
 
@@ -114,6 +124,8 @@ class UpdateDataAssetFromAtp(UpdateDataAssetDetails):
             'service_name': 'serviceName',
             'driver_class': 'driverClass',
             'credential_file_content': 'credentialFileContent',
+            'wallet_secret': 'walletSecret',
+            'wallet_password_secret': 'walletPasswordSecret',
             'default_connection': 'defaultConnection'
         }
 
@@ -131,6 +143,8 @@ class UpdateDataAssetFromAtp(UpdateDataAssetDetails):
         self._service_name = None
         self._driver_class = None
         self._credential_file_content = None
+        self._wallet_secret = None
+        self._wallet_password_secret = None
         self._default_connection = None
         self._model_type = 'ORACLE_ATP_DATA_ASSET'
 
@@ -205,6 +219,46 @@ class UpdateDataAssetFromAtp(UpdateDataAssetDetails):
         :type: str
         """
         self._credential_file_content = credential_file_content
+
+    @property
+    def wallet_secret(self):
+        """
+        Gets the wallet_secret of this UpdateDataAssetFromAtp.
+
+        :return: The wallet_secret of this UpdateDataAssetFromAtp.
+        :rtype: oci.data_integration.models.SensitiveAttribute
+        """
+        return self._wallet_secret
+
+    @wallet_secret.setter
+    def wallet_secret(self, wallet_secret):
+        """
+        Sets the wallet_secret of this UpdateDataAssetFromAtp.
+
+        :param wallet_secret: The wallet_secret of this UpdateDataAssetFromAtp.
+        :type: oci.data_integration.models.SensitiveAttribute
+        """
+        self._wallet_secret = wallet_secret
+
+    @property
+    def wallet_password_secret(self):
+        """
+        Gets the wallet_password_secret of this UpdateDataAssetFromAtp.
+
+        :return: The wallet_password_secret of this UpdateDataAssetFromAtp.
+        :rtype: oci.data_integration.models.SensitiveAttribute
+        """
+        return self._wallet_password_secret
+
+    @wallet_password_secret.setter
+    def wallet_password_secret(self, wallet_password_secret):
+        """
+        Sets the wallet_password_secret of this UpdateDataAssetFromAtp.
+
+        :param wallet_password_secret: The wallet_password_secret of this UpdateDataAssetFromAtp.
+        :type: oci.data_integration.models.SensitiveAttribute
+        """
+        self._wallet_password_secret = wallet_password_secret
 
     @property
     def default_connection(self):

--- a/src/oci/data_integration/models/update_data_asset_from_oracle.py
+++ b/src/oci/data_integration/models/update_data_asset_from_oracle.py
@@ -88,6 +88,14 @@ class UpdateDataAssetFromOracle(UpdateDataAssetDetails):
             The value to assign to the credential_file_content property of this UpdateDataAssetFromOracle.
         :type credential_file_content: str
 
+        :param wallet_secret:
+            The value to assign to the wallet_secret property of this UpdateDataAssetFromOracle.
+        :type wallet_secret: oci.data_integration.models.SensitiveAttribute
+
+        :param wallet_password_secret:
+            The value to assign to the wallet_password_secret property of this UpdateDataAssetFromOracle.
+        :type wallet_password_secret: oci.data_integration.models.SensitiveAttribute
+
         :param default_connection:
             The value to assign to the default_connection property of this UpdateDataAssetFromOracle.
         :type default_connection: oci.data_integration.models.UpdateConnectionFromOracle
@@ -111,6 +119,8 @@ class UpdateDataAssetFromOracle(UpdateDataAssetDetails):
             'driver_class': 'str',
             'sid': 'str',
             'credential_file_content': 'str',
+            'wallet_secret': 'SensitiveAttribute',
+            'wallet_password_secret': 'SensitiveAttribute',
             'default_connection': 'UpdateConnectionFromOracle'
         }
 
@@ -132,6 +142,8 @@ class UpdateDataAssetFromOracle(UpdateDataAssetDetails):
             'driver_class': 'driverClass',
             'sid': 'sid',
             'credential_file_content': 'credentialFileContent',
+            'wallet_secret': 'walletSecret',
+            'wallet_password_secret': 'walletPasswordSecret',
             'default_connection': 'defaultConnection'
         }
 
@@ -152,6 +164,8 @@ class UpdateDataAssetFromOracle(UpdateDataAssetDetails):
         self._driver_class = None
         self._sid = None
         self._credential_file_content = None
+        self._wallet_secret = None
+        self._wallet_password_secret = None
         self._default_connection = None
         self._model_type = 'ORACLE_DATA_ASSET'
 
@@ -298,6 +312,46 @@ class UpdateDataAssetFromOracle(UpdateDataAssetDetails):
         :type: str
         """
         self._credential_file_content = credential_file_content
+
+    @property
+    def wallet_secret(self):
+        """
+        Gets the wallet_secret of this UpdateDataAssetFromOracle.
+
+        :return: The wallet_secret of this UpdateDataAssetFromOracle.
+        :rtype: oci.data_integration.models.SensitiveAttribute
+        """
+        return self._wallet_secret
+
+    @wallet_secret.setter
+    def wallet_secret(self, wallet_secret):
+        """
+        Sets the wallet_secret of this UpdateDataAssetFromOracle.
+
+        :param wallet_secret: The wallet_secret of this UpdateDataAssetFromOracle.
+        :type: oci.data_integration.models.SensitiveAttribute
+        """
+        self._wallet_secret = wallet_secret
+
+    @property
+    def wallet_password_secret(self):
+        """
+        Gets the wallet_password_secret of this UpdateDataAssetFromOracle.
+
+        :return: The wallet_password_secret of this UpdateDataAssetFromOracle.
+        :rtype: oci.data_integration.models.SensitiveAttribute
+        """
+        return self._wallet_password_secret
+
+    @wallet_password_secret.setter
+    def wallet_password_secret(self, wallet_password_secret):
+        """
+        Sets the wallet_password_secret of this UpdateDataAssetFromOracle.
+
+        :param wallet_password_secret: The wallet_password_secret of this UpdateDataAssetFromOracle.
+        :type: oci.data_integration.models.SensitiveAttribute
+        """
+        self._wallet_password_secret = wallet_password_secret
 
     @property
     def default_connection(self):

--- a/src/oci/data_integration/models/update_pipeline_details.py
+++ b/src/oci/data_integration/models/update_pipeline_details.py
@@ -1,0 +1,461 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdatePipelineDetails(object):
+    """
+    Properties used in pipeline update operations
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdatePipelineDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param key:
+            The value to assign to the key property of this UpdatePipelineDetails.
+        :type key: str
+
+        :param model_type:
+            The value to assign to the model_type property of this UpdatePipelineDetails.
+        :type model_type: str
+
+        :param model_version:
+            The value to assign to the model_version property of this UpdatePipelineDetails.
+        :type model_version: str
+
+        :param parent_ref:
+            The value to assign to the parent_ref property of this UpdatePipelineDetails.
+        :type parent_ref: oci.data_integration.models.ParentReference
+
+        :param name:
+            The value to assign to the name property of this UpdatePipelineDetails.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this UpdatePipelineDetails.
+        :type description: str
+
+        :param object_version:
+            The value to assign to the object_version property of this UpdatePipelineDetails.
+        :type object_version: int
+
+        :param object_status:
+            The value to assign to the object_status property of this UpdatePipelineDetails.
+        :type object_status: int
+
+        :param identifier:
+            The value to assign to the identifier property of this UpdatePipelineDetails.
+        :type identifier: str
+
+        :param nodes:
+            The value to assign to the nodes property of this UpdatePipelineDetails.
+        :type nodes: list[oci.data_integration.models.FlowNode]
+
+        :param parameters:
+            The value to assign to the parameters property of this UpdatePipelineDetails.
+        :type parameters: list[oci.data_integration.models.Parameter]
+
+        :param flow_config_values:
+            The value to assign to the flow_config_values property of this UpdatePipelineDetails.
+        :type flow_config_values: oci.data_integration.models.ConfigValues
+
+        :param variables:
+            The value to assign to the variables property of this UpdatePipelineDetails.
+        :type variables: list[oci.data_integration.models.Variable]
+
+        :param registry_metadata:
+            The value to assign to the registry_metadata property of this UpdatePipelineDetails.
+        :type registry_metadata: oci.data_integration.models.RegistryMetadata
+
+        """
+        self.swagger_types = {
+            'key': 'str',
+            'model_type': 'str',
+            'model_version': 'str',
+            'parent_ref': 'ParentReference',
+            'name': 'str',
+            'description': 'str',
+            'object_version': 'int',
+            'object_status': 'int',
+            'identifier': 'str',
+            'nodes': 'list[FlowNode]',
+            'parameters': 'list[Parameter]',
+            'flow_config_values': 'ConfigValues',
+            'variables': 'list[Variable]',
+            'registry_metadata': 'RegistryMetadata'
+        }
+
+        self.attribute_map = {
+            'key': 'key',
+            'model_type': 'modelType',
+            'model_version': 'modelVersion',
+            'parent_ref': 'parentRef',
+            'name': 'name',
+            'description': 'description',
+            'object_version': 'objectVersion',
+            'object_status': 'objectStatus',
+            'identifier': 'identifier',
+            'nodes': 'nodes',
+            'parameters': 'parameters',
+            'flow_config_values': 'flowConfigValues',
+            'variables': 'variables',
+            'registry_metadata': 'registryMetadata'
+        }
+
+        self._key = None
+        self._model_type = None
+        self._model_version = None
+        self._parent_ref = None
+        self._name = None
+        self._description = None
+        self._object_version = None
+        self._object_status = None
+        self._identifier = None
+        self._nodes = None
+        self._parameters = None
+        self._flow_config_values = None
+        self._variables = None
+        self._registry_metadata = None
+
+    @property
+    def key(self):
+        """
+        **[Required]** Gets the key of this UpdatePipelineDetails.
+        Generated key that can be used in API calls to identify pipeline. On scenarios where reference to the pipeline is needed, a value can be passed in create.
+
+
+        :return: The key of this UpdatePipelineDetails.
+        :rtype: str
+        """
+        return self._key
+
+    @key.setter
+    def key(self, key):
+        """
+        Sets the key of this UpdatePipelineDetails.
+        Generated key that can be used in API calls to identify pipeline. On scenarios where reference to the pipeline is needed, a value can be passed in create.
+
+
+        :param key: The key of this UpdatePipelineDetails.
+        :type: str
+        """
+        self._key = key
+
+    @property
+    def model_type(self):
+        """
+        **[Required]** Gets the model_type of this UpdatePipelineDetails.
+        The type of the object.
+
+
+        :return: The model_type of this UpdatePipelineDetails.
+        :rtype: str
+        """
+        return self._model_type
+
+    @model_type.setter
+    def model_type(self, model_type):
+        """
+        Sets the model_type of this UpdatePipelineDetails.
+        The type of the object.
+
+
+        :param model_type: The model_type of this UpdatePipelineDetails.
+        :type: str
+        """
+        self._model_type = model_type
+
+    @property
+    def model_version(self):
+        """
+        Gets the model_version of this UpdatePipelineDetails.
+        This is a version number that is used by the service to upgrade objects if needed through releases of the service.
+
+
+        :return: The model_version of this UpdatePipelineDetails.
+        :rtype: str
+        """
+        return self._model_version
+
+    @model_version.setter
+    def model_version(self, model_version):
+        """
+        Sets the model_version of this UpdatePipelineDetails.
+        This is a version number that is used by the service to upgrade objects if needed through releases of the service.
+
+
+        :param model_version: The model_version of this UpdatePipelineDetails.
+        :type: str
+        """
+        self._model_version = model_version
+
+    @property
+    def parent_ref(self):
+        """
+        Gets the parent_ref of this UpdatePipelineDetails.
+
+        :return: The parent_ref of this UpdatePipelineDetails.
+        :rtype: oci.data_integration.models.ParentReference
+        """
+        return self._parent_ref
+
+    @parent_ref.setter
+    def parent_ref(self, parent_ref):
+        """
+        Sets the parent_ref of this UpdatePipelineDetails.
+
+        :param parent_ref: The parent_ref of this UpdatePipelineDetails.
+        :type: oci.data_integration.models.ParentReference
+        """
+        self._parent_ref = parent_ref
+
+    @property
+    def name(self):
+        """
+        Gets the name of this UpdatePipelineDetails.
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
+
+
+        :return: The name of this UpdatePipelineDetails.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this UpdatePipelineDetails.
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
+
+
+        :param name: The name of this UpdatePipelineDetails.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def description(self):
+        """
+        Gets the description of this UpdatePipelineDetails.
+        Detailed description for the object.
+
+
+        :return: The description of this UpdatePipelineDetails.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this UpdatePipelineDetails.
+        Detailed description for the object.
+
+
+        :param description: The description of this UpdatePipelineDetails.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def object_version(self):
+        """
+        **[Required]** Gets the object_version of this UpdatePipelineDetails.
+        This is used by the service for optimistic locking of the object, to prevent multiple users from simultaneously updating the object.
+
+
+        :return: The object_version of this UpdatePipelineDetails.
+        :rtype: int
+        """
+        return self._object_version
+
+    @object_version.setter
+    def object_version(self, object_version):
+        """
+        Sets the object_version of this UpdatePipelineDetails.
+        This is used by the service for optimistic locking of the object, to prevent multiple users from simultaneously updating the object.
+
+
+        :param object_version: The object_version of this UpdatePipelineDetails.
+        :type: int
+        """
+        self._object_version = object_version
+
+    @property
+    def object_status(self):
+        """
+        Gets the object_status of this UpdatePipelineDetails.
+        The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+
+
+        :return: The object_status of this UpdatePipelineDetails.
+        :rtype: int
+        """
+        return self._object_status
+
+    @object_status.setter
+    def object_status(self, object_status):
+        """
+        Sets the object_status of this UpdatePipelineDetails.
+        The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+
+
+        :param object_status: The object_status of this UpdatePipelineDetails.
+        :type: int
+        """
+        self._object_status = object_status
+
+    @property
+    def identifier(self):
+        """
+        Gets the identifier of this UpdatePipelineDetails.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
+
+
+        :return: The identifier of this UpdatePipelineDetails.
+        :rtype: str
+        """
+        return self._identifier
+
+    @identifier.setter
+    def identifier(self, identifier):
+        """
+        Sets the identifier of this UpdatePipelineDetails.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
+
+
+        :param identifier: The identifier of this UpdatePipelineDetails.
+        :type: str
+        """
+        self._identifier = identifier
+
+    @property
+    def nodes(self):
+        """
+        Gets the nodes of this UpdatePipelineDetails.
+        A list of nodes attached to the pipeline
+
+
+        :return: The nodes of this UpdatePipelineDetails.
+        :rtype: list[oci.data_integration.models.FlowNode]
+        """
+        return self._nodes
+
+    @nodes.setter
+    def nodes(self, nodes):
+        """
+        Sets the nodes of this UpdatePipelineDetails.
+        A list of nodes attached to the pipeline
+
+
+        :param nodes: The nodes of this UpdatePipelineDetails.
+        :type: list[oci.data_integration.models.FlowNode]
+        """
+        self._nodes = nodes
+
+    @property
+    def parameters(self):
+        """
+        Gets the parameters of this UpdatePipelineDetails.
+        A list of additional parameters required in pipeline.
+
+
+        :return: The parameters of this UpdatePipelineDetails.
+        :rtype: list[oci.data_integration.models.Parameter]
+        """
+        return self._parameters
+
+    @parameters.setter
+    def parameters(self, parameters):
+        """
+        Sets the parameters of this UpdatePipelineDetails.
+        A list of additional parameters required in pipeline.
+
+
+        :param parameters: The parameters of this UpdatePipelineDetails.
+        :type: list[oci.data_integration.models.Parameter]
+        """
+        self._parameters = parameters
+
+    @property
+    def flow_config_values(self):
+        """
+        Gets the flow_config_values of this UpdatePipelineDetails.
+
+        :return: The flow_config_values of this UpdatePipelineDetails.
+        :rtype: oci.data_integration.models.ConfigValues
+        """
+        return self._flow_config_values
+
+    @flow_config_values.setter
+    def flow_config_values(self, flow_config_values):
+        """
+        Sets the flow_config_values of this UpdatePipelineDetails.
+
+        :param flow_config_values: The flow_config_values of this UpdatePipelineDetails.
+        :type: oci.data_integration.models.ConfigValues
+        """
+        self._flow_config_values = flow_config_values
+
+    @property
+    def variables(self):
+        """
+        Gets the variables of this UpdatePipelineDetails.
+        The list of variables required in pipeline.
+
+
+        :return: The variables of this UpdatePipelineDetails.
+        :rtype: list[oci.data_integration.models.Variable]
+        """
+        return self._variables
+
+    @variables.setter
+    def variables(self, variables):
+        """
+        Sets the variables of this UpdatePipelineDetails.
+        The list of variables required in pipeline.
+
+
+        :param variables: The variables of this UpdatePipelineDetails.
+        :type: list[oci.data_integration.models.Variable]
+        """
+        self._variables = variables
+
+    @property
+    def registry_metadata(self):
+        """
+        Gets the registry_metadata of this UpdatePipelineDetails.
+
+        :return: The registry_metadata of this UpdatePipelineDetails.
+        :rtype: oci.data_integration.models.RegistryMetadata
+        """
+        return self._registry_metadata
+
+    @registry_metadata.setter
+    def registry_metadata(self, registry_metadata):
+        """
+        Sets the registry_metadata of this UpdatePipelineDetails.
+
+        :param registry_metadata: The registry_metadata of this UpdatePipelineDetails.
+        :type: oci.data_integration.models.RegistryMetadata
+        """
+        self._registry_metadata = registry_metadata
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/update_task_details.py
+++ b/src/oci/data_integration/models/update_task_details.py
@@ -21,11 +21,16 @@ class UpdateTaskDetails(object):
     #: This constant has a value of "DATA_LOADER_TASK"
     MODEL_TYPE_DATA_LOADER_TASK = "DATA_LOADER_TASK"
 
+    #: A constant which can be used with the model_type property of a UpdateTaskDetails.
+    #: This constant has a value of "PIPELINE_TASK"
+    MODEL_TYPE_PIPELINE_TASK = "PIPELINE_TASK"
+
     def __init__(self, **kwargs):
         """
         Initializes a new UpdateTaskDetails object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
         to a service operations then you should favor using a subclass over the base class:
 
+        * :class:`~oci.data_integration.models.UpdateTaskFromPipelineTask`
         * :class:`~oci.data_integration.models.UpdateTaskFromDataLoaderTask`
         * :class:`~oci.data_integration.models.UpdateTaskFromIntegrationTask`
 
@@ -33,7 +38,7 @@ class UpdateTaskDetails(object):
 
         :param model_type:
             The value to assign to the model_type property of this UpdateTaskDetails.
-            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK"
+            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK"
         :type model_type: str
 
         :param key:
@@ -153,6 +158,9 @@ class UpdateTaskDetails(object):
         """
         type = object_dictionary['modelType']
 
+        if type == 'PIPELINE_TASK':
+            return 'UpdateTaskFromPipelineTask'
+
         if type == 'DATA_LOADER_TASK':
             return 'UpdateTaskFromDataLoaderTask'
 
@@ -167,7 +175,7 @@ class UpdateTaskDetails(object):
         **[Required]** Gets the model_type of this UpdateTaskDetails.
         The type of the task.
 
-        Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK"
+        Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK"
 
 
         :return: The model_type of this UpdateTaskDetails.
@@ -185,7 +193,7 @@ class UpdateTaskDetails(object):
         :param model_type: The model_type of this UpdateTaskDetails.
         :type: str
         """
-        allowed_values = ["INTEGRATION_TASK", "DATA_LOADER_TASK"]
+        allowed_values = ["INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK"]
         if not value_allowed_none_or_none_sentinel(model_type, allowed_values):
             raise ValueError(
                 "Invalid value for `model_type`, must be None or one of {0}"

--- a/src/oci/data_integration/models/update_task_from_data_loader_task.py
+++ b/src/oci/data_integration/models/update_task_from_data_loader_task.py
@@ -21,7 +21,7 @@ class UpdateTaskFromDataLoaderTask(UpdateTaskDetails):
 
         :param model_type:
             The value to assign to the model_type property of this UpdateTaskFromDataLoaderTask.
-            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK"
+            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK"
         :type model_type: str
 
         :param key:

--- a/src/oci/data_integration/models/update_task_from_integration_task.py
+++ b/src/oci/data_integration/models/update_task_from_integration_task.py
@@ -21,7 +21,7 @@ class UpdateTaskFromIntegrationTask(UpdateTaskDetails):
 
         :param model_type:
             The value to assign to the model_type property of this UpdateTaskFromIntegrationTask.
-            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK"
+            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK"
         :type model_type: str
 
         :param key:

--- a/src/oci/data_integration/models/update_task_from_pipeline_task.py
+++ b/src/oci/data_integration/models/update_task_from_pipeline_task.py
@@ -1,0 +1,174 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .update_task_details import UpdateTaskDetails
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateTaskFromPipelineTask(UpdateTaskDetails):
+    """
+    The information about the pipeline task.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateTaskFromPipelineTask object with values from keyword arguments. The default value of the :py:attr:`~oci.data_integration.models.UpdateTaskFromPipelineTask.model_type` attribute
+        of this class is ``PIPELINE_TASK`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param model_type:
+            The value to assign to the model_type property of this UpdateTaskFromPipelineTask.
+            Allowed values for this property are: "INTEGRATION_TASK", "DATA_LOADER_TASK", "PIPELINE_TASK"
+        :type model_type: str
+
+        :param key:
+            The value to assign to the key property of this UpdateTaskFromPipelineTask.
+        :type key: str
+
+        :param model_version:
+            The value to assign to the model_version property of this UpdateTaskFromPipelineTask.
+        :type model_version: str
+
+        :param parent_ref:
+            The value to assign to the parent_ref property of this UpdateTaskFromPipelineTask.
+        :type parent_ref: oci.data_integration.models.ParentReference
+
+        :param name:
+            The value to assign to the name property of this UpdateTaskFromPipelineTask.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this UpdateTaskFromPipelineTask.
+        :type description: str
+
+        :param object_status:
+            The value to assign to the object_status property of this UpdateTaskFromPipelineTask.
+        :type object_status: int
+
+        :param object_version:
+            The value to assign to the object_version property of this UpdateTaskFromPipelineTask.
+        :type object_version: int
+
+        :param identifier:
+            The value to assign to the identifier property of this UpdateTaskFromPipelineTask.
+        :type identifier: str
+
+        :param input_ports:
+            The value to assign to the input_ports property of this UpdateTaskFromPipelineTask.
+        :type input_ports: list[oci.data_integration.models.InputPort]
+
+        :param output_ports:
+            The value to assign to the output_ports property of this UpdateTaskFromPipelineTask.
+        :type output_ports: list[oci.data_integration.models.OutputPort]
+
+        :param parameters:
+            The value to assign to the parameters property of this UpdateTaskFromPipelineTask.
+        :type parameters: list[oci.data_integration.models.Parameter]
+
+        :param op_config_values:
+            The value to assign to the op_config_values property of this UpdateTaskFromPipelineTask.
+        :type op_config_values: oci.data_integration.models.ConfigValues
+
+        :param config_provider_delegate:
+            The value to assign to the config_provider_delegate property of this UpdateTaskFromPipelineTask.
+        :type config_provider_delegate: oci.data_integration.models.ConfigProvider
+
+        :param registry_metadata:
+            The value to assign to the registry_metadata property of this UpdateTaskFromPipelineTask.
+        :type registry_metadata: oci.data_integration.models.RegistryMetadata
+
+        :param pipeline:
+            The value to assign to the pipeline property of this UpdateTaskFromPipelineTask.
+        :type pipeline: oci.data_integration.models.Pipeline
+
+        """
+        self.swagger_types = {
+            'model_type': 'str',
+            'key': 'str',
+            'model_version': 'str',
+            'parent_ref': 'ParentReference',
+            'name': 'str',
+            'description': 'str',
+            'object_status': 'int',
+            'object_version': 'int',
+            'identifier': 'str',
+            'input_ports': 'list[InputPort]',
+            'output_ports': 'list[OutputPort]',
+            'parameters': 'list[Parameter]',
+            'op_config_values': 'ConfigValues',
+            'config_provider_delegate': 'ConfigProvider',
+            'registry_metadata': 'RegistryMetadata',
+            'pipeline': 'Pipeline'
+        }
+
+        self.attribute_map = {
+            'model_type': 'modelType',
+            'key': 'key',
+            'model_version': 'modelVersion',
+            'parent_ref': 'parentRef',
+            'name': 'name',
+            'description': 'description',
+            'object_status': 'objectStatus',
+            'object_version': 'objectVersion',
+            'identifier': 'identifier',
+            'input_ports': 'inputPorts',
+            'output_ports': 'outputPorts',
+            'parameters': 'parameters',
+            'op_config_values': 'opConfigValues',
+            'config_provider_delegate': 'configProviderDelegate',
+            'registry_metadata': 'registryMetadata',
+            'pipeline': 'pipeline'
+        }
+
+        self._model_type = None
+        self._key = None
+        self._model_version = None
+        self._parent_ref = None
+        self._name = None
+        self._description = None
+        self._object_status = None
+        self._object_version = None
+        self._identifier = None
+        self._input_ports = None
+        self._output_ports = None
+        self._parameters = None
+        self._op_config_values = None
+        self._config_provider_delegate = None
+        self._registry_metadata = None
+        self._pipeline = None
+        self._model_type = 'PIPELINE_TASK'
+
+    @property
+    def pipeline(self):
+        """
+        Gets the pipeline of this UpdateTaskFromPipelineTask.
+
+        :return: The pipeline of this UpdateTaskFromPipelineTask.
+        :rtype: oci.data_integration.models.Pipeline
+        """
+        return self._pipeline
+
+    @pipeline.setter
+    def pipeline(self, pipeline):
+        """
+        Sets the pipeline of this UpdateTaskFromPipelineTask.
+
+        :param pipeline: The pipeline of this UpdateTaskFromPipelineTask.
+        :type: oci.data_integration.models.Pipeline
+        """
+        self._pipeline = pipeline
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_integration/models/variable.py
+++ b/src/oci/data_integration/models/variable.py
@@ -1,0 +1,426 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class Variable(object):
+    """
+    Variable definitions in the pipeline.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new Variable object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param key:
+            The value to assign to the key property of this Variable.
+        :type key: str
+
+        :param model_version:
+            The value to assign to the model_version property of this Variable.
+        :type model_version: str
+
+        :param model_type:
+            The value to assign to the model_type property of this Variable.
+        :type model_type: str
+
+        :param parent_ref:
+            The value to assign to the parent_ref property of this Variable.
+        :type parent_ref: oci.data_integration.models.ParentReference
+
+        :param name:
+            The value to assign to the name property of this Variable.
+        :type name: str
+
+        :param description:
+            The value to assign to the description property of this Variable.
+        :type description: str
+
+        :param object_version:
+            The value to assign to the object_version property of this Variable.
+        :type object_version: int
+
+        :param object_status:
+            The value to assign to the object_status property of this Variable.
+        :type object_status: int
+
+        :param identifier:
+            The value to assign to the identifier property of this Variable.
+        :type identifier: str
+
+        :param type:
+            The value to assign to the type property of this Variable.
+        :type type: oci.data_integration.models.BaseType
+
+        :param config_values:
+            The value to assign to the config_values property of this Variable.
+        :type config_values: oci.data_integration.models.ConfigValues
+
+        :param default_value:
+            The value to assign to the default_value property of this Variable.
+        :type default_value: object
+
+        :param root_object_default_value:
+            The value to assign to the root_object_default_value property of this Variable.
+        :type root_object_default_value: oci.data_integration.models.RootObject
+
+        """
+        self.swagger_types = {
+            'key': 'str',
+            'model_version': 'str',
+            'model_type': 'str',
+            'parent_ref': 'ParentReference',
+            'name': 'str',
+            'description': 'str',
+            'object_version': 'int',
+            'object_status': 'int',
+            'identifier': 'str',
+            'type': 'BaseType',
+            'config_values': 'ConfigValues',
+            'default_value': 'object',
+            'root_object_default_value': 'RootObject'
+        }
+
+        self.attribute_map = {
+            'key': 'key',
+            'model_version': 'modelVersion',
+            'model_type': 'modelType',
+            'parent_ref': 'parentRef',
+            'name': 'name',
+            'description': 'description',
+            'object_version': 'objectVersion',
+            'object_status': 'objectStatus',
+            'identifier': 'identifier',
+            'type': 'type',
+            'config_values': 'configValues',
+            'default_value': 'defaultValue',
+            'root_object_default_value': 'rootObjectDefaultValue'
+        }
+
+        self._key = None
+        self._model_version = None
+        self._model_type = None
+        self._parent_ref = None
+        self._name = None
+        self._description = None
+        self._object_version = None
+        self._object_status = None
+        self._identifier = None
+        self._type = None
+        self._config_values = None
+        self._default_value = None
+        self._root_object_default_value = None
+
+    @property
+    def key(self):
+        """
+        Gets the key of this Variable.
+        Generated key that can be used in API calls to identify variable. On scenarios where reference to the variable is needed, a value can be passed in create.
+
+
+        :return: The key of this Variable.
+        :rtype: str
+        """
+        return self._key
+
+    @key.setter
+    def key(self, key):
+        """
+        Sets the key of this Variable.
+        Generated key that can be used in API calls to identify variable. On scenarios where reference to the variable is needed, a value can be passed in create.
+
+
+        :param key: The key of this Variable.
+        :type: str
+        """
+        self._key = key
+
+    @property
+    def model_version(self):
+        """
+        Gets the model_version of this Variable.
+        This is a version number that is used by the service to upgrade objects if needed through releases of the service.
+
+
+        :return: The model_version of this Variable.
+        :rtype: str
+        """
+        return self._model_version
+
+    @model_version.setter
+    def model_version(self, model_version):
+        """
+        Sets the model_version of this Variable.
+        This is a version number that is used by the service to upgrade objects if needed through releases of the service.
+
+
+        :param model_version: The model_version of this Variable.
+        :type: str
+        """
+        self._model_version = model_version
+
+    @property
+    def model_type(self):
+        """
+        Gets the model_type of this Variable.
+        The type of the object.
+
+
+        :return: The model_type of this Variable.
+        :rtype: str
+        """
+        return self._model_type
+
+    @model_type.setter
+    def model_type(self, model_type):
+        """
+        Sets the model_type of this Variable.
+        The type of the object.
+
+
+        :param model_type: The model_type of this Variable.
+        :type: str
+        """
+        self._model_type = model_type
+
+    @property
+    def parent_ref(self):
+        """
+        Gets the parent_ref of this Variable.
+
+        :return: The parent_ref of this Variable.
+        :rtype: oci.data_integration.models.ParentReference
+        """
+        return self._parent_ref
+
+    @parent_ref.setter
+    def parent_ref(self, parent_ref):
+        """
+        Sets the parent_ref of this Variable.
+
+        :param parent_ref: The parent_ref of this Variable.
+        :type: oci.data_integration.models.ParentReference
+        """
+        self._parent_ref = parent_ref
+
+    @property
+    def name(self):
+        """
+        Gets the name of this Variable.
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
+
+
+        :return: The name of this Variable.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this Variable.
+        Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
+
+
+        :param name: The name of this Variable.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def description(self):
+        """
+        Gets the description of this Variable.
+        Detailed description for the object.
+
+
+        :return: The description of this Variable.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this Variable.
+        Detailed description for the object.
+
+
+        :param description: The description of this Variable.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def object_version(self):
+        """
+        Gets the object_version of this Variable.
+        This is used by the service for optimistic locking of the object, to prevent multiple users from simultaneously updating the object.
+
+
+        :return: The object_version of this Variable.
+        :rtype: int
+        """
+        return self._object_version
+
+    @object_version.setter
+    def object_version(self, object_version):
+        """
+        Sets the object_version of this Variable.
+        This is used by the service for optimistic locking of the object, to prevent multiple users from simultaneously updating the object.
+
+
+        :param object_version: The object_version of this Variable.
+        :type: int
+        """
+        self._object_version = object_version
+
+    @property
+    def object_status(self):
+        """
+        Gets the object_status of this Variable.
+        The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+
+
+        :return: The object_status of this Variable.
+        :rtype: int
+        """
+        return self._object_status
+
+    @object_status.setter
+    def object_status(self, object_status):
+        """
+        Sets the object_status of this Variable.
+        The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+
+
+        :param object_status: The object_status of this Variable.
+        :type: int
+        """
+        self._object_status = object_status
+
+    @property
+    def identifier(self):
+        """
+        Gets the identifier of this Variable.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
+
+
+        :return: The identifier of this Variable.
+        :rtype: str
+        """
+        return self._identifier
+
+    @identifier.setter
+    def identifier(self, identifier):
+        """
+        Sets the identifier of this Variable.
+        Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
+
+
+        :param identifier: The identifier of this Variable.
+        :type: str
+        """
+        self._identifier = identifier
+
+    @property
+    def type(self):
+        """
+        Gets the type of this Variable.
+
+        :return: The type of this Variable.
+        :rtype: oci.data_integration.models.BaseType
+        """
+        return self._type
+
+    @type.setter
+    def type(self, type):
+        """
+        Sets the type of this Variable.
+
+        :param type: The type of this Variable.
+        :type: oci.data_integration.models.BaseType
+        """
+        self._type = type
+
+    @property
+    def config_values(self):
+        """
+        Gets the config_values of this Variable.
+
+        :return: The config_values of this Variable.
+        :rtype: oci.data_integration.models.ConfigValues
+        """
+        return self._config_values
+
+    @config_values.setter
+    def config_values(self, config_values):
+        """
+        Sets the config_values of this Variable.
+
+        :param config_values: The config_values of this Variable.
+        :type: oci.data_integration.models.ConfigValues
+        """
+        self._config_values = config_values
+
+    @property
+    def default_value(self):
+        """
+        Gets the default_value of this Variable.
+        A default value for the vairable.
+
+
+        :return: The default_value of this Variable.
+        :rtype: object
+        """
+        return self._default_value
+
+    @default_value.setter
+    def default_value(self, default_value):
+        """
+        Sets the default_value of this Variable.
+        A default value for the vairable.
+
+
+        :param default_value: The default_value of this Variable.
+        :type: object
+        """
+        self._default_value = default_value
+
+    @property
+    def root_object_default_value(self):
+        """
+        Gets the root_object_default_value of this Variable.
+
+        :return: The root_object_default_value of this Variable.
+        :rtype: oci.data_integration.models.RootObject
+        """
+        return self._root_object_default_value
+
+    @root_object_default_value.setter
+    def root_object_default_value(self, root_object_default_value):
+        """
+        Sets the root_object_default_value of this Variable.
+
+        :param root_object_default_value: The root_object_default_value of this Variable.
+        :type: oci.data_integration.models.RootObject
+        """
+        self._root_object_default_value = root_object_default_value
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/file_storage/file_storage_client.py
+++ b/src/oci/file_storage/file_storage_client.py
@@ -93,7 +93,9 @@ class FileStorageClient(object):
 
 
         :param str file_system_id: (required)
-            The OCID of the file system.
+            The `OCID`__ of the file system.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param oci.file_storage.models.ChangeFileSystemCompartmentDetails change_file_system_compartment_details: (required)
             Details for changing the compartment.
@@ -183,7 +185,9 @@ class FileStorageClient(object):
 
 
         :param str mount_target_id: (required)
-            The OCID of the mount target.
+            The `OCID`__ of the mount target.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param oci.file_storage.models.ChangeMountTargetCompartmentDetails change_mount_target_compartment_details: (required)
             Details for changing the compartment.
@@ -370,14 +374,15 @@ class FileStorageClient(object):
 
         All Oracle Cloud Infrastructure resources, including
         file systems, get an Oracle-assigned, unique ID called an Oracle
-        Cloud Identifier (OCID).  When you create a resource, you can
-        find its OCID in the response. You can also retrieve a
-        resource's OCID by using a List API operation on that resource
+        Cloud Identifier (`OCID`__).
+        When you create a resource, you can find its OCID in the response.
+        You can also retrieve a resource's OCID by using a List API operation on that resource
         type or by viewing the resource in the Console.
 
         __ https://docs.cloud.oracle.com/Content/Identity/Concepts/overview.htm
         __ https://docs.cloud.oracle.com/Content/Network/Concepts/networksecuritygroups.htm
         __ https://docs.cloud.oracle.com/Content/General/Concepts/regions.htm
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :param oci.file_storage.models.CreateFileSystemDetails create_file_system_details: (required)
@@ -482,13 +487,14 @@ class FileStorageClient(object):
 
         All Oracle Cloud Infrastructure Services resources, including
         mount targets, get an Oracle-assigned, unique ID called an
-        Oracle Cloud Identifier (OCID).  When you create a resource,
-        you can find its OCID in the response. You can also retrieve a
-        resource's OCID by using a List API operation on that resource
+        Oracle Cloud Identifier (`OCID`__).
+        When you create a resource, you can find its OCID in the response.
+        You can also retrieve a resource's OCID by using a List API operation on that resource
         type, or by viewing the resource in the Console.
 
         __ https://docs.cloud.oracle.com/Content/Identity/Concepts/overview.htm
         __ https://docs.cloud.oracle.com/Content/General/Concepts/regions.htm
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :param oci.file_storage.models.CreateMountTargetDetails create_mount_target_details: (required)
@@ -647,7 +653,9 @@ class FileStorageClient(object):
 
 
         :param str export_id: (required)
-            The OCID of the export.
+            The `OCID`__ of the export.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call
@@ -732,7 +740,9 @@ class FileStorageClient(object):
 
 
         :param str file_system_id: (required)
-            The OCID of the file system.
+            The `OCID`__ of the file system.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call
@@ -816,7 +826,9 @@ class FileStorageClient(object):
 
 
         :param str mount_target_id: (required)
-            The OCID of the mount target.
+            The `OCID`__ of the mount target.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call
@@ -899,7 +911,9 @@ class FileStorageClient(object):
 
 
         :param str snapshot_id: (required)
-            The OCID of the snapshot.
+            The `OCID`__ of the snapshot.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call
@@ -982,7 +996,9 @@ class FileStorageClient(object):
 
 
         :param str export_id: (required)
-            The OCID of the export.
+            The `OCID`__ of the export.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str opc_request_id: (optional)
             Unique identifier for the request.
@@ -1058,7 +1074,9 @@ class FileStorageClient(object):
 
 
         :param str export_set_id: (required)
-            The OCID of the export set.
+            The `OCID`__ of the export set.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str opc_request_id: (optional)
             Unique identifier for the request.
@@ -1134,7 +1152,9 @@ class FileStorageClient(object):
 
 
         :param str file_system_id: (required)
-            The OCID of the file system.
+            The `OCID`__ of the file system.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str opc_request_id: (optional)
             Unique identifier for the request.
@@ -1210,7 +1230,9 @@ class FileStorageClient(object):
 
 
         :param str mount_target_id: (required)
-            The OCID of the mount target.
+            The `OCID`__ of the mount target.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str opc_request_id: (optional)
             Unique identifier for the request.
@@ -1286,7 +1308,9 @@ class FileStorageClient(object):
 
 
         :param str snapshot_id: (required)
-            The OCID of the snapshot.
+            The `OCID`__ of the snapshot.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str opc_request_id: (optional)
             Unique identifier for the request.
@@ -1362,7 +1386,9 @@ class FileStorageClient(object):
 
 
         :param str compartment_id: (required)
-            The OCID of the compartment.
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str availability_domain: (required)
             The name of the availability domain.
@@ -1402,8 +1428,10 @@ class FileStorageClient(object):
             Allowed values are: "CREATING", "ACTIVE", "DELETING", "DELETED", "FAILED"
 
         :param str id: (optional)
-            Filter results by OCID. Must be an OCID of the correct type for
+            Filter results by `OCID`__. Must be an OCID of the correct type for
             the resouce type.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str sort_by: (optional)
             The field to sort by. You can provide either value, but not both.
@@ -1527,7 +1555,9 @@ class FileStorageClient(object):
 
 
         :param str compartment_id: (optional)
-            The OCID of the compartment.
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param int limit: (optional)
             For list pagination. The maximum number of results per page,
@@ -1551,10 +1581,14 @@ class FileStorageClient(object):
             __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
 
         :param str export_set_id: (optional)
-            The OCID of the export set.
+            The `OCID`__ of the export set.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str file_system_id: (optional)
-            The OCID of the file system.
+            The `OCID`__ of the file system.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str lifecycle_state: (optional)
             Filter results by the specified lifecycle state. Must be a valid
@@ -1563,8 +1597,10 @@ class FileStorageClient(object):
             Allowed values are: "CREATING", "ACTIVE", "DELETING", "DELETED", "FAILED"
 
         :param str id: (optional)
-            Filter results by OCID. Must be an OCID of the correct type for
+            Filter results by `OCID`__. Must be an OCID of the correct type for
             the resouce type.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str sort_by: (optional)
             The field to sort by. You can provide either value, but not both.
@@ -1688,7 +1724,9 @@ class FileStorageClient(object):
 
 
         :param str compartment_id: (required)
-            The OCID of the compartment.
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str availability_domain: (required)
             The name of the availability domain.
@@ -1728,8 +1766,22 @@ class FileStorageClient(object):
             Allowed values are: "CREATING", "ACTIVE", "DELETING", "DELETED", "FAILED"
 
         :param str id: (optional)
-            Filter results by OCID. Must be an OCID of the correct type for
+            Filter results by `OCID`__. Must be an OCID of the correct type for
             the resouce type.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str source_snapshot_id: (optional)
+            The `OCID`__ of the snapshot used to create a cloned file system. See `Cloning a File System`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/File/Tasks/cloningafilesystem.htm
+
+        :param str parent_file_system_id: (optional)
+            The `OCID`__ of the file system that contains the source snapshot of a cloned file system. See `Cloning a File System`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/File/Tasks/cloningafilesystem.htm
 
         :param str sort_by: (optional)
             The field to sort by. You can provide either value, but not both.
@@ -1775,6 +1827,8 @@ class FileStorageClient(object):
             "display_name",
             "lifecycle_state",
             "id",
+            "source_snapshot_id",
+            "parent_file_system_id",
             "sort_by",
             "sort_order",
             "opc_request_id"
@@ -1813,6 +1867,8 @@ class FileStorageClient(object):
             "displayName": kwargs.get("display_name", missing),
             "lifecycleState": kwargs.get("lifecycle_state", missing),
             "id": kwargs.get("id", missing),
+            "sourceSnapshotId": kwargs.get("source_snapshot_id", missing),
+            "parentFileSystemId": kwargs.get("parent_file_system_id", missing),
             "sortBy": kwargs.get("sort_by", missing),
             "sortOrder": kwargs.get("sort_order", missing)
         }
@@ -1851,7 +1907,9 @@ class FileStorageClient(object):
 
 
         :param str compartment_id: (required)
-            The OCID of the compartment.
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str availability_domain: (required)
             The name of the availability domain.
@@ -1885,7 +1943,9 @@ class FileStorageClient(object):
             Example: `My resource`
 
         :param str export_set_id: (optional)
-            The OCID of the export set.
+            The `OCID`__ of the export set.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str lifecycle_state: (optional)
             Filter results by the specified lifecycle state. Must be a valid
@@ -1894,8 +1954,10 @@ class FileStorageClient(object):
             Allowed values are: "CREATING", "ACTIVE", "DELETING", "DELETED", "FAILED"
 
         :param str id: (optional)
-            Filter results by OCID. Must be an OCID of the correct type for
+            Filter results by `OCID`__. Must be an OCID of the correct type for
             the resouce type.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str sort_by: (optional)
             The field to sort by. You can choose either value, but not both.
@@ -2019,7 +2081,9 @@ class FileStorageClient(object):
 
 
         :param str file_system_id: (required)
-            The OCID of the file system.
+            The `OCID`__ of the file system.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param int limit: (optional)
             For list pagination. The maximum number of results per page,
@@ -2049,8 +2113,10 @@ class FileStorageClient(object):
             Allowed values are: "CREATING", "ACTIVE", "DELETING", "DELETED", "FAILED"
 
         :param str id: (optional)
-            Filter results by OCID. Must be an OCID of the correct type for
+            Filter results by `OCID`__. Must be an OCID of the correct type for
             the resouce type.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param str sort_order: (optional)
             The sort order to use, either 'asc' or 'desc', where 'asc' is
@@ -2152,7 +2218,9 @@ class FileStorageClient(object):
 
 
         :param str export_id: (required)
-            The OCID of the export.
+            The `OCID`__ of the export.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param oci.file_storage.models.UpdateExportDetails update_export_details: (required)
             Details object for updating an export.
@@ -2242,7 +2310,9 @@ class FileStorageClient(object):
 
 
         :param str export_set_id: (required)
-            The OCID of the export set.
+            The `OCID`__ of the export set.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param oci.file_storage.models.UpdateExportSetDetails update_export_set_details: (required)
             Details object for updating an export set.
@@ -2333,7 +2403,9 @@ class FileStorageClient(object):
 
 
         :param str file_system_id: (required)
-            The OCID of the file system.
+            The `OCID`__ of the file system.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param oci.file_storage.models.UpdateFileSystemDetails update_file_system_details: (required)
             Details object for updating a file system.
@@ -2423,7 +2495,9 @@ class FileStorageClient(object):
 
 
         :param str mount_target_id: (required)
-            The OCID of the mount target.
+            The `OCID`__ of the mount target.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param oci.file_storage.models.UpdateMountTargetDetails update_mount_target_details: (required)
             Details object for updating a mount target.
@@ -2513,7 +2587,9 @@ class FileStorageClient(object):
 
 
         :param str snapshot_id: (required)
-            The OCID of the snapshot.
+            The `OCID`__ of the snapshot.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param oci.file_storage.models.UpdateSnapshotDetails update_snapshot_details: (required)
             Details object for updating a snapshot.

--- a/src/oci/file_storage/file_storage_client_composite_operations.py
+++ b/src/oci/file_storage/file_storage_client_composite_operations.py
@@ -181,7 +181,9 @@ class FileStorageClientCompositeOperations(object):
         to enter the given state(s).
 
         :param str export_id: (required)
-            The OCID of the export.
+            The `OCID`__ of the export.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param list[str] wait_for_states:
             An array of states to wait on. These should be valid values for :py:attr:`~oci.file_storage.models.Export.lifecycle_state`
@@ -228,7 +230,9 @@ class FileStorageClientCompositeOperations(object):
         to enter the given state(s).
 
         :param str file_system_id: (required)
-            The OCID of the file system.
+            The `OCID`__ of the file system.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param list[str] wait_for_states:
             An array of states to wait on. These should be valid values for :py:attr:`~oci.file_storage.models.FileSystem.lifecycle_state`
@@ -275,7 +279,9 @@ class FileStorageClientCompositeOperations(object):
         to enter the given state(s).
 
         :param str mount_target_id: (required)
-            The OCID of the mount target.
+            The `OCID`__ of the mount target.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param list[str] wait_for_states:
             An array of states to wait on. These should be valid values for :py:attr:`~oci.file_storage.models.MountTarget.lifecycle_state`
@@ -322,7 +328,9 @@ class FileStorageClientCompositeOperations(object):
         to enter the given state(s).
 
         :param str snapshot_id: (required)
-            The OCID of the snapshot.
+            The `OCID`__ of the snapshot.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param list[str] wait_for_states:
             An array of states to wait on. These should be valid values for :py:attr:`~oci.file_storage.models.Snapshot.lifecycle_state`
@@ -369,7 +377,9 @@ class FileStorageClientCompositeOperations(object):
         to enter the given state(s).
 
         :param str export_id: (required)
-            The OCID of the export.
+            The `OCID`__ of the export.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param oci.file_storage.models.UpdateExportDetails update_export_details: (required)
             Details object for updating an export.
@@ -410,7 +420,9 @@ class FileStorageClientCompositeOperations(object):
         to enter the given state(s).
 
         :param str export_set_id: (required)
-            The OCID of the export set.
+            The `OCID`__ of the export set.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param oci.file_storage.models.UpdateExportSetDetails update_export_set_details: (required)
             Details object for updating an export set.
@@ -451,7 +463,9 @@ class FileStorageClientCompositeOperations(object):
         to enter the given state(s).
 
         :param str file_system_id: (required)
-            The OCID of the file system.
+            The `OCID`__ of the file system.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param oci.file_storage.models.UpdateFileSystemDetails update_file_system_details: (required)
             Details object for updating a file system.
@@ -492,7 +506,9 @@ class FileStorageClientCompositeOperations(object):
         to enter the given state(s).
 
         :param str mount_target_id: (required)
-            The OCID of the mount target.
+            The `OCID`__ of the mount target.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param oci.file_storage.models.UpdateMountTargetDetails update_mount_target_details: (required)
             Details object for updating a mount target.
@@ -533,7 +549,9 @@ class FileStorageClientCompositeOperations(object):
         to enter the given state(s).
 
         :param str snapshot_id: (required)
-            The OCID of the snapshot.
+            The `OCID`__ of the snapshot.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
         :param oci.file_storage.models.UpdateSnapshotDetails update_snapshot_details: (required)
             Details object for updating a snapshot.

--- a/src/oci/file_storage/models/__init__.py
+++ b/src/oci/file_storage/models/__init__.py
@@ -21,6 +21,7 @@ from .mount_target import MountTarget
 from .mount_target_summary import MountTargetSummary
 from .snapshot import Snapshot
 from .snapshot_summary import SnapshotSummary
+from .source_details import SourceDetails
 from .update_export_details import UpdateExportDetails
 from .update_export_set_details import UpdateExportSetDetails
 from .update_file_system_details import UpdateFileSystemDetails
@@ -46,6 +47,7 @@ file_storage_type_mapping = {
     "MountTargetSummary": MountTargetSummary,
     "Snapshot": Snapshot,
     "SnapshotSummary": SnapshotSummary,
+    "SourceDetails": SourceDetails,
     "UpdateExportDetails": UpdateExportDetails,
     "UpdateExportSetDetails": UpdateExportSetDetails,
     "UpdateFileSystemDetails": UpdateFileSystemDetails,

--- a/src/oci/file_storage/models/create_export_details.py
+++ b/src/oci/file_storage/models/create_export_details.py
@@ -124,7 +124,9 @@ class CreateExportDetails(object):
     def export_set_id(self):
         """
         **[Required]** Gets the export_set_id of this CreateExportDetails.
-        The OCID of this export's export set.
+        The `OCID`__ of this export's export set.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :return: The export_set_id of this CreateExportDetails.
@@ -136,7 +138,9 @@ class CreateExportDetails(object):
     def export_set_id(self, export_set_id):
         """
         Sets the export_set_id of this CreateExportDetails.
-        The OCID of this export's export set.
+        The `OCID`__ of this export's export set.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :param export_set_id: The export_set_id of this CreateExportDetails.
@@ -148,7 +152,9 @@ class CreateExportDetails(object):
     def file_system_id(self):
         """
         **[Required]** Gets the file_system_id of this CreateExportDetails.
-        The OCID of this export's file system.
+        The `OCID`__ of this export's file system.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :return: The file_system_id of this CreateExportDetails.
@@ -160,7 +166,9 @@ class CreateExportDetails(object):
     def file_system_id(self, file_system_id):
         """
         Sets the file_system_id of this CreateExportDetails.
-        The OCID of this export's file system.
+        The `OCID`__ of this export's file system.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :param file_system_id: The file_system_id of this CreateExportDetails.

--- a/src/oci/file_storage/models/create_file_system_details.py
+++ b/src/oci/file_storage/models/create_file_system_details.py
@@ -42,6 +42,10 @@ class CreateFileSystemDetails(object):
             The value to assign to the kms_key_id property of this CreateFileSystemDetails.
         :type kms_key_id: str
 
+        :param source_snapshot_id:
+            The value to assign to the source_snapshot_id property of this CreateFileSystemDetails.
+        :type source_snapshot_id: str
+
         """
         self.swagger_types = {
             'availability_domain': 'str',
@@ -49,7 +53,8 @@ class CreateFileSystemDetails(object):
             'display_name': 'str',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
-            'kms_key_id': 'str'
+            'kms_key_id': 'str',
+            'source_snapshot_id': 'str'
         }
 
         self.attribute_map = {
@@ -58,7 +63,8 @@ class CreateFileSystemDetails(object):
             'display_name': 'displayName',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
-            'kms_key_id': 'kmsKeyId'
+            'kms_key_id': 'kmsKeyId',
+            'source_snapshot_id': 'sourceSnapshotId'
         }
 
         self._availability_domain = None
@@ -67,6 +73,7 @@ class CreateFileSystemDetails(object):
         self._freeform_tags = None
         self._defined_tags = None
         self._kms_key_id = None
+        self._source_snapshot_id = None
 
     @property
     def availability_domain(self):
@@ -100,7 +107,9 @@ class CreateFileSystemDetails(object):
     def compartment_id(self):
         """
         **[Required]** Gets the compartment_id of this CreateFileSystemDetails.
-        The OCID of the compartment to create the file system in.
+        The `OCID`__ of the compartment to create the file system in.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :return: The compartment_id of this CreateFileSystemDetails.
@@ -112,7 +121,9 @@ class CreateFileSystemDetails(object):
     def compartment_id(self, compartment_id):
         """
         Sets the compartment_id of this CreateFileSystemDetails.
-        The OCID of the compartment to create the file system in.
+        The `OCID`__ of the compartment to create the file system in.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :param compartment_id: The compartment_id of this CreateFileSystemDetails.
@@ -220,7 +231,9 @@ class CreateFileSystemDetails(object):
     def kms_key_id(self):
         """
         Gets the kms_key_id of this CreateFileSystemDetails.
-        The OCID of KMS key used to encrypt the encryption keys associated with this file system.
+        The `OCID`__ of the KMS key used to encrypt the encryption keys associated with this file system.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :return: The kms_key_id of this CreateFileSystemDetails.
@@ -232,13 +245,47 @@ class CreateFileSystemDetails(object):
     def kms_key_id(self, kms_key_id):
         """
         Sets the kms_key_id of this CreateFileSystemDetails.
-        The OCID of KMS key used to encrypt the encryption keys associated with this file system.
+        The `OCID`__ of the KMS key used to encrypt the encryption keys associated with this file system.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :param kms_key_id: The kms_key_id of this CreateFileSystemDetails.
         :type: str
         """
         self._kms_key_id = kms_key_id
+
+    @property
+    def source_snapshot_id(self):
+        """
+        Gets the source_snapshot_id of this CreateFileSystemDetails.
+        The `OCID`__ of the snapshot used to create a cloned file system.
+        See `Cloning a File System`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/File/Tasks/cloningafilesystem.htm
+
+
+        :return: The source_snapshot_id of this CreateFileSystemDetails.
+        :rtype: str
+        """
+        return self._source_snapshot_id
+
+    @source_snapshot_id.setter
+    def source_snapshot_id(self, source_snapshot_id):
+        """
+        Sets the source_snapshot_id of this CreateFileSystemDetails.
+        The `OCID`__ of the snapshot used to create a cloned file system.
+        See `Cloning a File System`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/File/Tasks/cloningafilesystem.htm
+
+
+        :param source_snapshot_id: The source_snapshot_id of this CreateFileSystemDetails.
+        :type: str
+        """
+        self._source_snapshot_id = source_snapshot_id
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/file_storage/models/create_mount_target_details.py
+++ b/src/oci/file_storage/models/create_mount_target_details.py
@@ -121,7 +121,9 @@ class CreateMountTargetDetails(object):
     def compartment_id(self):
         """
         **[Required]** Gets the compartment_id of this CreateMountTargetDetails.
-        The OCID of the compartment in which to create the mount target.
+        The `OCID`__ of the compartment in which to create the mount target.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :return: The compartment_id of this CreateMountTargetDetails.
@@ -133,7 +135,9 @@ class CreateMountTargetDetails(object):
     def compartment_id(self, compartment_id):
         """
         Sets the compartment_id of this CreateMountTargetDetails.
-        The OCID of the compartment in which to create the mount target.
+        The `OCID`__ of the compartment in which to create the mount target.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :param compartment_id: The compartment_id of this CreateMountTargetDetails.
@@ -261,7 +265,9 @@ class CreateMountTargetDetails(object):
     def subnet_id(self):
         """
         **[Required]** Gets the subnet_id of this CreateMountTargetDetails.
-        The OCID of the subnet in which to create the mount target.
+        The `OCID`__ of the subnet in which to create the mount target.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :return: The subnet_id of this CreateMountTargetDetails.
@@ -273,7 +279,9 @@ class CreateMountTargetDetails(object):
     def subnet_id(self, subnet_id):
         """
         Sets the subnet_id of this CreateMountTargetDetails.
-        The OCID of the subnet in which to create the mount target.
+        The `OCID`__ of the subnet in which to create the mount target.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :param subnet_id: The subnet_id of this CreateMountTargetDetails.

--- a/src/oci/file_storage/models/create_snapshot_details.py
+++ b/src/oci/file_storage/models/create_snapshot_details.py
@@ -58,7 +58,9 @@ class CreateSnapshotDetails(object):
     def file_system_id(self):
         """
         **[Required]** Gets the file_system_id of this CreateSnapshotDetails.
-        The OCID of the file system to take a snapshot of.
+        The `OCID`__ of the file system to take a snapshot of.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :return: The file_system_id of this CreateSnapshotDetails.
@@ -70,7 +72,9 @@ class CreateSnapshotDetails(object):
     def file_system_id(self, file_system_id):
         """
         Sets the file_system_id of this CreateSnapshotDetails.
-        The OCID of the file system to take a snapshot of.
+        The `OCID`__ of the file system to take a snapshot of.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :param file_system_id: The file_system_id of this CreateSnapshotDetails.

--- a/src/oci/file_storage/models/export.py
+++ b/src/oci/file_storage/models/export.py
@@ -205,7 +205,9 @@ class Export(object):
     def export_set_id(self):
         """
         **[Required]** Gets the export_set_id of this Export.
-        The OCID of this export's export set.
+        The `OCID`__ of this export's export set.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :return: The export_set_id of this Export.
@@ -217,7 +219,9 @@ class Export(object):
     def export_set_id(self, export_set_id):
         """
         Sets the export_set_id of this Export.
-        The OCID of this export's export set.
+        The `OCID`__ of this export's export set.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :param export_set_id: The export_set_id of this Export.
@@ -229,7 +233,9 @@ class Export(object):
     def file_system_id(self):
         """
         **[Required]** Gets the file_system_id of this Export.
-        The OCID of this export's file system.
+        The `OCID`__ of this export's file system.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :return: The file_system_id of this Export.
@@ -241,7 +247,9 @@ class Export(object):
     def file_system_id(self, file_system_id):
         """
         Sets the file_system_id of this Export.
-        The OCID of this export's file system.
+        The `OCID`__ of this export's file system.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :param file_system_id: The file_system_id of this Export.
@@ -253,7 +261,9 @@ class Export(object):
     def id(self):
         """
         **[Required]** Gets the id of this Export.
-        The OCID of this export.
+        The `OCID`__ of this export.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :return: The id of this Export.
@@ -265,7 +275,9 @@ class Export(object):
     def id(self, id):
         """
         Sets the id of this Export.
-        The OCID of this export.
+        The `OCID`__ of this export.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :param id: The id of this Export.

--- a/src/oci/file_storage/models/export_set.py
+++ b/src/oci/file_storage/models/export_set.py
@@ -144,7 +144,9 @@ class ExportSet(object):
     def compartment_id(self):
         """
         **[Required]** Gets the compartment_id of this ExportSet.
-        The OCID of the compartment that contains the export set.
+        The `OCID`__ of the compartment that contains the export set.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :return: The compartment_id of this ExportSet.
@@ -156,7 +158,9 @@ class ExportSet(object):
     def compartment_id(self, compartment_id):
         """
         Sets the compartment_id of this ExportSet.
-        The OCID of the compartment that contains the export set.
+        The `OCID`__ of the compartment that contains the export set.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :param compartment_id: The compartment_id of this ExportSet.
@@ -198,7 +202,9 @@ class ExportSet(object):
     def id(self):
         """
         **[Required]** Gets the id of this ExportSet.
-        The OCID of the export set.
+        The `OCID`__ of the export set.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :return: The id of this ExportSet.
@@ -210,7 +216,9 @@ class ExportSet(object):
     def id(self, id):
         """
         Sets the id of this ExportSet.
-        The OCID of the export set.
+        The `OCID`__ of the export set.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :param id: The id of this ExportSet.
@@ -366,7 +374,9 @@ class ExportSet(object):
     def vcn_id(self):
         """
         **[Required]** Gets the vcn_id of this ExportSet.
-        The OCID of the virtual cloud network (VCN) the export set is in.
+        The `OCID`__ of the virtual cloud network (VCN) the export set is in.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :return: The vcn_id of this ExportSet.
@@ -378,7 +388,9 @@ class ExportSet(object):
     def vcn_id(self, vcn_id):
         """
         Sets the vcn_id of this ExportSet.
-        The OCID of the virtual cloud network (VCN) the export set is in.
+        The `OCID`__ of the virtual cloud network (VCN) the export set is in.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :param vcn_id: The vcn_id of this ExportSet.

--- a/src/oci/file_storage/models/export_set_summary.py
+++ b/src/oci/file_storage/models/export_set_summary.py
@@ -127,7 +127,9 @@ class ExportSetSummary(object):
     def compartment_id(self):
         """
         **[Required]** Gets the compartment_id of this ExportSetSummary.
-        The OCID of the compartment that contains the export set.
+        The `OCID`__ of the compartment that contains the export set.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :return: The compartment_id of this ExportSetSummary.
@@ -139,7 +141,9 @@ class ExportSetSummary(object):
     def compartment_id(self, compartment_id):
         """
         Sets the compartment_id of this ExportSetSummary.
-        The OCID of the compartment that contains the export set.
+        The `OCID`__ of the compartment that contains the export set.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :param compartment_id: The compartment_id of this ExportSetSummary.
@@ -181,7 +185,9 @@ class ExportSetSummary(object):
     def id(self):
         """
         **[Required]** Gets the id of this ExportSetSummary.
-        The OCID of the export set.
+        The `OCID`__ of the export set.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :return: The id of this ExportSetSummary.
@@ -193,7 +199,9 @@ class ExportSetSummary(object):
     def id(self, id):
         """
         Sets the id of this ExportSetSummary.
-        The OCID of the export set.
+        The `OCID`__ of the export set.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :param id: The id of this ExportSetSummary.
@@ -269,7 +277,9 @@ class ExportSetSummary(object):
     def vcn_id(self):
         """
         **[Required]** Gets the vcn_id of this ExportSetSummary.
-        The OCID of the virtual cloud network (VCN) the export set is in.
+        The `OCID`__ of the virtual cloud network (VCN) the export set is in.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :return: The vcn_id of this ExportSetSummary.
@@ -281,7 +291,9 @@ class ExportSetSummary(object):
     def vcn_id(self, vcn_id):
         """
         Sets the vcn_id of this ExportSetSummary.
-        The OCID of the virtual cloud network (VCN) the export set is in.
+        The `OCID`__ of the virtual cloud network (VCN) the export set is in.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :param vcn_id: The vcn_id of this ExportSetSummary.

--- a/src/oci/file_storage/models/export_summary.py
+++ b/src/oci/file_storage/models/export_summary.py
@@ -90,7 +90,9 @@ class ExportSummary(object):
     def export_set_id(self):
         """
         **[Required]** Gets the export_set_id of this ExportSummary.
-        The OCID of this export's export set.
+        The `OCID`__ of this export's export set.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :return: The export_set_id of this ExportSummary.
@@ -102,7 +104,9 @@ class ExportSummary(object):
     def export_set_id(self, export_set_id):
         """
         Sets the export_set_id of this ExportSummary.
-        The OCID of this export's export set.
+        The `OCID`__ of this export's export set.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :param export_set_id: The export_set_id of this ExportSummary.
@@ -114,7 +118,9 @@ class ExportSummary(object):
     def file_system_id(self):
         """
         **[Required]** Gets the file_system_id of this ExportSummary.
-        The OCID of this export's file system.
+        The `OCID`__ of this export's file system.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :return: The file_system_id of this ExportSummary.
@@ -126,7 +132,9 @@ class ExportSummary(object):
     def file_system_id(self, file_system_id):
         """
         Sets the file_system_id of this ExportSummary.
-        The OCID of this export's file system.
+        The `OCID`__ of this export's file system.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :param file_system_id: The file_system_id of this ExportSummary.
@@ -138,7 +146,9 @@ class ExportSummary(object):
     def id(self):
         """
         **[Required]** Gets the id of this ExportSummary.
-        The OCID of this export.
+        The `OCID`__ of this export.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :return: The id of this ExportSummary.
@@ -150,7 +160,9 @@ class ExportSummary(object):
     def id(self, id):
         """
         Sets the id of this ExportSummary.
-        The OCID of this export.
+        The `OCID`__ of this export.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :param id: The id of this ExportSummary.

--- a/src/oci/file_storage/models/file_system.py
+++ b/src/oci/file_storage/models/file_system.py
@@ -89,6 +89,22 @@ class FileSystem(object):
             The value to assign to the kms_key_id property of this FileSystem.
         :type kms_key_id: str
 
+        :param source_details:
+            The value to assign to the source_details property of this FileSystem.
+        :type source_details: oci.file_storage.models.SourceDetails
+
+        :param is_clone_parent:
+            The value to assign to the is_clone_parent property of this FileSystem.
+        :type is_clone_parent: bool
+
+        :param is_hydrated:
+            The value to assign to the is_hydrated property of this FileSystem.
+        :type is_hydrated: bool
+
+        :param lifecycle_details:
+            The value to assign to the lifecycle_details property of this FileSystem.
+        :type lifecycle_details: str
+
         """
         self.swagger_types = {
             'availability_domain': 'str',
@@ -100,7 +116,11 @@ class FileSystem(object):
             'time_created': 'datetime',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
-            'kms_key_id': 'str'
+            'kms_key_id': 'str',
+            'source_details': 'SourceDetails',
+            'is_clone_parent': 'bool',
+            'is_hydrated': 'bool',
+            'lifecycle_details': 'str'
         }
 
         self.attribute_map = {
@@ -113,7 +133,11 @@ class FileSystem(object):
             'time_created': 'timeCreated',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
-            'kms_key_id': 'kmsKeyId'
+            'kms_key_id': 'kmsKeyId',
+            'source_details': 'sourceDetails',
+            'is_clone_parent': 'isCloneParent',
+            'is_hydrated': 'isHydrated',
+            'lifecycle_details': 'lifecycleDetails'
         }
 
         self._availability_domain = None
@@ -126,6 +150,10 @@ class FileSystem(object):
         self._freeform_tags = None
         self._defined_tags = None
         self._kms_key_id = None
+        self._source_details = None
+        self._is_clone_parent = None
+        self._is_hydrated = None
+        self._lifecycle_details = None
 
     @property
     def availability_domain(self):
@@ -165,6 +193,9 @@ class FileSystem(object):
         any snapshots. This number reflects the metered size of the file
         system and is updated asynchronously with respect to
         updates to the file system.
+        For more information, see `File System Usage and Metering`__.
+
+        __ https://docs.cloud.oracle.com/Content/File/Concepts/FSutilization.htm
 
 
         :return: The metered_bytes of this FileSystem.
@@ -180,6 +211,9 @@ class FileSystem(object):
         any snapshots. This number reflects the metered size of the file
         system and is updated asynchronously with respect to
         updates to the file system.
+        For more information, see `File System Usage and Metering`__.
+
+        __ https://docs.cloud.oracle.com/Content/File/Concepts/FSutilization.htm
 
 
         :param metered_bytes: The metered_bytes of this FileSystem.
@@ -191,7 +225,9 @@ class FileSystem(object):
     def compartment_id(self):
         """
         **[Required]** Gets the compartment_id of this FileSystem.
-        The OCID of the compartment that contains the file system.
+        The `OCID`__ of the compartment that contains the file system.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :return: The compartment_id of this FileSystem.
@@ -203,7 +239,9 @@ class FileSystem(object):
     def compartment_id(self, compartment_id):
         """
         Sets the compartment_id of this FileSystem.
-        The OCID of the compartment that contains the file system.
+        The `OCID`__ of the compartment that contains the file system.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :param compartment_id: The compartment_id of this FileSystem.
@@ -245,7 +283,9 @@ class FileSystem(object):
     def id(self):
         """
         **[Required]** Gets the id of this FileSystem.
-        The OCID of the file system.
+        The `OCID`__ of the file system.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :return: The id of this FileSystem.
@@ -257,7 +297,9 @@ class FileSystem(object):
     def id(self, id):
         """
         Sets the id of this FileSystem.
-        The OCID of the file system.
+        The `OCID`__ of the file system.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :param id: The id of this FileSystem.
@@ -399,7 +441,9 @@ class FileSystem(object):
     def kms_key_id(self):
         """
         Gets the kms_key_id of this FileSystem.
-        The OCID of the KMS key which is the master encryption key for the file system.
+        The `OCID`__ of the KMS key which is the master encryption key for the file system.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :return: The kms_key_id of this FileSystem.
@@ -411,13 +455,123 @@ class FileSystem(object):
     def kms_key_id(self, kms_key_id):
         """
         Sets the kms_key_id of this FileSystem.
-        The OCID of the KMS key which is the master encryption key for the file system.
+        The `OCID`__ of the KMS key which is the master encryption key for the file system.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :param kms_key_id: The kms_key_id of this FileSystem.
         :type: str
         """
         self._kms_key_id = kms_key_id
+
+    @property
+    def source_details(self):
+        """
+        Gets the source_details of this FileSystem.
+
+        :return: The source_details of this FileSystem.
+        :rtype: oci.file_storage.models.SourceDetails
+        """
+        return self._source_details
+
+    @source_details.setter
+    def source_details(self, source_details):
+        """
+        Sets the source_details of this FileSystem.
+
+        :param source_details: The source_details of this FileSystem.
+        :type: oci.file_storage.models.SourceDetails
+        """
+        self._source_details = source_details
+
+    @property
+    def is_clone_parent(self):
+        """
+        Gets the is_clone_parent of this FileSystem.
+        Specifies whether the file system has been cloned.
+        See `Cloning a File System`__.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/File/Tasks/cloningafilesystem.htm
+
+
+        :return: The is_clone_parent of this FileSystem.
+        :rtype: bool
+        """
+        return self._is_clone_parent
+
+    @is_clone_parent.setter
+    def is_clone_parent(self, is_clone_parent):
+        """
+        Sets the is_clone_parent of this FileSystem.
+        Specifies whether the file system has been cloned.
+        See `Cloning a File System`__.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/File/Tasks/cloningafilesystem.htm
+
+
+        :param is_clone_parent: The is_clone_parent of this FileSystem.
+        :type: bool
+        """
+        self._is_clone_parent = is_clone_parent
+
+    @property
+    def is_hydrated(self):
+        """
+        Gets the is_hydrated of this FileSystem.
+        Specifies whether the data has finished copying from the source to the clone.
+        Hydration can take up to several hours to complete depending on the size of the source.
+        The source and clone remain available during hydration, but there may be some performance impact.
+        See `Cloning a File System`__.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/File/Tasks/cloningafilesystem.htm#hydration
+
+
+        :return: The is_hydrated of this FileSystem.
+        :rtype: bool
+        """
+        return self._is_hydrated
+
+    @is_hydrated.setter
+    def is_hydrated(self, is_hydrated):
+        """
+        Sets the is_hydrated of this FileSystem.
+        Specifies whether the data has finished copying from the source to the clone.
+        Hydration can take up to several hours to complete depending on the size of the source.
+        The source and clone remain available during hydration, but there may be some performance impact.
+        See `Cloning a File System`__.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/File/Tasks/cloningafilesystem.htm#hydration
+
+
+        :param is_hydrated: The is_hydrated of this FileSystem.
+        :type: bool
+        """
+        self._is_hydrated = is_hydrated
+
+    @property
+    def lifecycle_details(self):
+        """
+        Gets the lifecycle_details of this FileSystem.
+        Additional information about the current 'lifecycleState'.
+
+
+        :return: The lifecycle_details of this FileSystem.
+        :rtype: str
+        """
+        return self._lifecycle_details
+
+    @lifecycle_details.setter
+    def lifecycle_details(self, lifecycle_details):
+        """
+        Sets the lifecycle_details of this FileSystem.
+        Additional information about the current 'lifecycleState'.
+
+
+        :param lifecycle_details: The lifecycle_details of this FileSystem.
+        :type: str
+        """
+        self._lifecycle_details = lifecycle_details
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/file_storage/models/file_system_summary.py
+++ b/src/oci/file_storage/models/file_system_summary.py
@@ -76,6 +76,22 @@ class FileSystemSummary(object):
             The value to assign to the kms_key_id property of this FileSystemSummary.
         :type kms_key_id: str
 
+        :param source_details:
+            The value to assign to the source_details property of this FileSystemSummary.
+        :type source_details: oci.file_storage.models.SourceDetails
+
+        :param is_clone_parent:
+            The value to assign to the is_clone_parent property of this FileSystemSummary.
+        :type is_clone_parent: bool
+
+        :param is_hydrated:
+            The value to assign to the is_hydrated property of this FileSystemSummary.
+        :type is_hydrated: bool
+
+        :param lifecycle_details:
+            The value to assign to the lifecycle_details property of this FileSystemSummary.
+        :type lifecycle_details: str
+
         """
         self.swagger_types = {
             'availability_domain': 'str',
@@ -87,7 +103,11 @@ class FileSystemSummary(object):
             'time_created': 'datetime',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
-            'kms_key_id': 'str'
+            'kms_key_id': 'str',
+            'source_details': 'SourceDetails',
+            'is_clone_parent': 'bool',
+            'is_hydrated': 'bool',
+            'lifecycle_details': 'str'
         }
 
         self.attribute_map = {
@@ -100,7 +120,11 @@ class FileSystemSummary(object):
             'time_created': 'timeCreated',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
-            'kms_key_id': 'kmsKeyId'
+            'kms_key_id': 'kmsKeyId',
+            'source_details': 'sourceDetails',
+            'is_clone_parent': 'isCloneParent',
+            'is_hydrated': 'isHydrated',
+            'lifecycle_details': 'lifecycleDetails'
         }
 
         self._availability_domain = None
@@ -113,6 +137,10 @@ class FileSystemSummary(object):
         self._freeform_tags = None
         self._defined_tags = None
         self._kms_key_id = None
+        self._source_details = None
+        self._is_clone_parent = None
+        self._is_hydrated = None
+        self._lifecycle_details = None
 
     @property
     def availability_domain(self):
@@ -178,7 +206,9 @@ class FileSystemSummary(object):
     def compartment_id(self):
         """
         **[Required]** Gets the compartment_id of this FileSystemSummary.
-        The OCID of the compartment that contains the file system.
+        The `OCID`__ of the compartment that contains the file system.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :return: The compartment_id of this FileSystemSummary.
@@ -190,7 +220,9 @@ class FileSystemSummary(object):
     def compartment_id(self, compartment_id):
         """
         Sets the compartment_id of this FileSystemSummary.
-        The OCID of the compartment that contains the file system.
+        The `OCID`__ of the compartment that contains the file system.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :param compartment_id: The compartment_id of this FileSystemSummary.
@@ -232,7 +264,9 @@ class FileSystemSummary(object):
     def id(self):
         """
         **[Required]** Gets the id of this FileSystemSummary.
-        The OCID of the file system.
+        The `OCID`__ of the file system.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :return: The id of this FileSystemSummary.
@@ -244,7 +278,9 @@ class FileSystemSummary(object):
     def id(self, id):
         """
         Sets the id of this FileSystemSummary.
-        The OCID of the file system.
+        The `OCID`__ of the file system.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :param id: The id of this FileSystemSummary.
@@ -386,7 +422,9 @@ class FileSystemSummary(object):
     def kms_key_id(self):
         """
         Gets the kms_key_id of this FileSystemSummary.
-        The OCID of KMS key used to encrypt the encryption keys associated with this file system.
+        The `OCID`__ of the KMS key used to encrypt the encryption keys associated with this file system.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :return: The kms_key_id of this FileSystemSummary.
@@ -398,13 +436,123 @@ class FileSystemSummary(object):
     def kms_key_id(self, kms_key_id):
         """
         Sets the kms_key_id of this FileSystemSummary.
-        The OCID of KMS key used to encrypt the encryption keys associated with this file system.
+        The `OCID`__ of the KMS key used to encrypt the encryption keys associated with this file system.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :param kms_key_id: The kms_key_id of this FileSystemSummary.
         :type: str
         """
         self._kms_key_id = kms_key_id
+
+    @property
+    def source_details(self):
+        """
+        Gets the source_details of this FileSystemSummary.
+
+        :return: The source_details of this FileSystemSummary.
+        :rtype: oci.file_storage.models.SourceDetails
+        """
+        return self._source_details
+
+    @source_details.setter
+    def source_details(self, source_details):
+        """
+        Sets the source_details of this FileSystemSummary.
+
+        :param source_details: The source_details of this FileSystemSummary.
+        :type: oci.file_storage.models.SourceDetails
+        """
+        self._source_details = source_details
+
+    @property
+    def is_clone_parent(self):
+        """
+        Gets the is_clone_parent of this FileSystemSummary.
+        Specifies whether the file system has been cloned.
+        See `Cloning a File System`__.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/File/Tasks/cloningafilesystem.htm
+
+
+        :return: The is_clone_parent of this FileSystemSummary.
+        :rtype: bool
+        """
+        return self._is_clone_parent
+
+    @is_clone_parent.setter
+    def is_clone_parent(self, is_clone_parent):
+        """
+        Sets the is_clone_parent of this FileSystemSummary.
+        Specifies whether the file system has been cloned.
+        See `Cloning a File System`__.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/File/Tasks/cloningafilesystem.htm
+
+
+        :param is_clone_parent: The is_clone_parent of this FileSystemSummary.
+        :type: bool
+        """
+        self._is_clone_parent = is_clone_parent
+
+    @property
+    def is_hydrated(self):
+        """
+        Gets the is_hydrated of this FileSystemSummary.
+        Specifies whether the data has finished copying from the source to the clone.
+        Hydration can take up to several hours to complete depending on the size of the source.
+        The source and clone remain available during hydration, but there may be some performance impact.
+        See `Cloning a File System`__.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/File/Tasks/cloningafilesystem.htm#hydration
+
+
+        :return: The is_hydrated of this FileSystemSummary.
+        :rtype: bool
+        """
+        return self._is_hydrated
+
+    @is_hydrated.setter
+    def is_hydrated(self, is_hydrated):
+        """
+        Sets the is_hydrated of this FileSystemSummary.
+        Specifies whether the data has finished copying from the source to the clone.
+        Hydration can take up to several hours to complete depending on the size of the source.
+        The source and clone remain available during hydration, but there may be some performance impact.
+        See `Cloning a File System`__.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/File/Tasks/cloningafilesystem.htm#hydration
+
+
+        :param is_hydrated: The is_hydrated of this FileSystemSummary.
+        :type: bool
+        """
+        self._is_hydrated = is_hydrated
+
+    @property
+    def lifecycle_details(self):
+        """
+        Gets the lifecycle_details of this FileSystemSummary.
+        Additional information about the current 'lifecycleState'.
+
+
+        :return: The lifecycle_details of this FileSystemSummary.
+        :rtype: str
+        """
+        return self._lifecycle_details
+
+    @lifecycle_details.setter
+    def lifecycle_details(self, lifecycle_details):
+        """
+        Sets the lifecycle_details of this FileSystemSummary.
+        Additional information about the current 'lifecycleState'.
+
+
+        :param lifecycle_details: The lifecycle_details of this FileSystemSummary.
+        :type: str
+        """
+        self._lifecycle_details = lifecycle_details
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/file_storage/models/mount_target.py
+++ b/src/oci/file_storage/models/mount_target.py
@@ -177,7 +177,9 @@ class MountTarget(object):
     def compartment_id(self):
         """
         **[Required]** Gets the compartment_id of this MountTarget.
-        The OCID of the compartment that contains the mount target.
+        The `OCID`__ of the compartment that contains the mount target.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :return: The compartment_id of this MountTarget.
@@ -189,7 +191,9 @@ class MountTarget(object):
     def compartment_id(self, compartment_id):
         """
         Sets the compartment_id of this MountTarget.
-        The OCID of the compartment that contains the mount target.
+        The `OCID`__ of the compartment that contains the mount target.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :param compartment_id: The compartment_id of this MountTarget.
@@ -231,9 +235,11 @@ class MountTarget(object):
     def export_set_id(self):
         """
         Gets the export_set_id of this MountTarget.
-        The OCID of the associated export set. Controls what file
+        The `OCID`__ of the associated export set. Controls what file
         systems will be exported through Network File System (NFS) protocol on this
         mount target.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :return: The export_set_id of this MountTarget.
@@ -245,9 +251,11 @@ class MountTarget(object):
     def export_set_id(self, export_set_id):
         """
         Sets the export_set_id of this MountTarget.
-        The OCID of the associated export set. Controls what file
+        The `OCID`__ of the associated export set. Controls what file
         systems will be exported through Network File System (NFS) protocol on this
         mount target.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :param export_set_id: The export_set_id of this MountTarget.
@@ -259,7 +267,9 @@ class MountTarget(object):
     def id(self):
         """
         **[Required]** Gets the id of this MountTarget.
-        The OCID of the mount target.
+        The `OCID`__ of the mount target.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :return: The id of this MountTarget.
@@ -271,7 +281,9 @@ class MountTarget(object):
     def id(self, id):
         """
         Sets the id of this MountTarget.
-        The OCID of the mount target.
+        The `OCID`__ of the mount target.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :param id: The id of this MountTarget.
@@ -361,7 +373,9 @@ class MountTarget(object):
     def subnet_id(self):
         """
         **[Required]** Gets the subnet_id of this MountTarget.
-        The OCID of the subnet the mount target is in.
+        The `OCID`__ of the subnet the mount target is in.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :return: The subnet_id of this MountTarget.
@@ -373,7 +387,9 @@ class MountTarget(object):
     def subnet_id(self, subnet_id):
         """
         Sets the subnet_id of this MountTarget.
-        The OCID of the subnet the mount target is in.
+        The `OCID`__ of the subnet the mount target is in.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :param subnet_id: The subnet_id of this MountTarget.

--- a/src/oci/file_storage/models/mount_target_summary.py
+++ b/src/oci/file_storage/models/mount_target_summary.py
@@ -166,7 +166,9 @@ class MountTargetSummary(object):
     def compartment_id(self):
         """
         **[Required]** Gets the compartment_id of this MountTargetSummary.
-        The OCID of the compartment that contains the mount target.
+        The `OCID`__ of the compartment that contains the mount target.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :return: The compartment_id of this MountTargetSummary.
@@ -178,7 +180,9 @@ class MountTargetSummary(object):
     def compartment_id(self, compartment_id):
         """
         Sets the compartment_id of this MountTargetSummary.
-        The OCID of the compartment that contains the mount target.
+        The `OCID`__ of the compartment that contains the mount target.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :param compartment_id: The compartment_id of this MountTargetSummary.
@@ -220,9 +224,11 @@ class MountTargetSummary(object):
     def export_set_id(self):
         """
         Gets the export_set_id of this MountTargetSummary.
-        The OCID of the associated export set. Controls what file
+        The `OCID`__ of the associated export set. Controls what file
         systems will be exported using Network File System (NFS) protocol on
         this mount target.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :return: The export_set_id of this MountTargetSummary.
@@ -234,9 +240,11 @@ class MountTargetSummary(object):
     def export_set_id(self, export_set_id):
         """
         Sets the export_set_id of this MountTargetSummary.
-        The OCID of the associated export set. Controls what file
+        The `OCID`__ of the associated export set. Controls what file
         systems will be exported using Network File System (NFS) protocol on
         this mount target.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :param export_set_id: The export_set_id of this MountTargetSummary.
@@ -248,7 +256,9 @@ class MountTargetSummary(object):
     def id(self):
         """
         **[Required]** Gets the id of this MountTargetSummary.
-        The OCID of the mount target.
+        The `OCID`__ of the mount target.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :return: The id of this MountTargetSummary.
@@ -260,7 +270,9 @@ class MountTargetSummary(object):
     def id(self, id):
         """
         Sets the id of this MountTargetSummary.
-        The OCID of the mount target.
+        The `OCID`__ of the mount target.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :param id: The id of this MountTargetSummary.
@@ -326,7 +338,9 @@ class MountTargetSummary(object):
     def subnet_id(self):
         """
         **[Required]** Gets the subnet_id of this MountTargetSummary.
-        The OCID of the subnet the mount target is in.
+        The `OCID`__ of the subnet the mount target is in.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :return: The subnet_id of this MountTargetSummary.
@@ -338,7 +352,9 @@ class MountTargetSummary(object):
     def subnet_id(self, subnet_id):
         """
         Sets the subnet_id of this MountTargetSummary.
-        The OCID of the subnet the mount target is in.
+        The `OCID`__ of the subnet the mount target is in.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :param subnet_id: The subnet_id of this MountTargetSummary.

--- a/src/oci/file_storage/models/snapshot.py
+++ b/src/oci/file_storage/models/snapshot.py
@@ -58,6 +58,18 @@ class Snapshot(object):
             The value to assign to the time_created property of this Snapshot.
         :type time_created: datetime
 
+        :param provenance_id:
+            The value to assign to the provenance_id property of this Snapshot.
+        :type provenance_id: str
+
+        :param is_clone_source:
+            The value to assign to the is_clone_source property of this Snapshot.
+        :type is_clone_source: bool
+
+        :param lifecycle_details:
+            The value to assign to the lifecycle_details property of this Snapshot.
+        :type lifecycle_details: str
+
         :param freeform_tags:
             The value to assign to the freeform_tags property of this Snapshot.
         :type freeform_tags: dict(str, str)
@@ -73,6 +85,9 @@ class Snapshot(object):
             'lifecycle_state': 'str',
             'name': 'str',
             'time_created': 'datetime',
+            'provenance_id': 'str',
+            'is_clone_source': 'bool',
+            'lifecycle_details': 'str',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))'
         }
@@ -83,6 +98,9 @@ class Snapshot(object):
             'lifecycle_state': 'lifecycleState',
             'name': 'name',
             'time_created': 'timeCreated',
+            'provenance_id': 'provenanceId',
+            'is_clone_source': 'isCloneSource',
+            'lifecycle_details': 'lifecycleDetails',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags'
         }
@@ -92,6 +110,9 @@ class Snapshot(object):
         self._lifecycle_state = None
         self._name = None
         self._time_created = None
+        self._provenance_id = None
+        self._is_clone_source = None
+        self._lifecycle_details = None
         self._freeform_tags = None
         self._defined_tags = None
 
@@ -99,8 +120,10 @@ class Snapshot(object):
     def file_system_id(self):
         """
         **[Required]** Gets the file_system_id of this Snapshot.
-        The OCID of the file system from which the snapshot
+        The `OCID`__ of the file system from which the snapshot
         was created.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :return: The file_system_id of this Snapshot.
@@ -112,8 +135,10 @@ class Snapshot(object):
     def file_system_id(self, file_system_id):
         """
         Sets the file_system_id of this Snapshot.
-        The OCID of the file system from which the snapshot
+        The `OCID`__ of the file system from which the snapshot
         was created.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :param file_system_id: The file_system_id of this Snapshot.
@@ -125,7 +150,9 @@ class Snapshot(object):
     def id(self):
         """
         **[Required]** Gets the id of this Snapshot.
-        The OCID of the snapshot.
+        The `OCID`__ of the snapshot.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :return: The id of this Snapshot.
@@ -137,7 +164,9 @@ class Snapshot(object):
     def id(self, id):
         """
         Sets the id of this Snapshot.
-        The OCID of the snapshot.
+        The `OCID`__ of the snapshot.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :param id: The id of this Snapshot.
@@ -240,6 +269,96 @@ class Snapshot(object):
         :type: datetime
         """
         self._time_created = time_created
+
+    @property
+    def provenance_id(self):
+        """
+        Gets the provenance_id of this Snapshot.
+        An `OCID`__ identifying the parent from which this snapshot was cloned.
+        If this snapshot was not cloned, then the `provenanceId` is the same as the snapshot `id` value.
+        If this snapshot was cloned, then the `provenanceId` value is the parent's `provenanceId`.
+        See `Cloning a File System`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/File/Tasks/cloningafilesystem.htm
+
+
+        :return: The provenance_id of this Snapshot.
+        :rtype: str
+        """
+        return self._provenance_id
+
+    @provenance_id.setter
+    def provenance_id(self, provenance_id):
+        """
+        Sets the provenance_id of this Snapshot.
+        An `OCID`__ identifying the parent from which this snapshot was cloned.
+        If this snapshot was not cloned, then the `provenanceId` is the same as the snapshot `id` value.
+        If this snapshot was cloned, then the `provenanceId` value is the parent's `provenanceId`.
+        See `Cloning a File System`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/File/Tasks/cloningafilesystem.htm
+
+
+        :param provenance_id: The provenance_id of this Snapshot.
+        :type: str
+        """
+        self._provenance_id = provenance_id
+
+    @property
+    def is_clone_source(self):
+        """
+        Gets the is_clone_source of this Snapshot.
+        Specifies whether the snapshot has been cloned.
+        See `Cloning a File System`__.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/File/Tasks/cloningafilesystem.htm
+
+
+        :return: The is_clone_source of this Snapshot.
+        :rtype: bool
+        """
+        return self._is_clone_source
+
+    @is_clone_source.setter
+    def is_clone_source(self, is_clone_source):
+        """
+        Sets the is_clone_source of this Snapshot.
+        Specifies whether the snapshot has been cloned.
+        See `Cloning a File System`__.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/File/Tasks/cloningafilesystem.htm
+
+
+        :param is_clone_source: The is_clone_source of this Snapshot.
+        :type: bool
+        """
+        self._is_clone_source = is_clone_source
+
+    @property
+    def lifecycle_details(self):
+        """
+        Gets the lifecycle_details of this Snapshot.
+        Additional information about the current 'lifecycleState'.
+
+
+        :return: The lifecycle_details of this Snapshot.
+        :rtype: str
+        """
+        return self._lifecycle_details
+
+    @lifecycle_details.setter
+    def lifecycle_details(self, lifecycle_details):
+        """
+        Sets the lifecycle_details of this Snapshot.
+        Additional information about the current 'lifecycleState'.
+
+
+        :param lifecycle_details: The lifecycle_details of this Snapshot.
+        :type: str
+        """
+        self._lifecycle_details = lifecycle_details
 
     @property
     def freeform_tags(self):

--- a/src/oci/file_storage/models/snapshot_summary.py
+++ b/src/oci/file_storage/models/snapshot_summary.py
@@ -56,6 +56,18 @@ class SnapshotSummary(object):
             The value to assign to the time_created property of this SnapshotSummary.
         :type time_created: datetime
 
+        :param provenance_id:
+            The value to assign to the provenance_id property of this SnapshotSummary.
+        :type provenance_id: str
+
+        :param is_clone_source:
+            The value to assign to the is_clone_source property of this SnapshotSummary.
+        :type is_clone_source: bool
+
+        :param lifecycle_details:
+            The value to assign to the lifecycle_details property of this SnapshotSummary.
+        :type lifecycle_details: str
+
         :param freeform_tags:
             The value to assign to the freeform_tags property of this SnapshotSummary.
         :type freeform_tags: dict(str, str)
@@ -71,6 +83,9 @@ class SnapshotSummary(object):
             'lifecycle_state': 'str',
             'name': 'str',
             'time_created': 'datetime',
+            'provenance_id': 'str',
+            'is_clone_source': 'bool',
+            'lifecycle_details': 'str',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))'
         }
@@ -81,6 +96,9 @@ class SnapshotSummary(object):
             'lifecycle_state': 'lifecycleState',
             'name': 'name',
             'time_created': 'timeCreated',
+            'provenance_id': 'provenanceId',
+            'is_clone_source': 'isCloneSource',
+            'lifecycle_details': 'lifecycleDetails',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags'
         }
@@ -90,6 +108,9 @@ class SnapshotSummary(object):
         self._lifecycle_state = None
         self._name = None
         self._time_created = None
+        self._provenance_id = None
+        self._is_clone_source = None
+        self._lifecycle_details = None
         self._freeform_tags = None
         self._defined_tags = None
 
@@ -97,8 +118,9 @@ class SnapshotSummary(object):
     def file_system_id(self):
         """
         **[Required]** Gets the file_system_id of this SnapshotSummary.
-        The OCID of the file system from which the
-        snapshot was created.
+        The `OCID`__ of the file system from which the snapshot was created.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :return: The file_system_id of this SnapshotSummary.
@@ -110,8 +132,9 @@ class SnapshotSummary(object):
     def file_system_id(self, file_system_id):
         """
         Sets the file_system_id of this SnapshotSummary.
-        The OCID of the file system from which the
-        snapshot was created.
+        The `OCID`__ of the file system from which the snapshot was created.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :param file_system_id: The file_system_id of this SnapshotSummary.
@@ -123,7 +146,9 @@ class SnapshotSummary(object):
     def id(self):
         """
         **[Required]** Gets the id of this SnapshotSummary.
-        The OCID of the snapshot.
+        The `OCID`__ of the snapshot.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :return: The id of this SnapshotSummary.
@@ -135,7 +160,9 @@ class SnapshotSummary(object):
     def id(self, id):
         """
         Sets the id of this SnapshotSummary.
-        The OCID of the snapshot.
+        The `OCID`__ of the snapshot.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
 
         :param id: The id of this SnapshotSummary.
@@ -238,6 +265,96 @@ class SnapshotSummary(object):
         :type: datetime
         """
         self._time_created = time_created
+
+    @property
+    def provenance_id(self):
+        """
+        Gets the provenance_id of this SnapshotSummary.
+        An `OCID`__ identifying the parent from which this snapshot was cloned.
+        If this snapshot was not cloned, then the `provenanceId` is the same as the snapshot `id` value.
+        If this snapshot was cloned, then the `provenanceId` value is the parent's `provenanceId`.
+        See `Cloning a File System`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/File/Tasks/cloningafilesystem.htm
+
+
+        :return: The provenance_id of this SnapshotSummary.
+        :rtype: str
+        """
+        return self._provenance_id
+
+    @provenance_id.setter
+    def provenance_id(self, provenance_id):
+        """
+        Sets the provenance_id of this SnapshotSummary.
+        An `OCID`__ identifying the parent from which this snapshot was cloned.
+        If this snapshot was not cloned, then the `provenanceId` is the same as the snapshot `id` value.
+        If this snapshot was cloned, then the `provenanceId` value is the parent's `provenanceId`.
+        See `Cloning a File System`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/File/Tasks/cloningafilesystem.htm
+
+
+        :param provenance_id: The provenance_id of this SnapshotSummary.
+        :type: str
+        """
+        self._provenance_id = provenance_id
+
+    @property
+    def is_clone_source(self):
+        """
+        Gets the is_clone_source of this SnapshotSummary.
+        Specifies whether the snapshot has been cloned.
+        See `Cloning a File System`__.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/File/Tasks/cloningafilesystem.htm
+
+
+        :return: The is_clone_source of this SnapshotSummary.
+        :rtype: bool
+        """
+        return self._is_clone_source
+
+    @is_clone_source.setter
+    def is_clone_source(self, is_clone_source):
+        """
+        Sets the is_clone_source of this SnapshotSummary.
+        Specifies whether the snapshot has been cloned.
+        See `Cloning a File System`__.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/File/Tasks/cloningafilesystem.htm
+
+
+        :param is_clone_source: The is_clone_source of this SnapshotSummary.
+        :type: bool
+        """
+        self._is_clone_source = is_clone_source
+
+    @property
+    def lifecycle_details(self):
+        """
+        Gets the lifecycle_details of this SnapshotSummary.
+        Additional information about the current 'lifecycleState'.
+
+
+        :return: The lifecycle_details of this SnapshotSummary.
+        :rtype: str
+        """
+        return self._lifecycle_details
+
+    @lifecycle_details.setter
+    def lifecycle_details(self, lifecycle_details):
+        """
+        Sets the lifecycle_details of this SnapshotSummary.
+        Additional information about the current 'lifecycleState'.
+
+
+        :param lifecycle_details: The lifecycle_details of this SnapshotSummary.
+        :type: str
+        """
+        self._lifecycle_details = lifecycle_details
 
     @property
     def freeform_tags(self):

--- a/src/oci/file_storage/models/source_details.py
+++ b/src/oci/file_storage/models/source_details.py
@@ -1,0 +1,117 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class SourceDetails(object):
+    """
+    Source information for the file system.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new SourceDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param parent_file_system_id:
+            The value to assign to the parent_file_system_id property of this SourceDetails.
+        :type parent_file_system_id: str
+
+        :param source_snapshot_id:
+            The value to assign to the source_snapshot_id property of this SourceDetails.
+        :type source_snapshot_id: str
+
+        """
+        self.swagger_types = {
+            'parent_file_system_id': 'str',
+            'source_snapshot_id': 'str'
+        }
+
+        self.attribute_map = {
+            'parent_file_system_id': 'parentFileSystemId',
+            'source_snapshot_id': 'sourceSnapshotId'
+        }
+
+        self._parent_file_system_id = None
+        self._source_snapshot_id = None
+
+    @property
+    def parent_file_system_id(self):
+        """
+        Gets the parent_file_system_id of this SourceDetails.
+        The `OCID`__ of the file system that contains the source snapshot of a cloned file system.
+        See `Cloning a File System`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/File/Tasks/cloningafilesystem.htm
+
+
+        :return: The parent_file_system_id of this SourceDetails.
+        :rtype: str
+        """
+        return self._parent_file_system_id
+
+    @parent_file_system_id.setter
+    def parent_file_system_id(self, parent_file_system_id):
+        """
+        Sets the parent_file_system_id of this SourceDetails.
+        The `OCID`__ of the file system that contains the source snapshot of a cloned file system.
+        See `Cloning a File System`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/File/Tasks/cloningafilesystem.htm
+
+
+        :param parent_file_system_id: The parent_file_system_id of this SourceDetails.
+        :type: str
+        """
+        self._parent_file_system_id = parent_file_system_id
+
+    @property
+    def source_snapshot_id(self):
+        """
+        Gets the source_snapshot_id of this SourceDetails.
+        The `OCID`__ of the source snapshot used to create a cloned file system.
+        See `Cloning a File System`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/File/Tasks/cloningafilesystem.htm
+
+
+        :return: The source_snapshot_id of this SourceDetails.
+        :rtype: str
+        """
+        return self._source_snapshot_id
+
+    @source_snapshot_id.setter
+    def source_snapshot_id(self, source_snapshot_id):
+        """
+        Sets the source_snapshot_id of this SourceDetails.
+        The `OCID`__ of the source snapshot used to create a cloned file system.
+        See `Cloning a File System`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/File/Tasks/cloningafilesystem.htm
+
+
+        :param source_snapshot_id: The source_snapshot_id of this SourceDetails.
+        :type: str
+        """
+        self._source_snapshot_id = source_snapshot_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/file_storage/models/update_file_system_details.py
+++ b/src/oci/file_storage/models/update_file_system_details.py
@@ -154,12 +154,12 @@ class UpdateFileSystemDetails(object):
     def kms_key_id(self):
         """
         Gets the kms_key_id of this UpdateFileSystemDetails.
-        The OCID of the Key Management master encryption key to associate with the specified file system. If this value is empty, the Update operation will remove the associated key, if there is one, from the file system. (The file system will continue to be encrypted, but with an encryption key managed by Oracle.)
+        The `OCID`__ of the Key Management master encryption key to associate with the specified file system. If this value is empty, the Update operation will remove the associated key, if there is one, from the file system. (The file system will continue to be encrypted, but with an encryption key managed by Oracle.)
 
         If updating to a new Key Management key, the old key must remain enabled so that files previously encrypted continue
-        to be accessible. For more information, see `Overview of Key
-        Management`__.
+        to be accessible. For more information, see `Overview of Key Management`__.
 
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
         __ https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm
 
 
@@ -172,12 +172,12 @@ class UpdateFileSystemDetails(object):
     def kms_key_id(self, kms_key_id):
         """
         Sets the kms_key_id of this UpdateFileSystemDetails.
-        The OCID of the Key Management master encryption key to associate with the specified file system. If this value is empty, the Update operation will remove the associated key, if there is one, from the file system. (The file system will continue to be encrypted, but with an encryption key managed by Oracle.)
+        The `OCID`__ of the Key Management master encryption key to associate with the specified file system. If this value is empty, the Update operation will remove the associated key, if there is one, from the file system. (The file system will continue to be encrypted, but with an encryption key managed by Oracle.)
 
         If updating to a new Key Management key, the old key must remain enabled so that files previously encrypted continue
-        to be accessible. For more information, see `Overview of Key
-        Management`__.
+        to be accessible. For more information, see `Overview of Key Management`__.
 
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
         __ https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm
 
 

--- a/src/oci/version.py
+++ b/src/oci/version.py
@@ -2,4 +2,4 @@
 # Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
 # This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 
-__version__ = "2.31.2"
+__version__ = "2.32.0"


### PR DESCRIPTION
## Added

* Support for pipelines, pipeline tasks, and favorites in the Data Integration service

* Support for publishing tasks to OCI Data Flow in the Data Integration service

* Support for clones in the File Storage service



## Breaking

* Changed model `UniqueKey` in the Dataintegration service to not inherit from Key.

* Changed model `PrimaryKey` in the Dataintegration service to inherit from `UniqueKey`.

* Removed enum values `PRIMARY_KEY` and `UNIQUE_KEY` in property `model_type` from model `key` in the Dataintegration service.
