### PR TITLE
Releasing version 2.33.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 ====================
+2.33.0 - 2020-03-16
+====================
+
+Added
+-----
+* Support for routing policies and HTTP2 listener protocols in the Load Balancing service
+* Support for model deployments in the Data Science service
+* Support for private clusters in the Container Engine for Kubernetes service
+* Support for updating an instance's usage type in the Content and Experience service
+
+Breaking
+--------
+* Retries are now enabled on all operations performing binary data upload, except upload manager. The SDK used to explicitly override retry configuration on binary upload operations because of potential data corruption issue (https://github.com/oracle/oci-python-sdk/issues/203).
+
+====================
 2.32.1 - 2020-03-09
 ====================
 

--- a/docs/api/container_engine.rst
+++ b/docs/api/container_engine.rst
@@ -22,11 +22,13 @@ Container Engine
     oci.container_engine.models.AdmissionControllerOptions
     oci.container_engine.models.Cluster
     oci.container_engine.models.ClusterCreateOptions
+    oci.container_engine.models.ClusterEndpointConfig
     oci.container_engine.models.ClusterEndpoints
     oci.container_engine.models.ClusterMetadata
     oci.container_engine.models.ClusterOptions
     oci.container_engine.models.ClusterSummary
     oci.container_engine.models.CreateClusterDetails
+    oci.container_engine.models.CreateClusterEndpointConfigDetails
     oci.container_engine.models.CreateClusterKubeconfigContentDetails
     oci.container_engine.models.CreateNodePoolDetails
     oci.container_engine.models.CreateNodePoolNodeConfigDetails
@@ -46,6 +48,7 @@ Container Engine
     oci.container_engine.models.NodeSourceViaImageDetails
     oci.container_engine.models.NodeSourceViaImageOption
     oci.container_engine.models.UpdateClusterDetails
+    oci.container_engine.models.UpdateClusterEndpointConfigDetails
     oci.container_engine.models.UpdateClusterOptionsDetails
     oci.container_engine.models.UpdateNodePoolDetails
     oci.container_engine.models.UpdateNodePoolNodeConfigDetails

--- a/docs/api/container_engine/models/oci.container_engine.models.ClusterEndpointConfig.rst
+++ b/docs/api/container_engine/models/oci.container_engine.models.ClusterEndpointConfig.rst
@@ -1,0 +1,11 @@
+ClusterEndpointConfig
+=====================
+
+.. currentmodule:: oci.container_engine.models
+
+.. autoclass:: ClusterEndpointConfig
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/container_engine/models/oci.container_engine.models.CreateClusterEndpointConfigDetails.rst
+++ b/docs/api/container_engine/models/oci.container_engine.models.CreateClusterEndpointConfigDetails.rst
@@ -1,0 +1,11 @@
+CreateClusterEndpointConfigDetails
+==================================
+
+.. currentmodule:: oci.container_engine.models
+
+.. autoclass:: CreateClusterEndpointConfigDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/container_engine/models/oci.container_engine.models.UpdateClusterEndpointConfigDetails.rst
+++ b/docs/api/container_engine/models/oci.container_engine.models.UpdateClusterEndpointConfigDetails.rst
@@ -1,0 +1,11 @@
+UpdateClusterEndpointConfigDetails
+==================================
+
+.. currentmodule:: oci.container_engine.models
+
+.. autoclass:: UpdateClusterEndpointConfigDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_science.rst
+++ b/docs/api/data_science.rst
@@ -18,14 +18,25 @@ Data Science
     :nosignatures:
     :template: autosummary/model_class.rst
 
+    oci.data_science.models.CategoryLogDetails
     oci.data_science.models.ChangeModelCompartmentDetails
+    oci.data_science.models.ChangeModelDeploymentCompartmentDetails
     oci.data_science.models.ChangeNotebookSessionCompartmentDetails
     oci.data_science.models.ChangeProjectCompartmentDetails
+    oci.data_science.models.CreateModelDeploymentDetails
     oci.data_science.models.CreateModelDetails
     oci.data_science.models.CreateModelProvenanceDetails
     oci.data_science.models.CreateNotebookSessionDetails
     oci.data_science.models.CreateProjectDetails
+    oci.data_science.models.FixedSizeScalingPolicy
+    oci.data_science.models.InstanceConfiguration
+    oci.data_science.models.LogDetails
     oci.data_science.models.Model
+    oci.data_science.models.ModelConfigurationDetails
+    oci.data_science.models.ModelDeployment
+    oci.data_science.models.ModelDeploymentConfigurationDetails
+    oci.data_science.models.ModelDeploymentShapeSummary
+    oci.data_science.models.ModelDeploymentSummary
     oci.data_science.models.ModelProvenance
     oci.data_science.models.ModelSummary
     oci.data_science.models.NotebookSession
@@ -34,10 +45,17 @@ Data Science
     oci.data_science.models.NotebookSessionSummary
     oci.data_science.models.Project
     oci.data_science.models.ProjectSummary
+    oci.data_science.models.ScalingPolicy
+    oci.data_science.models.SingleModelDeploymentConfigurationDetails
+    oci.data_science.models.UpdateCategoryLogDetails
+    oci.data_science.models.UpdateModelConfigurationDetails
+    oci.data_science.models.UpdateModelDeploymentConfigurationDetails
+    oci.data_science.models.UpdateModelDeploymentDetails
     oci.data_science.models.UpdateModelDetails
     oci.data_science.models.UpdateModelProvenanceDetails
     oci.data_science.models.UpdateNotebookSessionDetails
     oci.data_science.models.UpdateProjectDetails
+    oci.data_science.models.UpdateSingleModelDeploymentConfigurationDetails
     oci.data_science.models.WorkRequest
     oci.data_science.models.WorkRequestError
     oci.data_science.models.WorkRequestLogEntry

--- a/docs/api/data_science/models/oci.data_science.models.CategoryLogDetails.rst
+++ b/docs/api/data_science/models/oci.data_science.models.CategoryLogDetails.rst
@@ -1,0 +1,11 @@
+CategoryLogDetails
+==================
+
+.. currentmodule:: oci.data_science.models
+
+.. autoclass:: CategoryLogDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_science/models/oci.data_science.models.ChangeModelDeploymentCompartmentDetails.rst
+++ b/docs/api/data_science/models/oci.data_science.models.ChangeModelDeploymentCompartmentDetails.rst
@@ -1,0 +1,11 @@
+ChangeModelDeploymentCompartmentDetails
+=======================================
+
+.. currentmodule:: oci.data_science.models
+
+.. autoclass:: ChangeModelDeploymentCompartmentDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_science/models/oci.data_science.models.CreateModelDeploymentDetails.rst
+++ b/docs/api/data_science/models/oci.data_science.models.CreateModelDeploymentDetails.rst
@@ -1,0 +1,11 @@
+CreateModelDeploymentDetails
+============================
+
+.. currentmodule:: oci.data_science.models
+
+.. autoclass:: CreateModelDeploymentDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_science/models/oci.data_science.models.FixedSizeScalingPolicy.rst
+++ b/docs/api/data_science/models/oci.data_science.models.FixedSizeScalingPolicy.rst
@@ -1,0 +1,11 @@
+FixedSizeScalingPolicy
+======================
+
+.. currentmodule:: oci.data_science.models
+
+.. autoclass:: FixedSizeScalingPolicy
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_science/models/oci.data_science.models.InstanceConfiguration.rst
+++ b/docs/api/data_science/models/oci.data_science.models.InstanceConfiguration.rst
@@ -1,0 +1,11 @@
+InstanceConfiguration
+=====================
+
+.. currentmodule:: oci.data_science.models
+
+.. autoclass:: InstanceConfiguration
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_science/models/oci.data_science.models.LogDetails.rst
+++ b/docs/api/data_science/models/oci.data_science.models.LogDetails.rst
@@ -1,0 +1,11 @@
+LogDetails
+==========
+
+.. currentmodule:: oci.data_science.models
+
+.. autoclass:: LogDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_science/models/oci.data_science.models.ModelConfigurationDetails.rst
+++ b/docs/api/data_science/models/oci.data_science.models.ModelConfigurationDetails.rst
@@ -1,0 +1,11 @@
+ModelConfigurationDetails
+=========================
+
+.. currentmodule:: oci.data_science.models
+
+.. autoclass:: ModelConfigurationDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_science/models/oci.data_science.models.ModelDeployment.rst
+++ b/docs/api/data_science/models/oci.data_science.models.ModelDeployment.rst
@@ -1,0 +1,11 @@
+ModelDeployment
+===============
+
+.. currentmodule:: oci.data_science.models
+
+.. autoclass:: ModelDeployment
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_science/models/oci.data_science.models.ModelDeploymentConfigurationDetails.rst
+++ b/docs/api/data_science/models/oci.data_science.models.ModelDeploymentConfigurationDetails.rst
@@ -1,0 +1,11 @@
+ModelDeploymentConfigurationDetails
+===================================
+
+.. currentmodule:: oci.data_science.models
+
+.. autoclass:: ModelDeploymentConfigurationDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_science/models/oci.data_science.models.ModelDeploymentShapeSummary.rst
+++ b/docs/api/data_science/models/oci.data_science.models.ModelDeploymentShapeSummary.rst
@@ -1,0 +1,11 @@
+ModelDeploymentShapeSummary
+===========================
+
+.. currentmodule:: oci.data_science.models
+
+.. autoclass:: ModelDeploymentShapeSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_science/models/oci.data_science.models.ModelDeploymentSummary.rst
+++ b/docs/api/data_science/models/oci.data_science.models.ModelDeploymentSummary.rst
@@ -1,0 +1,11 @@
+ModelDeploymentSummary
+======================
+
+.. currentmodule:: oci.data_science.models
+
+.. autoclass:: ModelDeploymentSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_science/models/oci.data_science.models.ScalingPolicy.rst
+++ b/docs/api/data_science/models/oci.data_science.models.ScalingPolicy.rst
@@ -1,0 +1,11 @@
+ScalingPolicy
+=============
+
+.. currentmodule:: oci.data_science.models
+
+.. autoclass:: ScalingPolicy
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_science/models/oci.data_science.models.SingleModelDeploymentConfigurationDetails.rst
+++ b/docs/api/data_science/models/oci.data_science.models.SingleModelDeploymentConfigurationDetails.rst
@@ -1,0 +1,11 @@
+SingleModelDeploymentConfigurationDetails
+=========================================
+
+.. currentmodule:: oci.data_science.models
+
+.. autoclass:: SingleModelDeploymentConfigurationDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_science/models/oci.data_science.models.UpdateCategoryLogDetails.rst
+++ b/docs/api/data_science/models/oci.data_science.models.UpdateCategoryLogDetails.rst
@@ -1,0 +1,11 @@
+UpdateCategoryLogDetails
+========================
+
+.. currentmodule:: oci.data_science.models
+
+.. autoclass:: UpdateCategoryLogDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_science/models/oci.data_science.models.UpdateModelConfigurationDetails.rst
+++ b/docs/api/data_science/models/oci.data_science.models.UpdateModelConfigurationDetails.rst
@@ -1,0 +1,11 @@
+UpdateModelConfigurationDetails
+===============================
+
+.. currentmodule:: oci.data_science.models
+
+.. autoclass:: UpdateModelConfigurationDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_science/models/oci.data_science.models.UpdateModelDeploymentConfigurationDetails.rst
+++ b/docs/api/data_science/models/oci.data_science.models.UpdateModelDeploymentConfigurationDetails.rst
@@ -1,0 +1,11 @@
+UpdateModelDeploymentConfigurationDetails
+=========================================
+
+.. currentmodule:: oci.data_science.models
+
+.. autoclass:: UpdateModelDeploymentConfigurationDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_science/models/oci.data_science.models.UpdateModelDeploymentDetails.rst
+++ b/docs/api/data_science/models/oci.data_science.models.UpdateModelDeploymentDetails.rst
@@ -1,0 +1,11 @@
+UpdateModelDeploymentDetails
+============================
+
+.. currentmodule:: oci.data_science.models
+
+.. autoclass:: UpdateModelDeploymentDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_science/models/oci.data_science.models.UpdateSingleModelDeploymentConfigurationDetails.rst
+++ b/docs/api/data_science/models/oci.data_science.models.UpdateSingleModelDeploymentConfigurationDetails.rst
@@ -1,0 +1,11 @@
+UpdateSingleModelDeploymentConfigurationDetails
+===============================================
+
+.. currentmodule:: oci.data_science.models
+
+.. autoclass:: UpdateSingleModelDeploymentConfigurationDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/load_balancer.rst
+++ b/docs/api/load_balancer.rst
@@ -18,6 +18,7 @@ Load Balancer
     :nosignatures:
     :template: autosummary/model_class.rst
 
+    oci.load_balancer.models.Action
     oci.load_balancer.models.AddHttpRequestHeaderRule
     oci.load_balancer.models.AddHttpResponseHeaderRule
     oci.load_balancer.models.AllowRule
@@ -39,10 +40,12 @@ Load Balancer
     oci.load_balancer.models.CreateListenerDetails
     oci.load_balancer.models.CreateLoadBalancerDetails
     oci.load_balancer.models.CreatePathRouteSetDetails
+    oci.load_balancer.models.CreateRoutingPolicyDetails
     oci.load_balancer.models.CreateRuleSetDetails
     oci.load_balancer.models.CreateSSLCipherSuiteDetails
     oci.load_balancer.models.ExtendHttpRequestHeaderValueRule
     oci.load_balancer.models.ExtendHttpResponseHeaderValueRule
+    oci.load_balancer.models.ForwardToBackendSet
     oci.load_balancer.models.HealthCheckResult
     oci.load_balancer.models.HealthChecker
     oci.load_balancer.models.HealthCheckerDetails
@@ -70,6 +73,9 @@ Load Balancer
     oci.load_balancer.models.RemoveHttpRequestHeaderRule
     oci.load_balancer.models.RemoveHttpResponseHeaderRule
     oci.load_balancer.models.ReservedIP
+    oci.load_balancer.models.RoutingPolicy
+    oci.load_balancer.models.RoutingPolicyDetails
+    oci.load_balancer.models.RoutingRule
     oci.load_balancer.models.Rule
     oci.load_balancer.models.RuleCondition
     oci.load_balancer.models.RuleSet
@@ -92,6 +98,7 @@ Load Balancer
     oci.load_balancer.models.UpdateLoadBalancerShapeDetails
     oci.load_balancer.models.UpdateNetworkSecurityGroupsDetails
     oci.load_balancer.models.UpdatePathRouteSetDetails
+    oci.load_balancer.models.UpdateRoutingPolicyDetails
     oci.load_balancer.models.UpdateRuleSetDetails
     oci.load_balancer.models.UpdateSSLCipherSuiteDetails
     oci.load_balancer.models.WorkRequest

--- a/docs/api/load_balancer/models/oci.load_balancer.models.Action.rst
+++ b/docs/api/load_balancer/models/oci.load_balancer.models.Action.rst
@@ -1,0 +1,11 @@
+Action
+======
+
+.. currentmodule:: oci.load_balancer.models
+
+.. autoclass:: Action
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/load_balancer/models/oci.load_balancer.models.CreateRoutingPolicyDetails.rst
+++ b/docs/api/load_balancer/models/oci.load_balancer.models.CreateRoutingPolicyDetails.rst
@@ -1,0 +1,11 @@
+CreateRoutingPolicyDetails
+==========================
+
+.. currentmodule:: oci.load_balancer.models
+
+.. autoclass:: CreateRoutingPolicyDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/load_balancer/models/oci.load_balancer.models.ForwardToBackendSet.rst
+++ b/docs/api/load_balancer/models/oci.load_balancer.models.ForwardToBackendSet.rst
@@ -1,0 +1,11 @@
+ForwardToBackendSet
+===================
+
+.. currentmodule:: oci.load_balancer.models
+
+.. autoclass:: ForwardToBackendSet
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/load_balancer/models/oci.load_balancer.models.RoutingPolicy.rst
+++ b/docs/api/load_balancer/models/oci.load_balancer.models.RoutingPolicy.rst
@@ -1,0 +1,11 @@
+RoutingPolicy
+=============
+
+.. currentmodule:: oci.load_balancer.models
+
+.. autoclass:: RoutingPolicy
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/load_balancer/models/oci.load_balancer.models.RoutingPolicyDetails.rst
+++ b/docs/api/load_balancer/models/oci.load_balancer.models.RoutingPolicyDetails.rst
@@ -1,0 +1,11 @@
+RoutingPolicyDetails
+====================
+
+.. currentmodule:: oci.load_balancer.models
+
+.. autoclass:: RoutingPolicyDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/load_balancer/models/oci.load_balancer.models.RoutingRule.rst
+++ b/docs/api/load_balancer/models/oci.load_balancer.models.RoutingRule.rst
@@ -1,0 +1,11 @@
+RoutingRule
+===========
+
+.. currentmodule:: oci.load_balancer.models
+
+.. autoclass:: RoutingRule
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/load_balancer/models/oci.load_balancer.models.UpdateRoutingPolicyDetails.rst
+++ b/docs/api/load_balancer/models/oci.load_balancer.models.UpdateRoutingPolicyDetails.rst
@@ -1,0 +1,11 @@
+UpdateRoutingPolicyDetails
+==========================
+
+.. currentmodule:: oci.load_balancer.models
+
+.. autoclass:: UpdateRoutingPolicyDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/customize_service_client/connection_read_timeout.rst
+++ b/docs/customize_service_client/connection_read_timeout.rst
@@ -13,15 +13,25 @@ Setting connection and read timeouts
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The Python SDK uses the `Requests <http://docs.python-requests.org/en/master/>`_ library to make calls to Oracle Cloud Infrastructure services. The SDK uses the Requests `definition <http://docs.python-requests.org/en/master/user/advanced/#timeouts>`_ for connection and read timeouts.
 
-By default, calls made to services have no connection or read timeout associated with them (i.e. it is possible to wait forever for a response). If you wish to override this default behaviour and set a timeout, you can do something similar to:
+By default, calls made to services have the following timeouts associated with them:
+
+* Connection timeout - 10 seconds
+* Read timeout - 60 seconds
+
+If you wish to override this default behaviour and set a different values to timeouts, you can pass `timeout` parameter when constructing the client:
 
 .. code-block:: python
 
     import oci
 
     config = oci.config.from_file()
-    compute = oci.core.ComputeClient(config)
-    
+    # This will set a value of 5 seconds to the connection and read timeout
+    compute = oci.core.ComputeClient(config, timeout=5)
+
+    # This will set the connection timeout to 2 seconds and the read timeout to 25 seconds
+    compute = oci.core.ComputeClient(config, timeout=(2, 25))
+
+    # You can also modify the underlying base client
     # This will set a value of 5 seconds to the connection and read timeout
     compute.base_client.timeout = 5
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -21,7 +21,7 @@ This topic describes how to install, configure, and use the Oracle Cloud Infrast
 The Python SDK requires:
 
 * Python version 3.6+
-* `OpenSSL`_ version 1.0.1 or later. The Python SDK uses the `Cryptography.io`_ library which requires `OpenSSL`_. For details on all Cryptography.io prerequisites, see `Cryptography.io Installation`_.
+* `OpenSSL`_ version 1.0.2 or later. The Python SDK uses the `Cryptography.io`_ library which requires `OpenSSL`_. For details on all Cryptography.io prerequisites, see `Cryptography.io Installation`_.
 
 In addition, all Oracle Cloud Infrastructure SDKs require:
 
@@ -41,7 +41,7 @@ In addition, all Oracle Cloud Infrastructure SDKs require:
  Downloading and Installing the SDK
 ====================================
 
-You can install the Python SDK through the Python Package Index (PyPI), or alternatively through GitHub.
+You can install the Python SDK through the Python Package Index (PyPI), GitHub, OCI Resource Manager or yum on Oracle Linux.
 
 Set up a virtual environment
 -----------------------------
@@ -85,6 +85,45 @@ To install from GitHub:
 
       If you're unable to install the whl file, make sure pip is up to date.
       Use ``pip install -U pip`` and then try to install the whl file again.
+
+Offline Installation
+--------------------
+
+To install the Python SDK in an environment which does not allow internet connection, you can use the OCI CLI offline install files to install the Python SDK in offline mode. Here are the steps:
+
+1. Go to the `CLI releases page <https://github.com/oracle/oci-cli/releases>`_
+2. To install the latest SDK version, go to the latest release. If you want to install a particular SDK version, follow the below steps:
+    a. Find that version in the `SDK changelog <https://github.com/oracle/oci-python-sdk/blob/master/CHANGELOG.rst>`_.
+    b. Note at the date this version was released.
+    c. Check the `CLI changelog <https://github.com/oracle/oci-cli/blob/master/CHANGELOG.rst>`_ and find the CLI version released on the same date as the SDK version you want to install.
+    d. Go to the `CLI releases page <https://github.com/oracle/oci-cli/releases>`_ and select that CLI version.
+3. Go to the "Assets" area.
+4. Download the .zip file for your Operating System.
+5. Copy the .zip file to the environment in which you want to install the SDK.
+6. Unzip the .zip file. This should create a new directory called "oci-cli-installation".
+7. Use the following command to install the SDK::
+
+    pip3 install oci --find-links ./oci-cli-installation/cli-deps --no-index
+
+  .. note::
+
+      If you have any issues executing the above steps, please see common installation issues here https://github.com/oracle/oci-cli/blob/master/COMMON_ISSUES.rst or create a Github issue and we will look into it.
+
+Installing with Resource Manager
+--------------------------------
+
+You can use `Resource Manager <https://docs.oracle.com/en-us/iaas/Content/ResourceManager/Concepts/resourcemanager.htm#Overview_of_Resource_Manager>`_
+to `install the Oracle Cloud Development Kit on a Compute instance in your compartment <https://docs.oracle.com/en-us/iaas/Content/ResourceManager/Tasks/devtools.htm#devtools>`_.
+The Oracle Cloud Development Kit includes the SDK for Python, along with other Oracle development tools.
+
+Installing with yum
+-------------------
+
+If you're using Oracle Linux 7, you can use yum to install the OCI SDK for Python.
+
+The following example shows how to use yum to install the OCI SDK for Python 3.6::
+
+    sudo yum install python36-oci-sdk.x86_64
 
 
 =====================

--- a/examples/data_science/model_deployment_example.py
+++ b/examples/data_science/model_deployment_example.py
@@ -1,0 +1,290 @@
+"""
+This is a model deployment example using the Python-SDK
+This script requires to do authentication, see details: https://docs.oracle.com/en-us/iaas/data-science/using/use-notebook-sessions.htm#signing-oci-apis
+    + Using OCI configuration file:
+        user = <your user_ocid>
+        fingerprint = <your fingerprint>
+        tenancy = <your tenancy_ocid>
+        region = <region>
+        key_file = <the path to the private key>
+    + Or using the resource principal:
+        Sample code:# import oci
+                    # from oci.data_science import DataScienceClient
+                    # rps = oci.auth.signers.get_resource_principals_signer()
+                    # dsc = DataScienceClient(config={}, signer=rps)
+A user needs to provide information below to set up and run the script (check #TODO)
+    + config_file = <OCI configuration file>
+    + compartment_id = <compartment ocid>
+    + project_id = <project ocid>
+    + model_id = <model ocid>
+    + instance_shape_name = <instance shape name>
+    + instance_count = <number of instances>
+    + bandwidth_mbps = <load balancer bandwidth>
+    + access_log_id = <access log ocid> -- optional
+    + predict_log_id = <predict log ocid> -- optional
+    + log_group_id = <log group ocid> -- optional
+    + input_body = <input in json format for making prediction>
+    + new_deployment_name = <new name for the model deployment to update a model deployment>
+    + new_instance_shape_name = <new instance shape name to update a model deployment>
+    + new_model_id = <new model ocid if you want to update a deployment with new model>
+This script covers:
+    + creating a model deployment
+    + getting a model deployment info
+    + making prediction using a model deployment url
+    + updating an active model deployment with display name, instance shape name and model id
+    + activating a model deployment
+    + deactivating a model deployment
+    + deleting a model deployment
+For other use cases: see details in the documentation https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/api/data_science.html
+"""
+
+import oci
+import oci.data_science as data_science
+from oci.signer import Signer
+from oci.data_science.models import CreateModelDeploymentDetails, ModelConfigurationDetails
+from oci.data_science.models import InstanceConfiguration, FixedSizeScalingPolicy
+from oci.data_science.models import UpdateModelDeploymentDetails, UpdateModelConfigurationDetails, UpdateSingleModelDeploymentConfigurationDetails
+from oci.data_science.models import CategoryLogDetails, LogDetails, UpdateCategoryLogDetails
+import json
+import requests
+
+# --- Set up
+# TODO: Change the below variables to prepare for model deployment activities
+config_file = "<config file>"  # '~/.oci/config'
+
+# TODO: Change the compartment id and project id
+compartment_id = "<compartment ocid>"
+project_id = "<project ocid>"
+
+# TODO: Change configuration details for deploying a model
+deployment_name = "my_deployment"
+model_id = "<model ocid>"
+instance_shape_name = "VM.Standard2.1"
+instance_count = 1
+bandwidth_mbps = 10
+# this is an option to set up logs for a model deployment. If no logs, setting log-related variables to an empty string
+access_log_id = "<access log ocid>"
+predict_log_id = "<predict log ocid>"
+log_group_id = "<log group ocid>"
+
+# TODO: Set the input to make a prediction using the newly created model deployment
+input_body = "<input json format>"
+
+# TODO: Change the variables for updating model deployment
+new_deployment_name = "my_new_model_deployment"  # new name of the model deployment
+new_instance_shape_name = "<new instance shape name to update a model deployment>"
+new_model_id = "<new model ocid if you want to update a deployment with new model>"
+
+
+class ModelDeployment:
+    def __init__(self, config_file, compartment_id, project_id):
+        self.model_deployment_id = None
+        self.config_file = config_file
+        self.compartment_id = compartment_id
+        self.project_id = project_id
+        self.active = False
+        # -- Create data science client and data science composite client with oci config to organize your work
+        try:
+            print("*** Setting up data science client....")
+            """
+            Using resource principal, a user can take the identity of the resource (for example notebook session) and
+               the notebook session has to be authorized to create a model deployment.
+               auth = Signer.get_resource_principals_signer()
+               data_science_client = DataScienceClient({}, signer=auth)
+            Or using the OCI configuration file and API key as below:
+            """
+            # read oci_config file
+            self.oci_config = oci.config.from_file(self.config_file, "DEFAULT")
+            self.data_science_client = data_science.DataScienceClient(config=self.oci_config)
+            print("Setting up a data science client succeeded!")
+            self.data_science_composite_client = data_science.DataScienceClientCompositeOperations(self.data_science_client)
+            print("Setting up a data science composite client succeeded!")
+            self.auth = Signer(tenancy=self.oci_config['tenancy'], user=self.oci_config['user'], fingerprint=self.oci_config['fingerprint'], private_key_file_location=self.oci_config['key_file'], pass_phrase=self.oci_config['pass_phrase'])
+        except Exception as e:
+            print("Setting up a data science client failed!!!")
+            raise e
+
+    def create_model_deployment(self, deployment_name, instance_shape_name, instance_count, bandwidth_mbps, model_id, log_group_id=None, access_log_id=None, predict_log_id=None):
+        # -- Create a model deployment
+        print("------------------------------------")
+        print("*** Creating a model deployment ...")
+        try:
+            self.deployment_name = deployment_name
+            self.instance_configuration = InstanceConfiguration()  # model deployment instance configuration
+            self.instance_configuration.instance_shape_name = instance_shape_name
+
+            self.scaling_policy = FixedSizeScalingPolicy()  # the fixed size scaling policy for model deployment
+            self.scaling_policy.instance_count = instance_count
+            self.model_id = model_id
+            self.bandwidth_mbps = bandwidth_mbps
+
+            # create a model confifguration details object
+            model_config_details = ModelConfigurationDetails(model_id=self.model_id, bandwidth_mbps=self.bandwidth_mbps, instance_configuration=self.instance_configuration, scaling_policy=self.scaling_policy)
+
+            # create a model type deployment
+            single_model_deployment_config_details = data_science.models.SingleModelDeploymentConfigurationDetails(deployment_type="SINGLE_MODEL", model_configuration_details=model_config_details)
+
+            # set up parameters required to create a new model deployment.
+            create_model_deployment_details = CreateModelDeploymentDetails(display_name=deployment_name, model_deployment_configuration_details=single_model_deployment_config_details, compartment_id=self.compartment_id, project_id=self.project_id)
+
+            # for logging uncomment the line below
+            # create_model_deployment_details.category_log_details = self.create_logging(log_group_id, access_log_id, predict_log_id, is_create = True)
+
+            # create a model deployment with data science composite client
+            create_model_deployment_response = self.data_science_composite_client.create_model_deployment_and_wait_for_state(create_model_deployment_details=create_model_deployment_details, wait_for_states=["SUCCEEDED", "FAILED"])
+            work_request_resources = create_model_deployment_response.data.resources
+            self.model_deployment_id = work_request_resources[0].identifier
+            if create_model_deployment_response.data.status == "SUCCEEDED":
+                print("Creating a model deployment succeeded!")
+                self.active = True
+            else:
+                print("Creating a model deployment failed!!!")
+        except Exception as e:
+            print("Creating a model deployment failed!!!")
+            raise e
+
+    def get_model_deployment_info(self):
+        # -- Get the model deployment info
+        print("------------------------------------")
+        print("*** Getting the model deployment details ... ")
+        try:
+            model_deployment = self.data_science_client.get_model_deployment(model_deployment_id=self.model_deployment_id)
+            print(model_deployment.data)
+            self.model_deployment_url = model_deployment.data.model_deployment_url
+        except Exception as e:
+            print("The model deployment has not created. Should run create_model_deployment method first!")
+            raise e
+
+    def make_prediction(self, input_body):
+        # -- Make predictions
+        print("------------------------------------")
+        print("*** Making prediction ...")
+        try:
+            if self.model_deployment_url is None:
+                self.get_model_deployment_info()
+            prediction = requests.post(self.model_deployment_url + "/predict", data=json.dumps(input_body), auth=self.auth)  # make a prediction request
+            if prediction.status_code == 200:
+                print(prediction.json())
+            else:
+                print("Making predictions failed!!!")
+        except Exception as e:
+            print("Making predictions failed!!!")
+            raise e
+
+    def deactivate_model_deployment(self):
+        # -- Deactivate a model deployment
+        print("------------------------------------")
+        print("*** Deactivating the model deployment ...")
+        try:
+            deactivate_model_deployment_response = self.data_science_composite_client.deactivate_model_deployment_and_wait_for_state(model_deployment_id=self.model_deployment_id, wait_for_states=["SUCCEEDED", "FAILED"])
+            if deactivate_model_deployment_response.data.status == "SUCCEEDED":
+                print("Deactivating the model deployment succeeded, model_deployment_id = ", self.model_deployment_id)
+                self.active = False
+            else:
+                print("Deactivating the model deployment failed!!!")
+        except Exception as e:
+            print("Deactivating the model deployment failed!!!")
+            raise e
+
+    def activate_model_deployment(self):
+        # -- Activate a model deployment
+        print("------------------------------------")
+        print("*** Activating the model deployment ...")
+        try:
+            if not self.active:
+                activate_model_deployment_response = self.data_science_composite_client.activate_model_deployment_and_wait_for_state(model_deployment_id=self.model_deployment_id, wait_for_states=["SUCCEEDED", "FAILED"])
+                if activate_model_deployment_response.data.status == "SUCCEEDED":
+                    print("Activating the model deployment succeeded, model_deployment_id = ", self.model_deployment_id)
+                    self.active = True
+                else:
+                    print("Activating the model deployment failed!!!")
+        except Exception as e:
+            print("Activating the model deployment failed!!!")
+            raise e
+
+    def update_model_deployment(self, new_deployment_name, new_instance_shape_name, new_model_id, log_group_id=None, access_log_id=None, predict_log_id=None):
+        # -- Update a model deployment with changing display name, instance shape name, and model_id when the model deployment is active
+        print("------------------------------------")
+        print("*** Updating the model deployment ... ")
+        self.model_deployment_name = new_deployment_name
+        self.instance_configuration.instance_shape_name = new_instance_shape_name
+        self.model_id = new_model_id
+        try:
+            update_model_config_details = UpdateModelConfigurationDetails(bandwidth_mbps=self.bandwidth_mbps, instance_configuration=self.instance_configuration, model_id=self.model_id, scaling_policy=self.scaling_policy)
+            update_model_deployment_config_details = UpdateSingleModelDeploymentConfigurationDetails(deployment_type="SINGLE_MODEL", model_configuration_details=update_model_config_details)
+            update_model_deployment_details = UpdateModelDeploymentDetails(display_name=self.model_deployment_name, model_deployment_configuration_details=update_model_deployment_config_details)
+
+            # for logging, uncomment the line below
+            # update_model_deployment_details.category_log_details = self.create_logging(log_group_id, access_log_id, predict_log_id, is_create=False)
+
+            update_model_deployment_response = self.data_science_composite_client.update_model_deployment_and_wait_for_state(model_deployment_id=self.model_deployment_id, update_model_deployment_details=update_model_deployment_details, wait_for_states=["SUCCEEDED", "FAILED"])
+            if update_model_deployment_response.data.status == "SUCCEEDED":
+                print("Updating the model deployment succeeded, model_deployment_id = ", self.model_deployment_id)
+            else:
+                print("Updating the model deployment failed!!!")
+        except Exception as e:
+            print("Updating the model deployment failed!!!")
+            raise e
+
+    def delete_model_deployoment(self):
+        # -- Delete the model deployment
+        print("------------------------------------")
+        print("*** Deleting the model deployment ... ")
+        try:
+            delete_model_deployment_response = self.data_science_composite_client.delete_model_deployment_and_wait_for_state(model_deployment_id=self.model_deployment_id, wait_for_states=["SUCCEEDED", "FAILED"])
+            if delete_model_deployment_response.data.status == "SUCCEEDED":
+                print("Deleting the model deployment succeeded, model_deployment_id = ", self.model_deployment_id)
+                self.model_deployment_id = None
+                self.model_deployment_name = None
+                self.model_deployment_url = None
+            else:
+                print("Deleting the model deployment failed!!! ")
+        except Exception as e:
+            print("Deleting the model deployment failed!!!")
+            raise e
+
+    def create_logging(self, log_group_id, access_log_id, predict_log_id, is_create=True):
+        try:
+            access_log_details = LogDetails()
+            access_log_details.log_id = access_log_id
+            access_log_details.log_group_id = log_group_id
+
+            predict_log_details = LogDetails()
+            predict_log_details.log_id = predict_log_id
+            predict_log_details.log_group_id = log_group_id
+
+            if is_create:
+                category_log_details = CategoryLogDetails()
+                category_log_details.access = access_log_details
+                category_log_details.predict = predict_log_details
+                return category_log_details
+            else:
+                update_category_log_details = UpdateCategoryLogDetails()
+                update_category_log_details.access = access_log_details
+                update_category_log_details.predict = predict_log_details
+                return update_category_log_details
+        except Exception as e:
+            print("Creating logs failed!!!")
+            raise e
+
+
+if __name__ == "__main__":
+    """
+    All variables can be specified above by user.
+    A user can select the methods to run.
+    """
+    try:
+        md = ModelDeployment(config_file, compartment_id, project_id)  # initialize a model deployment
+        md.create_model_deployment(deployment_name, instance_shape_name, instance_count, bandwidth_mbps, model_id, log_group_id, access_log_id, predict_log_id)  # create a model deployment
+
+        md.get_model_deployment_info()  # get a model deployment
+        md.make_prediction(input_body)  # make a prediction using a newly created model deployment
+        md.deactivate_model_deployment()  # deactivate a model deployment
+        md.activate_model_deployment()  # activate a model deployment
+        md.update_model_deployment(new_deployment_name, new_instance_shape_name, new_model_id, log_group_id, access_log_id, predict_log_id)  # update a model deployment configurations
+        md.delete_model_deployoment()  # delete a model deployment
+    except Exception as e:
+        print("ERROR: ", e)
+        if md.model_deployment_id is not None:
+            print("*** Starting clean up ... ")
+            md.delete_model_deployoment()

--- a/src/oci/container_engine/container_engine_client.py
+++ b/src/oci/container_engine/container_engine_client.py
@@ -638,7 +638,7 @@ class ContainerEngineClient(object):
 
 
         :param str cluster_option_id: (required)
-            The id of the option set to retrieve. Only \"all\" is supported.
+            The id of the option set to retrieve. Use \"all\" get all options, or use a cluster ID to get options specific to the provided cluster.
 
         :param str compartment_id: (optional)
             The OCID of the compartment.
@@ -1622,6 +1622,92 @@ class ContainerEngineClient(object):
                 path_params=path_params,
                 header_params=header_params,
                 body=update_cluster_details)
+
+    def update_cluster_endpoint_config(self, cluster_id, update_cluster_endpoint_config_details, **kwargs):
+        """
+        Update the details of the cluster endpoint configuration.
+
+
+        :param str cluster_id: (required)
+            The OCID of the cluster.
+
+        :param oci.container_engine.models.UpdateClusterEndpointConfigDetails update_cluster_endpoint_config_details: (required)
+            The details of the cluster's endpoint to update.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If you need to contact
+            Oracle about a particular request, please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/containerengine/update_cluster_endpoint_config.py.html>`__ to see an example of how to use update_cluster_endpoint_config API.
+        """
+        resource_path = "/clusters/{clusterId}/actions/updateEndpointConfig"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "update_cluster_endpoint_config got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "clusterId": cluster_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_cluster_endpoint_config_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_cluster_endpoint_config_details)
 
     def update_node_pool(self, node_pool_id, update_node_pool_details, **kwargs):
         """

--- a/src/oci/container_engine/container_engine_client_composite_operations.py
+++ b/src/oci/container_engine/container_engine_client_composite_operations.py
@@ -232,6 +232,47 @@ class ContainerEngineClientCompositeOperations(object):
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
+    def update_cluster_endpoint_config_and_wait_for_state(self, cluster_id, update_cluster_endpoint_config_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.container_engine.ContainerEngineClient.update_cluster_endpoint_config` and waits for the :py:class:`~oci.container_engine.models.WorkRequest`
+        to enter the given state(s).
+
+        :param str cluster_id: (required)
+            The OCID of the cluster.
+
+        :param oci.container_engine.models.UpdateClusterEndpointConfigDetails update_cluster_endpoint_config_details: (required)
+            The details of the cluster's endpoint to update.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.container_engine.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.container_engine.ContainerEngineClient.update_cluster_endpoint_config`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_cluster_endpoint_config(cluster_id, update_cluster_endpoint_config_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def update_node_pool_and_wait_for_state(self, node_pool_id, update_node_pool_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.container_engine.ContainerEngineClient.update_node_pool` and waits for the :py:class:`~oci.container_engine.models.WorkRequest`

--- a/src/oci/container_engine/models/__init__.py
+++ b/src/oci/container_engine/models/__init__.py
@@ -8,11 +8,13 @@ from .add_on_options import AddOnOptions
 from .admission_controller_options import AdmissionControllerOptions
 from .cluster import Cluster
 from .cluster_create_options import ClusterCreateOptions
+from .cluster_endpoint_config import ClusterEndpointConfig
 from .cluster_endpoints import ClusterEndpoints
 from .cluster_metadata import ClusterMetadata
 from .cluster_options import ClusterOptions
 from .cluster_summary import ClusterSummary
 from .create_cluster_details import CreateClusterDetails
+from .create_cluster_endpoint_config_details import CreateClusterEndpointConfigDetails
 from .create_cluster_kubeconfig_content_details import CreateClusterKubeconfigContentDetails
 from .create_node_pool_details import CreateNodePoolDetails
 from .create_node_pool_node_config_details import CreateNodePoolNodeConfigDetails
@@ -32,6 +34,7 @@ from .node_source_option import NodeSourceOption
 from .node_source_via_image_details import NodeSourceViaImageDetails
 from .node_source_via_image_option import NodeSourceViaImageOption
 from .update_cluster_details import UpdateClusterDetails
+from .update_cluster_endpoint_config_details import UpdateClusterEndpointConfigDetails
 from .update_cluster_options_details import UpdateClusterOptionsDetails
 from .update_node_pool_details import UpdateNodePoolDetails
 from .update_node_pool_node_config_details import UpdateNodePoolNodeConfigDetails
@@ -48,11 +51,13 @@ container_engine_type_mapping = {
     "AdmissionControllerOptions": AdmissionControllerOptions,
     "Cluster": Cluster,
     "ClusterCreateOptions": ClusterCreateOptions,
+    "ClusterEndpointConfig": ClusterEndpointConfig,
     "ClusterEndpoints": ClusterEndpoints,
     "ClusterMetadata": ClusterMetadata,
     "ClusterOptions": ClusterOptions,
     "ClusterSummary": ClusterSummary,
     "CreateClusterDetails": CreateClusterDetails,
+    "CreateClusterEndpointConfigDetails": CreateClusterEndpointConfigDetails,
     "CreateClusterKubeconfigContentDetails": CreateClusterKubeconfigContentDetails,
     "CreateNodePoolDetails": CreateNodePoolDetails,
     "CreateNodePoolNodeConfigDetails": CreateNodePoolNodeConfigDetails,
@@ -72,6 +77,7 @@ container_engine_type_mapping = {
     "NodeSourceViaImageDetails": NodeSourceViaImageDetails,
     "NodeSourceViaImageOption": NodeSourceViaImageOption,
     "UpdateClusterDetails": UpdateClusterDetails,
+    "UpdateClusterEndpointConfigDetails": UpdateClusterEndpointConfigDetails,
     "UpdateClusterOptionsDetails": UpdateClusterOptionsDetails,
     "UpdateNodePoolDetails": UpdateNodePoolDetails,
     "UpdateNodePoolNodeConfigDetails": UpdateNodePoolNodeConfigDetails,

--- a/src/oci/container_engine/models/cluster.py
+++ b/src/oci/container_engine/models/cluster.py
@@ -54,6 +54,10 @@ class Cluster(object):
             The value to assign to the compartment_id property of this Cluster.
         :type compartment_id: str
 
+        :param endpoint_config:
+            The value to assign to the endpoint_config property of this Cluster.
+        :type endpoint_config: oci.container_engine.models.ClusterEndpointConfig
+
         :param vcn_id:
             The value to assign to the vcn_id property of this Cluster.
         :type vcn_id: str
@@ -97,6 +101,7 @@ class Cluster(object):
             'id': 'str',
             'name': 'str',
             'compartment_id': 'str',
+            'endpoint_config': 'ClusterEndpointConfig',
             'vcn_id': 'str',
             'kubernetes_version': 'str',
             'kms_key_id': 'str',
@@ -112,6 +117,7 @@ class Cluster(object):
             'id': 'id',
             'name': 'name',
             'compartment_id': 'compartmentId',
+            'endpoint_config': 'endpointConfig',
             'vcn_id': 'vcnId',
             'kubernetes_version': 'kubernetesVersion',
             'kms_key_id': 'kmsKeyId',
@@ -126,6 +132,7 @@ class Cluster(object):
         self._id = None
         self._name = None
         self._compartment_id = None
+        self._endpoint_config = None
         self._vcn_id = None
         self._kubernetes_version = None
         self._kms_key_id = None
@@ -207,6 +214,30 @@ class Cluster(object):
         :type: str
         """
         self._compartment_id = compartment_id
+
+    @property
+    def endpoint_config(self):
+        """
+        Gets the endpoint_config of this Cluster.
+        The network configuration for access to the Cluster control plane.
+
+
+        :return: The endpoint_config of this Cluster.
+        :rtype: oci.container_engine.models.ClusterEndpointConfig
+        """
+        return self._endpoint_config
+
+    @endpoint_config.setter
+    def endpoint_config(self, endpoint_config):
+        """
+        Sets the endpoint_config of this Cluster.
+        The network configuration for access to the Cluster control plane.
+
+
+        :param endpoint_config: The endpoint_config of this Cluster.
+        :type: oci.container_engine.models.ClusterEndpointConfig
+        """
+        self._endpoint_config = endpoint_config
 
     @property
     def vcn_id(self):

--- a/src/oci/container_engine/models/cluster_endpoint_config.py
+++ b/src/oci/container_engine/models/cluster_endpoint_config.py
@@ -1,0 +1,132 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ClusterEndpointConfig(object):
+    """
+    The properties that define the network configuration for the Cluster endpoint.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ClusterEndpointConfig object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param subnet_id:
+            The value to assign to the subnet_id property of this ClusterEndpointConfig.
+        :type subnet_id: str
+
+        :param nsg_ids:
+            The value to assign to the nsg_ids property of this ClusterEndpointConfig.
+        :type nsg_ids: list[str]
+
+        :param is_public_ip_enabled:
+            The value to assign to the is_public_ip_enabled property of this ClusterEndpointConfig.
+        :type is_public_ip_enabled: bool
+
+        """
+        self.swagger_types = {
+            'subnet_id': 'str',
+            'nsg_ids': 'list[str]',
+            'is_public_ip_enabled': 'bool'
+        }
+
+        self.attribute_map = {
+            'subnet_id': 'subnetId',
+            'nsg_ids': 'nsgIds',
+            'is_public_ip_enabled': 'isPublicIpEnabled'
+        }
+
+        self._subnet_id = None
+        self._nsg_ids = None
+        self._is_public_ip_enabled = None
+
+    @property
+    def subnet_id(self):
+        """
+        Gets the subnet_id of this ClusterEndpointConfig.
+        The OCID of the regional subnet in which to place the Cluster endpoint.
+
+
+        :return: The subnet_id of this ClusterEndpointConfig.
+        :rtype: str
+        """
+        return self._subnet_id
+
+    @subnet_id.setter
+    def subnet_id(self, subnet_id):
+        """
+        Sets the subnet_id of this ClusterEndpointConfig.
+        The OCID of the regional subnet in which to place the Cluster endpoint.
+
+
+        :param subnet_id: The subnet_id of this ClusterEndpointConfig.
+        :type: str
+        """
+        self._subnet_id = subnet_id
+
+    @property
+    def nsg_ids(self):
+        """
+        Gets the nsg_ids of this ClusterEndpointConfig.
+        A list of the OCIDs of the network security groups (NSGs) to apply to the cluster endpoint. For more information about NSGs, see :class:`NetworkSecurityGroup`.
+
+
+        :return: The nsg_ids of this ClusterEndpointConfig.
+        :rtype: list[str]
+        """
+        return self._nsg_ids
+
+    @nsg_ids.setter
+    def nsg_ids(self, nsg_ids):
+        """
+        Sets the nsg_ids of this ClusterEndpointConfig.
+        A list of the OCIDs of the network security groups (NSGs) to apply to the cluster endpoint. For more information about NSGs, see :class:`NetworkSecurityGroup`.
+
+
+        :param nsg_ids: The nsg_ids of this ClusterEndpointConfig.
+        :type: list[str]
+        """
+        self._nsg_ids = nsg_ids
+
+    @property
+    def is_public_ip_enabled(self):
+        """
+        Gets the is_public_ip_enabled of this ClusterEndpointConfig.
+        Whether the cluster should be assigned a public IP address. Defaults to false. If set to true on a private subnet, the cluster provisioning will fail.
+
+
+        :return: The is_public_ip_enabled of this ClusterEndpointConfig.
+        :rtype: bool
+        """
+        return self._is_public_ip_enabled
+
+    @is_public_ip_enabled.setter
+    def is_public_ip_enabled(self, is_public_ip_enabled):
+        """
+        Sets the is_public_ip_enabled of this ClusterEndpointConfig.
+        Whether the cluster should be assigned a public IP address. Defaults to false. If set to true on a private subnet, the cluster provisioning will fail.
+
+
+        :param is_public_ip_enabled: The is_public_ip_enabled of this ClusterEndpointConfig.
+        :type: bool
+        """
+        self._is_public_ip_enabled = is_public_ip_enabled
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/container_engine/models/cluster_endpoints.py
+++ b/src/oci/container_engine/models/cluster_endpoints.py
@@ -22,22 +22,36 @@ class ClusterEndpoints(object):
             The value to assign to the kubernetes property of this ClusterEndpoints.
         :type kubernetes: str
 
+        :param public_endpoint:
+            The value to assign to the public_endpoint property of this ClusterEndpoints.
+        :type public_endpoint: str
+
+        :param private_endpoint:
+            The value to assign to the private_endpoint property of this ClusterEndpoints.
+        :type private_endpoint: str
+
         """
         self.swagger_types = {
-            'kubernetes': 'str'
+            'kubernetes': 'str',
+            'public_endpoint': 'str',
+            'private_endpoint': 'str'
         }
 
         self.attribute_map = {
-            'kubernetes': 'kubernetes'
+            'kubernetes': 'kubernetes',
+            'public_endpoint': 'publicEndpoint',
+            'private_endpoint': 'privateEndpoint'
         }
 
         self._kubernetes = None
+        self._public_endpoint = None
+        self._private_endpoint = None
 
     @property
     def kubernetes(self):
         """
         Gets the kubernetes of this ClusterEndpoints.
-        The Kubernetes API server endpoint.
+        The non-native networking Kubernetes API server endpoint.
 
 
         :return: The kubernetes of this ClusterEndpoints.
@@ -49,13 +63,61 @@ class ClusterEndpoints(object):
     def kubernetes(self, kubernetes):
         """
         Sets the kubernetes of this ClusterEndpoints.
-        The Kubernetes API server endpoint.
+        The non-native networking Kubernetes API server endpoint.
 
 
         :param kubernetes: The kubernetes of this ClusterEndpoints.
         :type: str
         """
         self._kubernetes = kubernetes
+
+    @property
+    def public_endpoint(self):
+        """
+        Gets the public_endpoint of this ClusterEndpoints.
+        The public native networking Kubernetes API server endpoint, if one was requested.
+
+
+        :return: The public_endpoint of this ClusterEndpoints.
+        :rtype: str
+        """
+        return self._public_endpoint
+
+    @public_endpoint.setter
+    def public_endpoint(self, public_endpoint):
+        """
+        Sets the public_endpoint of this ClusterEndpoints.
+        The public native networking Kubernetes API server endpoint, if one was requested.
+
+
+        :param public_endpoint: The public_endpoint of this ClusterEndpoints.
+        :type: str
+        """
+        self._public_endpoint = public_endpoint
+
+    @property
+    def private_endpoint(self):
+        """
+        Gets the private_endpoint of this ClusterEndpoints.
+        The private native networking Kubernetes API server endpoint.
+
+
+        :return: The private_endpoint of this ClusterEndpoints.
+        :rtype: str
+        """
+        return self._private_endpoint
+
+    @private_endpoint.setter
+    def private_endpoint(self, private_endpoint):
+        """
+        Sets the private_endpoint of this ClusterEndpoints.
+        The private native networking Kubernetes API server endpoint.
+
+
+        :param private_endpoint: The private_endpoint of this ClusterEndpoints.
+        :type: str
+        """
+        self._private_endpoint = private_endpoint
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/container_engine/models/cluster_summary.py
+++ b/src/oci/container_engine/models/cluster_summary.py
@@ -54,6 +54,10 @@ class ClusterSummary(object):
             The value to assign to the compartment_id property of this ClusterSummary.
         :type compartment_id: str
 
+        :param endpoint_config:
+            The value to assign to the endpoint_config property of this ClusterSummary.
+        :type endpoint_config: oci.container_engine.models.ClusterEndpointConfig
+
         :param vcn_id:
             The value to assign to the vcn_id property of this ClusterSummary.
         :type vcn_id: str
@@ -93,6 +97,7 @@ class ClusterSummary(object):
             'id': 'str',
             'name': 'str',
             'compartment_id': 'str',
+            'endpoint_config': 'ClusterEndpointConfig',
             'vcn_id': 'str',
             'kubernetes_version': 'str',
             'options': 'ClusterCreateOptions',
@@ -107,6 +112,7 @@ class ClusterSummary(object):
             'id': 'id',
             'name': 'name',
             'compartment_id': 'compartmentId',
+            'endpoint_config': 'endpointConfig',
             'vcn_id': 'vcnId',
             'kubernetes_version': 'kubernetesVersion',
             'options': 'options',
@@ -120,6 +126,7 @@ class ClusterSummary(object):
         self._id = None
         self._name = None
         self._compartment_id = None
+        self._endpoint_config = None
         self._vcn_id = None
         self._kubernetes_version = None
         self._options = None
@@ -200,6 +207,30 @@ class ClusterSummary(object):
         :type: str
         """
         self._compartment_id = compartment_id
+
+    @property
+    def endpoint_config(self):
+        """
+        Gets the endpoint_config of this ClusterSummary.
+        The network configuration for access to the Cluster control plane.
+
+
+        :return: The endpoint_config of this ClusterSummary.
+        :rtype: oci.container_engine.models.ClusterEndpointConfig
+        """
+        return self._endpoint_config
+
+    @endpoint_config.setter
+    def endpoint_config(self, endpoint_config):
+        """
+        Sets the endpoint_config of this ClusterSummary.
+        The network configuration for access to the Cluster control plane.
+
+
+        :param endpoint_config: The endpoint_config of this ClusterSummary.
+        :type: oci.container_engine.models.ClusterEndpointConfig
+        """
+        self._endpoint_config = endpoint_config
 
     @property
     def vcn_id(self):

--- a/src/oci/container_engine/models/create_cluster_details.py
+++ b/src/oci/container_engine/models/create_cluster_details.py
@@ -26,6 +26,10 @@ class CreateClusterDetails(object):
             The value to assign to the compartment_id property of this CreateClusterDetails.
         :type compartment_id: str
 
+        :param endpoint_config:
+            The value to assign to the endpoint_config property of this CreateClusterDetails.
+        :type endpoint_config: oci.container_engine.models.CreateClusterEndpointConfigDetails
+
         :param vcn_id:
             The value to assign to the vcn_id property of this CreateClusterDetails.
         :type vcn_id: str
@@ -46,6 +50,7 @@ class CreateClusterDetails(object):
         self.swagger_types = {
             'name': 'str',
             'compartment_id': 'str',
+            'endpoint_config': 'CreateClusterEndpointConfigDetails',
             'vcn_id': 'str',
             'kubernetes_version': 'str',
             'kms_key_id': 'str',
@@ -55,6 +60,7 @@ class CreateClusterDetails(object):
         self.attribute_map = {
             'name': 'name',
             'compartment_id': 'compartmentId',
+            'endpoint_config': 'endpointConfig',
             'vcn_id': 'vcnId',
             'kubernetes_version': 'kubernetesVersion',
             'kms_key_id': 'kmsKeyId',
@@ -63,6 +69,7 @@ class CreateClusterDetails(object):
 
         self._name = None
         self._compartment_id = None
+        self._endpoint_config = None
         self._vcn_id = None
         self._kubernetes_version = None
         self._kms_key_id = None
@@ -115,6 +122,30 @@ class CreateClusterDetails(object):
         :type: str
         """
         self._compartment_id = compartment_id
+
+    @property
+    def endpoint_config(self):
+        """
+        Gets the endpoint_config of this CreateClusterDetails.
+        The network configuration for access to the Cluster control plane.
+
+
+        :return: The endpoint_config of this CreateClusterDetails.
+        :rtype: oci.container_engine.models.CreateClusterEndpointConfigDetails
+        """
+        return self._endpoint_config
+
+    @endpoint_config.setter
+    def endpoint_config(self, endpoint_config):
+        """
+        Sets the endpoint_config of this CreateClusterDetails.
+        The network configuration for access to the Cluster control plane.
+
+
+        :param endpoint_config: The endpoint_config of this CreateClusterDetails.
+        :type: oci.container_engine.models.CreateClusterEndpointConfigDetails
+        """
+        self._endpoint_config = endpoint_config
 
     @property
     def vcn_id(self):

--- a/src/oci/container_engine/models/create_cluster_endpoint_config_details.py
+++ b/src/oci/container_engine/models/create_cluster_endpoint_config_details.py
@@ -1,0 +1,132 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateClusterEndpointConfigDetails(object):
+    """
+    The properties that define the network configuration for the Cluster endpoint.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateClusterEndpointConfigDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param subnet_id:
+            The value to assign to the subnet_id property of this CreateClusterEndpointConfigDetails.
+        :type subnet_id: str
+
+        :param nsg_ids:
+            The value to assign to the nsg_ids property of this CreateClusterEndpointConfigDetails.
+        :type nsg_ids: list[str]
+
+        :param is_public_ip_enabled:
+            The value to assign to the is_public_ip_enabled property of this CreateClusterEndpointConfigDetails.
+        :type is_public_ip_enabled: bool
+
+        """
+        self.swagger_types = {
+            'subnet_id': 'str',
+            'nsg_ids': 'list[str]',
+            'is_public_ip_enabled': 'bool'
+        }
+
+        self.attribute_map = {
+            'subnet_id': 'subnetId',
+            'nsg_ids': 'nsgIds',
+            'is_public_ip_enabled': 'isPublicIpEnabled'
+        }
+
+        self._subnet_id = None
+        self._nsg_ids = None
+        self._is_public_ip_enabled = None
+
+    @property
+    def subnet_id(self):
+        """
+        Gets the subnet_id of this CreateClusterEndpointConfigDetails.
+        The OCID of the regional subnet in which to place the Cluster endpoint.
+
+
+        :return: The subnet_id of this CreateClusterEndpointConfigDetails.
+        :rtype: str
+        """
+        return self._subnet_id
+
+    @subnet_id.setter
+    def subnet_id(self, subnet_id):
+        """
+        Sets the subnet_id of this CreateClusterEndpointConfigDetails.
+        The OCID of the regional subnet in which to place the Cluster endpoint.
+
+
+        :param subnet_id: The subnet_id of this CreateClusterEndpointConfigDetails.
+        :type: str
+        """
+        self._subnet_id = subnet_id
+
+    @property
+    def nsg_ids(self):
+        """
+        Gets the nsg_ids of this CreateClusterEndpointConfigDetails.
+        A list of the OCIDs of the network security groups (NSGs) to apply to the cluster endpoint. For more information about NSGs, see :class:`NetworkSecurityGroup`.
+
+
+        :return: The nsg_ids of this CreateClusterEndpointConfigDetails.
+        :rtype: list[str]
+        """
+        return self._nsg_ids
+
+    @nsg_ids.setter
+    def nsg_ids(self, nsg_ids):
+        """
+        Sets the nsg_ids of this CreateClusterEndpointConfigDetails.
+        A list of the OCIDs of the network security groups (NSGs) to apply to the cluster endpoint. For more information about NSGs, see :class:`NetworkSecurityGroup`.
+
+
+        :param nsg_ids: The nsg_ids of this CreateClusterEndpointConfigDetails.
+        :type: list[str]
+        """
+        self._nsg_ids = nsg_ids
+
+    @property
+    def is_public_ip_enabled(self):
+        """
+        Gets the is_public_ip_enabled of this CreateClusterEndpointConfigDetails.
+        Whether the cluster should be assigned a public IP address. Defaults to false. If set to true on a private subnet, the cluster provisioning will fail.
+
+
+        :return: The is_public_ip_enabled of this CreateClusterEndpointConfigDetails.
+        :rtype: bool
+        """
+        return self._is_public_ip_enabled
+
+    @is_public_ip_enabled.setter
+    def is_public_ip_enabled(self, is_public_ip_enabled):
+        """
+        Sets the is_public_ip_enabled of this CreateClusterEndpointConfigDetails.
+        Whether the cluster should be assigned a public IP address. Defaults to false. If set to true on a private subnet, the cluster provisioning will fail.
+
+
+        :param is_public_ip_enabled: The is_public_ip_enabled of this CreateClusterEndpointConfigDetails.
+        :type: bool
+        """
+        self._is_public_ip_enabled = is_public_ip_enabled
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/container_engine/models/create_cluster_kubeconfig_content_details.py
+++ b/src/oci/container_engine/models/create_cluster_kubeconfig_content_details.py
@@ -13,6 +13,18 @@ class CreateClusterKubeconfigContentDetails(object):
     The properties that define a request to create a cluster kubeconfig.
     """
 
+    #: A constant which can be used with the endpoint property of a CreateClusterKubeconfigContentDetails.
+    #: This constant has a value of "LEGACY_KUBERNETES"
+    ENDPOINT_LEGACY_KUBERNETES = "LEGACY_KUBERNETES"
+
+    #: A constant which can be used with the endpoint property of a CreateClusterKubeconfigContentDetails.
+    #: This constant has a value of "PUBLIC_ENDPOINT"
+    ENDPOINT_PUBLIC_ENDPOINT = "PUBLIC_ENDPOINT"
+
+    #: A constant which can be used with the endpoint property of a CreateClusterKubeconfigContentDetails.
+    #: This constant has a value of "PRIVATE_ENDPOINT"
+    ENDPOINT_PRIVATE_ENDPOINT = "PRIVATE_ENDPOINT"
+
     def __init__(self, **kwargs):
         """
         Initializes a new CreateClusterKubeconfigContentDetails object with values from keyword arguments.
@@ -26,19 +38,27 @@ class CreateClusterKubeconfigContentDetails(object):
             The value to assign to the expiration property of this CreateClusterKubeconfigContentDetails.
         :type expiration: int
 
+        :param endpoint:
+            The value to assign to the endpoint property of this CreateClusterKubeconfigContentDetails.
+            Allowed values for this property are: "LEGACY_KUBERNETES", "PUBLIC_ENDPOINT", "PRIVATE_ENDPOINT"
+        :type endpoint: str
+
         """
         self.swagger_types = {
             'token_version': 'str',
-            'expiration': 'int'
+            'expiration': 'int',
+            'endpoint': 'str'
         }
 
         self.attribute_map = {
             'token_version': 'tokenVersion',
-            'expiration': 'expiration'
+            'expiration': 'expiration',
+            'endpoint': 'endpoint'
         }
 
         self._token_version = None
         self._expiration = None
+        self._endpoint = None
 
     @property
     def token_version(self):
@@ -87,6 +107,38 @@ class CreateClusterKubeconfigContentDetails(object):
         :type: int
         """
         self._expiration = expiration
+
+    @property
+    def endpoint(self):
+        """
+        Gets the endpoint of this CreateClusterKubeconfigContentDetails.
+        The endpoint to target. A cluster may have multiple endpoints exposed but the kubeconfig can only target one at a time.
+
+        Allowed values for this property are: "LEGACY_KUBERNETES", "PUBLIC_ENDPOINT", "PRIVATE_ENDPOINT"
+
+
+        :return: The endpoint of this CreateClusterKubeconfigContentDetails.
+        :rtype: str
+        """
+        return self._endpoint
+
+    @endpoint.setter
+    def endpoint(self, endpoint):
+        """
+        Sets the endpoint of this CreateClusterKubeconfigContentDetails.
+        The endpoint to target. A cluster may have multiple endpoints exposed but the kubeconfig can only target one at a time.
+
+
+        :param endpoint: The endpoint of this CreateClusterKubeconfigContentDetails.
+        :type: str
+        """
+        allowed_values = ["LEGACY_KUBERNETES", "PUBLIC_ENDPOINT", "PRIVATE_ENDPOINT"]
+        if not value_allowed_none_or_none_sentinel(endpoint, allowed_values):
+            raise ValueError(
+                "Invalid value for `endpoint`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._endpoint = endpoint
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/container_engine/models/update_cluster_endpoint_config_details.py
+++ b/src/oci/container_engine/models/update_cluster_endpoint_config_details.py
@@ -1,0 +1,101 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateClusterEndpointConfigDetails(object):
+    """
+    The properties that define a request to update a cluster endpoint config.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateClusterEndpointConfigDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param nsg_ids:
+            The value to assign to the nsg_ids property of this UpdateClusterEndpointConfigDetails.
+        :type nsg_ids: list[str]
+
+        :param is_public_ip_enabled:
+            The value to assign to the is_public_ip_enabled property of this UpdateClusterEndpointConfigDetails.
+        :type is_public_ip_enabled: bool
+
+        """
+        self.swagger_types = {
+            'nsg_ids': 'list[str]',
+            'is_public_ip_enabled': 'bool'
+        }
+
+        self.attribute_map = {
+            'nsg_ids': 'nsgIds',
+            'is_public_ip_enabled': 'isPublicIpEnabled'
+        }
+
+        self._nsg_ids = None
+        self._is_public_ip_enabled = None
+
+    @property
+    def nsg_ids(self):
+        """
+        Gets the nsg_ids of this UpdateClusterEndpointConfigDetails.
+        A list of the OCIDs of the network security groups (NSGs) to apply to the cluster endpoint. For more information about NSGs, see :class:`NetworkSecurityGroup`.
+
+
+        :return: The nsg_ids of this UpdateClusterEndpointConfigDetails.
+        :rtype: list[str]
+        """
+        return self._nsg_ids
+
+    @nsg_ids.setter
+    def nsg_ids(self, nsg_ids):
+        """
+        Sets the nsg_ids of this UpdateClusterEndpointConfigDetails.
+        A list of the OCIDs of the network security groups (NSGs) to apply to the cluster endpoint. For more information about NSGs, see :class:`NetworkSecurityGroup`.
+
+
+        :param nsg_ids: The nsg_ids of this UpdateClusterEndpointConfigDetails.
+        :type: list[str]
+        """
+        self._nsg_ids = nsg_ids
+
+    @property
+    def is_public_ip_enabled(self):
+        """
+        Gets the is_public_ip_enabled of this UpdateClusterEndpointConfigDetails.
+        Whether the cluster should be assigned a public IP address. Defaults to false. If set to true on a private subnet, the cluster update will fail.
+
+
+        :return: The is_public_ip_enabled of this UpdateClusterEndpointConfigDetails.
+        :rtype: bool
+        """
+        return self._is_public_ip_enabled
+
+    @is_public_ip_enabled.setter
+    def is_public_ip_enabled(self, is_public_ip_enabled):
+        """
+        Sets the is_public_ip_enabled of this UpdateClusterEndpointConfigDetails.
+        Whether the cluster should be assigned a public IP address. Defaults to false. If set to true on a private subnet, the cluster update will fail.
+
+
+        :param is_public_ip_enabled: The is_public_ip_enabled of this UpdateClusterEndpointConfigDetails.
+        :type: bool
+        """
+        self._is_public_ip_enabled = is_public_ip_enabled
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/container_engine/models/work_request_resource.py
+++ b/src/oci/container_engine/models/work_request_resource.py
@@ -37,6 +37,18 @@ class WorkRequestResource(object):
     #: This constant has a value of "FAILED"
     ACTION_TYPE_FAILED = "FAILED"
 
+    #: A constant which can be used with the action_type property of a WorkRequestResource.
+    #: This constant has a value of "CANCELED_CREATE"
+    ACTION_TYPE_CANCELED_CREATE = "CANCELED_CREATE"
+
+    #: A constant which can be used with the action_type property of a WorkRequestResource.
+    #: This constant has a value of "CANCELED_UPDATE"
+    ACTION_TYPE_CANCELED_UPDATE = "CANCELED_UPDATE"
+
+    #: A constant which can be used with the action_type property of a WorkRequestResource.
+    #: This constant has a value of "CANCELED_DELETE"
+    ACTION_TYPE_CANCELED_DELETE = "CANCELED_DELETE"
+
     def __init__(self, **kwargs):
         """
         Initializes a new WorkRequestResource object with values from keyword arguments.
@@ -44,7 +56,7 @@ class WorkRequestResource(object):
 
         :param action_type:
             The value to assign to the action_type property of this WorkRequestResource.
-            Allowed values for this property are: "CREATED", "UPDATED", "DELETED", "RELATED", "IN_PROGRESS", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "CREATED", "UPDATED", "DELETED", "RELATED", "IN_PROGRESS", "FAILED", "CANCELED_CREATE", "CANCELED_UPDATE", "CANCELED_DELETE", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type action_type: str
 
@@ -86,7 +98,7 @@ class WorkRequestResource(object):
         Gets the action_type of this WorkRequestResource.
         The way in which this resource was affected by the work tracked by the work request.
 
-        Allowed values for this property are: "CREATED", "UPDATED", "DELETED", "RELATED", "IN_PROGRESS", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "CREATED", "UPDATED", "DELETED", "RELATED", "IN_PROGRESS", "FAILED", "CANCELED_CREATE", "CANCELED_UPDATE", "CANCELED_DELETE", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -105,7 +117,7 @@ class WorkRequestResource(object):
         :param action_type: The action_type of this WorkRequestResource.
         :type: str
         """
-        allowed_values = ["CREATED", "UPDATED", "DELETED", "RELATED", "IN_PROGRESS", "FAILED"]
+        allowed_values = ["CREATED", "UPDATED", "DELETED", "RELATED", "IN_PROGRESS", "FAILED", "CANCELED_CREATE", "CANCELED_UPDATE", "CANCELED_DELETE"]
         if not value_allowed_none_or_none_sentinel(action_type, allowed_values):
             action_type = 'UNKNOWN_ENUM_VALUE'
         self._action_type = action_type

--- a/src/oci/data_science/data_science_client.py
+++ b/src/oci/data_science/data_science_client.py
@@ -93,17 +93,17 @@ class DataScienceClient(object):
         :param str model_id: (required)
             The `OCID`__ of the model.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call
             for a resource, set the `if-match` parameter to the value of the
             etag from a previous GET or POST response for that resource.
-            The resource will be updated or deleted only if the `etag` you
+            The resource is updated or deleted only if the `etag` you
             provide matches the resource's current `etag` value.
 
         :param str opc_request_id: (optional)
-            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+            Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -171,6 +171,90 @@ class DataScienceClient(object):
                 header_params=header_params,
                 response_type="Model")
 
+    def activate_model_deployment(self, model_deployment_id, **kwargs):
+        """
+        Activates the model deployment.
+
+
+        :param str model_deployment_id: (required)
+            The `OCID`__ of the model deployment.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call
+            for a resource, set the `if-match` parameter to the value of the
+            etag from a previous GET or POST response for that resource.
+            The resource is updated or deleted only if the `etag` you
+            provide matches the resource's current `etag` value.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/datascience/activate_model_deployment.py.html>`__ to see an example of how to use activate_model_deployment API.
+        """
+        resource_path = "/modelDeployments/{modelDeploymentId}/actions/activate"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "activate_model_deployment got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "modelDeploymentId": model_deployment_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
     def activate_notebook_session(self, notebook_session_id, **kwargs):
         """
         Activates the notebook session.
@@ -179,17 +263,17 @@ class DataScienceClient(object):
         :param str notebook_session_id: (required)
             The `OCID`__ of the notebook session.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call
             for a resource, set the `if-match` parameter to the value of the
             etag from a previous GET or POST response for that resource.
-            The resource will be updated or deleted only if the `etag` you
+            The resource is updated or deleted only if the `etag` you
             provide matches the resource's current `etag` value.
 
         :param str opc_request_id: (optional)
-            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+            Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -263,17 +347,17 @@ class DataScienceClient(object):
         :param str work_request_id: (required)
             The `OCID`__ of the work request.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call
             for a resource, set the `if-match` parameter to the value of the
             etag from a previous GET or POST response for that resource.
-            The resource will be updated or deleted only if the `etag` you
+            The resource is updated or deleted only if the `etag` you
             provide matches the resource's current `etag` value.
 
         :param str opc_request_id: (optional)
-            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+            Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -347,7 +431,7 @@ class DataScienceClient(object):
         :param str model_id: (required)
             The `OCID`__ of the model.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param oci.data_science.models.ChangeModelCompartmentDetails change_model_compartment_details: (required)
             Details for changing the compartment of a model.
@@ -356,11 +440,11 @@ class DataScienceClient(object):
             For optimistic concurrency control. In the PUT or DELETE call
             for a resource, set the `if-match` parameter to the value of the
             etag from a previous GET or POST response for that resource.
-            The resource will be updated or deleted only if the `etag` you
+            The resource is updated or deleted only if the `etag` you
             provide matches the resource's current `etag` value.
 
         :param str opc_request_id: (optional)
-            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+            Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
 
         :param str opc_retry_token: (optional)
             A token that uniquely identifies a request so it can be retried in case of a timeout or server error without risk of executing that same action again. Retry tokens expire after 24 hours, but can be invalidated before then due to conflicting operations. For example, if a resource has been deleted and purged from the system, then a retry of the original creation request might be rejected.
@@ -435,6 +519,102 @@ class DataScienceClient(object):
                 header_params=header_params,
                 body=change_model_compartment_details)
 
+    def change_model_deployment_compartment(self, model_deployment_id, change_model_deployment_compartment_details, **kwargs):
+        """
+        Moves a model deployment into a different compartment. When provided, If-Match is checked against ETag values of the resource.
+
+
+        :param str model_deployment_id: (required)
+            The `OCID`__ of the model deployment.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+        :param oci.data_science.models.ChangeModelDeploymentCompartmentDetails change_model_deployment_compartment_details: (required)
+            Details for changing the compartment of a model deployment.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call
+            for a resource, set the `if-match` parameter to the value of the
+            etag from a previous GET or POST response for that resource.
+            The resource is updated or deleted only if the `etag` you
+            provide matches the resource's current `etag` value.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or server error without risk of executing that same action again. Retry tokens expire after 24 hours, but can be invalidated before then due to conflicting operations. For example, if a resource has been deleted and purged from the system, then a retry of the original creation request might be rejected.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/datascience/change_model_deployment_compartment.py.html>`__ to see an example of how to use change_model_deployment_compartment API.
+        """
+        resource_path = "/modelDeployments/{modelDeploymentId}/actions/changeCompartment"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "change_model_deployment_compartment got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "modelDeploymentId": model_deployment_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_model_deployment_compartment_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_model_deployment_compartment_details)
+
     def change_notebook_session_compartment(self, notebook_session_id, change_notebook_session_compartment_details, **kwargs):
         """
         Moves a notebook session resource into a different compartment.
@@ -443,7 +623,7 @@ class DataScienceClient(object):
         :param str notebook_session_id: (required)
             The `OCID`__ of the notebook session.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param oci.data_science.models.ChangeNotebookSessionCompartmentDetails change_notebook_session_compartment_details: (required)
             Details for changing the compartment of a notebook session.
@@ -452,11 +632,11 @@ class DataScienceClient(object):
             For optimistic concurrency control. In the PUT or DELETE call
             for a resource, set the `if-match` parameter to the value of the
             etag from a previous GET or POST response for that resource.
-            The resource will be updated or deleted only if the `etag` you
+            The resource is updated or deleted only if the `etag` you
             provide matches the resource's current `etag` value.
 
         :param str opc_request_id: (optional)
-            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+            Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
 
         :param str opc_retry_token: (optional)
             A token that uniquely identifies a request so it can be retried in case of a timeout or server error without risk of executing that same action again. Retry tokens expire after 24 hours, but can be invalidated before then due to conflicting operations. For example, if a resource has been deleted and purged from the system, then a retry of the original creation request might be rejected.
@@ -539,7 +719,7 @@ class DataScienceClient(object):
         :param str project_id: (required)
             The `OCID`__ of the project.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param oci.data_science.models.ChangeProjectCompartmentDetails change_project_compartment_details: (required)
             Details for changing the compartment of a project.
@@ -548,11 +728,11 @@ class DataScienceClient(object):
             For optimistic concurrency control. In the PUT or DELETE call
             for a resource, set the `if-match` parameter to the value of the
             etag from a previous GET or POST response for that resource.
-            The resource will be updated or deleted only if the `etag` you
+            The resource is updated or deleted only if the `etag` you
             provide matches the resource's current `etag` value.
 
         :param str opc_request_id: (optional)
-            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+            Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
 
         :param str opc_retry_token: (optional)
             A token that uniquely identifies a request so it can be retried in case of a timeout or server error without risk of executing that same action again. Retry tokens expire after 24 hours, but can be invalidated before then due to conflicting operations. For example, if a resource has been deleted and purged from the system, then a retry of the original creation request might be rejected.
@@ -636,7 +816,7 @@ class DataScienceClient(object):
             Details for creating a new model.
 
         :param str opc_request_id: (optional)
-            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+            Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
 
         :param str opc_retry_token: (optional)
             A token that uniquely identifies a request so it can be retried in case of a timeout or server error without risk of executing that same action again. Retry tokens expire after 24 hours, but can be invalidated before then due to conflicting operations. For example, if a resource has been deleted and purged from the system, then a retry of the original creation request might be rejected.
@@ -707,7 +887,7 @@ class DataScienceClient(object):
         :param str model_id: (required)
             The `OCID`__ of the model.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param stream model_artifact: (required)
             The model artifact to upload.
@@ -716,7 +896,7 @@ class DataScienceClient(object):
             The content length of the body.
 
         :param str opc_request_id: (optional)
-            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+            Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
 
         :param str opc_retry_token: (optional)
             A token that uniquely identifies a request so it can be retried in case of a timeout or server error without risk of executing that same action again. Retry tokens expire after 24 hours, but can be invalidated before then due to conflicting operations. For example, if a resource has been deleted and purged from the system, then a retry of the original creation request might be rejected.
@@ -792,9 +972,6 @@ class DataScienceClient(object):
         if kwargs.get('retry_strategy'):
             retry_strategy = kwargs.get('retry_strategy')
 
-        # Disable the retry_strategy to work around data corruption issue temporarily
-        if retry_strategy:
-            retry_strategy = None
         if retry_strategy:
             if not isinstance(retry_strategy, retry.NoneRetryStrategy):
                 self.base_client.add_opc_retry_token_if_needed(header_params)
@@ -815,6 +992,78 @@ class DataScienceClient(object):
                 body=model_artifact,
                 enforce_content_headers=False)
 
+    def create_model_deployment(self, create_model_deployment_details, **kwargs):
+        """
+        Creates a new model deployment.
+
+
+        :param oci.data_science.models.CreateModelDeploymentDetails create_model_deployment_details: (required)
+            Details for creating a new model deployment.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or server error without risk of executing that same action again. Retry tokens expire after 24 hours, but can be invalidated before then due to conflicting operations. For example, if a resource has been deleted and purged from the system, then a retry of the original creation request might be rejected.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.data_science.models.ModelDeployment`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/datascience/create_model_deployment.py.html>`__ to see an example of how to use create_model_deployment API.
+        """
+        resource_path = "/modelDeployments"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "create_model_deployment got unknown kwargs: {!r}".format(extra_kwargs))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_model_deployment_details,
+                response_type="ModelDeployment")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_model_deployment_details,
+                response_type="ModelDeployment")
+
     def create_model_provenance(self, model_id, create_model_provenance_details, **kwargs):
         """
         Creates provenance information for the specified model.
@@ -823,13 +1072,13 @@ class DataScienceClient(object):
         :param str model_id: (required)
             The `OCID`__ of the model.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param oci.data_science.models.CreateModelProvenanceDetails create_model_provenance_details: (required)
             Provenance information for specified model.
 
         :param str opc_request_id: (optional)
-            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+            Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
 
         :param str opc_retry_token: (optional)
             A token that uniquely identifies a request so it can be retried in case of a timeout or server error without risk of executing that same action again. Retry tokens expire after 24 hours, but can be invalidated before then due to conflicting operations. For example, if a resource has been deleted and purged from the system, then a retry of the original creation request might be rejected.
@@ -913,7 +1162,7 @@ class DataScienceClient(object):
             Details for creating a new notebook session.
 
         :param str opc_request_id: (optional)
-            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+            Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
 
         :param str opc_retry_token: (optional)
             A token that uniquely identifies a request so it can be retried in case of a timeout or server error without risk of executing that same action again. Retry tokens expire after 24 hours, but can be invalidated before then due to conflicting operations. For example, if a resource has been deleted and purged from the system, then a retry of the original creation request might be rejected.
@@ -985,7 +1234,7 @@ class DataScienceClient(object):
             Details for creating a new project.
 
         :param str opc_request_id: (optional)
-            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+            Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
 
         :param str opc_retry_token: (optional)
             A token that uniquely identifies a request so it can be retried in case of a timeout or server error without risk of executing that same action again. Retry tokens expire after 24 hours, but can be invalidated before then due to conflicting operations. For example, if a resource has been deleted and purged from the system, then a retry of the original creation request might be rejected.
@@ -1056,17 +1305,17 @@ class DataScienceClient(object):
         :param str model_id: (required)
             The `OCID`__ of the model.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call
             for a resource, set the `if-match` parameter to the value of the
             etag from a previous GET or POST response for that resource.
-            The resource will be updated or deleted only if the `etag` you
+            The resource is updated or deleted only if the `etag` you
             provide matches the resource's current `etag` value.
 
         :param str opc_request_id: (optional)
-            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+            Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -1134,6 +1383,90 @@ class DataScienceClient(object):
                 header_params=header_params,
                 response_type="Model")
 
+    def deactivate_model_deployment(self, model_deployment_id, **kwargs):
+        """
+        Deactivates the model deployment.
+
+
+        :param str model_deployment_id: (required)
+            The `OCID`__ of the model deployment.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call
+            for a resource, set the `if-match` parameter to the value of the
+            etag from a previous GET or POST response for that resource.
+            The resource is updated or deleted only if the `etag` you
+            provide matches the resource's current `etag` value.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/datascience/deactivate_model_deployment.py.html>`__ to see an example of how to use deactivate_model_deployment API.
+        """
+        resource_path = "/modelDeployments/{modelDeploymentId}/actions/deactivate"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "deactivate_model_deployment got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "modelDeploymentId": model_deployment_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
     def deactivate_notebook_session(self, notebook_session_id, **kwargs):
         """
         Deactivates the notebook session.
@@ -1142,17 +1475,17 @@ class DataScienceClient(object):
         :param str notebook_session_id: (required)
             The `OCID`__ of the notebook session.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call
             for a resource, set the `if-match` parameter to the value of the
             etag from a previous GET or POST response for that resource.
-            The resource will be updated or deleted only if the `etag` you
+            The resource is updated or deleted only if the `etag` you
             provide matches the resource's current `etag` value.
 
         :param str opc_request_id: (optional)
-            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+            Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -1226,17 +1559,17 @@ class DataScienceClient(object):
         :param str model_id: (required)
             The `OCID`__ of the model.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call
             for a resource, set the `if-match` parameter to the value of the
             etag from a previous GET or POST response for that resource.
-            The resource will be updated or deleted only if the `etag` you
+            The resource is updated or deleted only if the `etag` you
             provide matches the resource's current `etag` value.
 
         :param str opc_request_id: (optional)
-            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+            Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -1302,25 +1635,109 @@ class DataScienceClient(object):
                 path_params=path_params,
                 header_params=header_params)
 
-    def delete_notebook_session(self, notebook_session_id, **kwargs):
+    def delete_model_deployment(self, model_deployment_id, **kwargs):
         """
-        Deletes the specified notebook session. Any unsaved work in this notebook session will be lost.
+        Deletes the specified model deployment. Any unsaved work in this model deployment is lost.
 
 
-        :param str notebook_session_id: (required)
-            The `OCID`__ of the notebook session.
+        :param str model_deployment_id: (required)
+            The `OCID`__ of the model deployment.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call
             for a resource, set the `if-match` parameter to the value of the
             etag from a previous GET or POST response for that resource.
-            The resource will be updated or deleted only if the `etag` you
+            The resource is updated or deleted only if the `etag` you
             provide matches the resource's current `etag` value.
 
         :param str opc_request_id: (optional)
-            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+            Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/datascience/delete_model_deployment.py.html>`__ to see an example of how to use delete_model_deployment API.
+        """
+        resource_path = "/modelDeployments/{modelDeploymentId}"
+        method = "DELETE"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "delete_model_deployment got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "modelDeploymentId": model_deployment_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
+    def delete_notebook_session(self, notebook_session_id, **kwargs):
+        """
+        Deletes the specified notebook session. Any unsaved work in this notebook session are lost.
+
+
+        :param str notebook_session_id: (required)
+            The `OCID`__ of the notebook session.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call
+            for a resource, set the `if-match` parameter to the value of the
+            etag from a previous GET or POST response for that resource.
+            The resource is updated or deleted only if the `etag` you
+            provide matches the resource's current `etag` value.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -1388,23 +1805,23 @@ class DataScienceClient(object):
 
     def delete_project(self, project_id, **kwargs):
         """
-        Deletes the specified project. This operation will fail unless all associated resources (such as notebook sessions or models) are in a DELETED state. You must delete all associated resources before deleting a project.
+        Deletes the specified project. This operation fails unless all associated resources (notebook sessions or models) are in a DELETED state. You must delete all associated resources before deleting a project.
 
 
         :param str project_id: (required)
             The `OCID`__ of the project.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call
             for a resource, set the `if-match` parameter to the value of the
             etag from a previous GET or POST response for that resource.
-            The resource will be updated or deleted only if the `etag` you
+            The resource is updated or deleted only if the `etag` you
             provide matches the resource's current `etag` value.
 
         :param str opc_request_id: (optional)
-            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+            Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -1478,10 +1895,10 @@ class DataScienceClient(object):
         :param str model_id: (required)
             The `OCID`__ of the model.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param str opc_request_id: (optional)
-            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+            Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -1555,10 +1972,10 @@ class DataScienceClient(object):
         :param str model_id: (required)
             The `OCID`__ of the model.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param str opc_request_id: (optional)
-            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+            Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
 
         :param str range: (optional)
             Optional byte range to fetch, as described in `RFC 7233`__, section 2.1.
@@ -1632,6 +2049,83 @@ class DataScienceClient(object):
                 header_params=header_params,
                 response_type="stream")
 
+    def get_model_deployment(self, model_deployment_id, **kwargs):
+        """
+        Retrieves the model deployment for the specified `modelDeploymentId`.
+
+
+        :param str model_deployment_id: (required)
+            The `OCID`__ of the model deployment.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+        :param str opc_request_id: (optional)
+            Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.data_science.models.ModelDeployment`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/datascience/get_model_deployment.py.html>`__ to see an example of how to use get_model_deployment API.
+        """
+        resource_path = "/modelDeployments/{modelDeploymentId}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_model_deployment got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "modelDeploymentId": model_deployment_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="ModelDeployment")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="ModelDeployment")
+
     def get_model_provenance(self, model_id, **kwargs):
         """
         Gets provenance information for specified model.
@@ -1640,10 +2134,10 @@ class DataScienceClient(object):
         :param str model_id: (required)
             The `OCID`__ of the model.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param str opc_request_id: (optional)
-            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+            Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -1717,10 +2211,10 @@ class DataScienceClient(object):
         :param str notebook_session_id: (required)
             The `OCID`__ of the notebook session.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param str opc_request_id: (optional)
-            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+            Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -1794,10 +2288,10 @@ class DataScienceClient(object):
         :param str project_id: (required)
             The `OCID`__ of the project.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param str opc_request_id: (optional)
-            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+            Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -1871,10 +2365,10 @@ class DataScienceClient(object):
         :param str work_request_id: (required)
             The `OCID`__ of the work request.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param str opc_request_id: (optional)
-            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+            Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -1948,10 +2442,10 @@ class DataScienceClient(object):
         :param str model_id: (required)
             The `OCID`__ of the model.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param str opc_request_id: (optional)
-            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+            Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -2015,6 +2509,266 @@ class DataScienceClient(object):
                 path_params=path_params,
                 header_params=header_params)
 
+    def list_model_deployment_shapes(self, compartment_id, **kwargs):
+        """
+        Lists the valid model deployment shapes.
+
+
+        :param str compartment_id: (required)
+            <b>Filter</b> results by the `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+        :param str opc_request_id: (optional)
+            Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
+
+        :param int limit: (optional)
+            For list pagination. The maximum number of results per page,
+            or items to return in a paginated \"List\" call.
+            1 is the minimum, 1000 is the maximum.
+            See `List Pagination`__.
+
+            Example: `500`
+
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/usingapi.htm#nine
+
+        :param str page: (optional)
+            For list pagination. The value of the `opc-next-page` response
+            header from the previous \"List\" call.
+
+            See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/usingapi.htm#nine
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.data_science.models.ModelDeploymentShapeSummary`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/datascience/list_model_deployment_shapes.py.html>`__ to see an example of how to use list_model_deployment_shapes API.
+        """
+        resource_path = "/modelDeploymentShapes"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "limit",
+            "page"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_model_deployment_shapes got unknown kwargs: {!r}".format(extra_kwargs))
+
+        query_params = {
+            "compartmentId": compartment_id,
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[ModelDeploymentShapeSummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[ModelDeploymentShapeSummary]")
+
+    def list_model_deployments(self, compartment_id, **kwargs):
+        """
+        Lists all model deployments in the specified compartment. Only one parameter other than compartmentId may also be included in a query. The query must include compartmentId. If the query does not include compartmentId, or includes compartmentId but two or more other parameters an error is returned.
+
+
+        :param str compartment_id: (required)
+            <b>Filter</b> results by the `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+        :param str id: (optional)
+            <b>Filter</b> results by `OCID`__. Must be an OCID of the correct type for the resource type.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+        :param str project_id: (optional)
+            <b>Filter</b> results by the `OCID`__ of the project.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+        :param str display_name: (optional)
+            <b>Filter</b> results by its user-friendly name.
+
+        :param str lifecycle_state: (optional)
+            <b>Filter</b> results by the specified lifecycle state. Must be a valid
+            state for the resource type.
+
+            Allowed values are: "CREATING", "ACTIVE", "DELETING", "FAILED", "INACTIVE", "UPDATING", "DELETED", "NEEDS_ATTENTION"
+
+        :param str created_by: (optional)
+            <b>Filter</b> results by the `OCID`__ of the user who created the resource.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+        :param int limit: (optional)
+            For list pagination. The maximum number of results per page,
+            or items to return in a paginated \"List\" call.
+            1 is the minimum, 1000 is the maximum.
+            See `List Pagination`__.
+
+            Example: `500`
+
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/usingapi.htm#nine
+
+        :param str page: (optional)
+            For list pagination. The value of the `opc-next-page` response
+            header from the previous \"List\" call.
+
+            See `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/usingapi.htm#nine
+
+        :param str sort_order: (optional)
+            Specifies sort order to use, either `ASC` (ascending) or `DESC` (descending).
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str sort_by: (optional)
+            Specifies the field to sort by. Accepts only one field.
+            By default, when you sort by `timeCreated`, results are shown
+            in descending order. When you sort by `displayName`, results are
+            shown in ascending order. Sort order for the `displayName` field is case sensitive.
+
+            Allowed values are: "timeCreated", "displayName"
+
+        :param str opc_request_id: (optional)
+            Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.data_science.models.ModelDeploymentSummary`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/datascience/list_model_deployments.py.html>`__ to see an example of how to use list_model_deployments API.
+        """
+        resource_path = "/modelDeployments"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "id",
+            "project_id",
+            "display_name",
+            "lifecycle_state",
+            "created_by",
+            "limit",
+            "page",
+            "sort_order",
+            "sort_by",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_model_deployments got unknown kwargs: {!r}".format(extra_kwargs))
+
+        if 'lifecycle_state' in kwargs:
+            lifecycle_state_allowed_values = ["CREATING", "ACTIVE", "DELETING", "FAILED", "INACTIVE", "UPDATING", "DELETED", "NEEDS_ATTENTION"]
+            if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
+                raise ValueError(
+                    "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
+                )
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["timeCreated", "displayName"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        query_params = {
+            "compartmentId": compartment_id,
+            "id": kwargs.get("id", missing),
+            "projectId": kwargs.get("project_id", missing),
+            "displayName": kwargs.get("display_name", missing),
+            "lifecycleState": kwargs.get("lifecycle_state", missing),
+            "createdBy": kwargs.get("created_by", missing),
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "sortBy": kwargs.get("sort_by", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[ModelDeploymentSummary]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[ModelDeploymentSummary]")
+
     def list_models(self, compartment_id, **kwargs):
         """
         Lists models in the specified compartment.
@@ -2023,17 +2777,17 @@ class DataScienceClient(object):
         :param str compartment_id: (required)
             <b>Filter</b> results by the `OCID`__ of the compartment.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param str id: (optional)
             <b>Filter</b> results by `OCID`__. Must be an OCID of the correct type for the resource type.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param str project_id: (optional)
             <b>Filter</b> results by the `OCID`__ of the project.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param str display_name: (optional)
             <b>Filter</b> results by its user-friendly name.
@@ -2047,7 +2801,7 @@ class DataScienceClient(object):
         :param str created_by: (optional)
             <b>Filter</b> results by the `OCID`__ of the user who created the resource.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param int limit: (optional)
             For list pagination. The maximum number of results per page,
@@ -2057,7 +2811,7 @@ class DataScienceClient(object):
 
             Example: `500`
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/usingapi.htm#nine
 
         :param str page: (optional)
             For list pagination. The value of the `opc-next-page` response
@@ -2065,7 +2819,7 @@ class DataScienceClient(object):
 
             See `List Pagination`__.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/usingapi.htm#nine
 
         :param str sort_order: (optional)
             Specifies sort order to use, either `ASC` (ascending) or `DESC` (descending).
@@ -2074,13 +2828,13 @@ class DataScienceClient(object):
 
         :param str sort_by: (optional)
             Specifies the field to sort by. Accepts only one field.
-            By default, when you sort by `timeCreated`, results are shown
-            in descending order. All other fields default to ascending order. Sort order for `displayName` field is case sensitive.
+            By default, when you sort by `timeCreated`, the results are shown
+            in descending order. All other fields default to ascending order. Sort order for the `displayName` field is case sensitive.
 
             Allowed values are: "timeCreated", "displayName", "lifecycleState"
 
         :param str opc_request_id: (optional)
-            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+            Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -2188,10 +2942,10 @@ class DataScienceClient(object):
         :param str compartment_id: (required)
             <b>Filter</b> results by the `OCID`__ of the compartment.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param str opc_request_id: (optional)
-            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+            Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
 
         :param int limit: (optional)
             For list pagination. The maximum number of results per page,
@@ -2201,7 +2955,7 @@ class DataScienceClient(object):
 
             Example: `500`
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/usingapi.htm#nine
 
         :param str page: (optional)
             For list pagination. The value of the `opc-next-page` response
@@ -2209,7 +2963,7 @@ class DataScienceClient(object):
 
             See `List Pagination`__.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/usingapi.htm#nine
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -2276,23 +3030,23 @@ class DataScienceClient(object):
 
     def list_notebook_sessions(self, compartment_id, **kwargs):
         """
-        Lists notebook sessions in the specified compartment.
+        Lists the notebook sessions in the specified compartment.
 
 
         :param str compartment_id: (required)
             <b>Filter</b> results by the `OCID`__ of the compartment.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param str id: (optional)
             <b>Filter</b> results by `OCID`__. Must be an OCID of the correct type for the resource type.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param str project_id: (optional)
             <b>Filter</b> results by the `OCID`__ of the project.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param str display_name: (optional)
             <b>Filter</b> results by its user-friendly name.
@@ -2306,7 +3060,7 @@ class DataScienceClient(object):
         :param str created_by: (optional)
             <b>Filter</b> results by the `OCID`__ of the user who created the resource.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param int limit: (optional)
             For list pagination. The maximum number of results per page,
@@ -2316,7 +3070,7 @@ class DataScienceClient(object):
 
             Example: `500`
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/usingapi.htm#nine
 
         :param str page: (optional)
             For list pagination. The value of the `opc-next-page` response
@@ -2324,7 +3078,7 @@ class DataScienceClient(object):
 
             See `List Pagination`__.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/usingapi.htm#nine
 
         :param str sort_order: (optional)
             Specifies sort order to use, either `ASC` (ascending) or `DESC` (descending).
@@ -2333,14 +3087,14 @@ class DataScienceClient(object):
 
         :param str sort_by: (optional)
             Specifies the field to sort by. Accepts only one field.
-            By default, when you sort by `timeCreated`, results are shown
+            By default, when you sort by `timeCreated`, the results are shown
             in descending order. When you sort by `displayName`, results are
-            shown in ascending order. Sort order for `displayName` field is case sensitive.
+            shown in ascending order. Sort order for the `displayName` field is case sensitive.
 
             Allowed values are: "timeCreated", "displayName"
 
         :param str opc_request_id: (optional)
-            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+            Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -2448,12 +3202,12 @@ class DataScienceClient(object):
         :param str compartment_id: (required)
             <b>Filter</b> results by the `OCID`__ of the compartment.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param str id: (optional)
             <b>Filter</b> results by `OCID`__. Must be an OCID of the correct type for the resource type.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param str display_name: (optional)
             <b>Filter</b> results by its user-friendly name.
@@ -2467,7 +3221,7 @@ class DataScienceClient(object):
         :param str created_by: (optional)
             <b>Filter</b> results by the `OCID`__ of the user who created the resource.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param int limit: (optional)
             For list pagination. The maximum number of results per page,
@@ -2477,7 +3231,7 @@ class DataScienceClient(object):
 
             Example: `500`
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/usingapi.htm#nine
 
         :param str page: (optional)
             For list pagination. The value of the `opc-next-page` response
@@ -2485,7 +3239,7 @@ class DataScienceClient(object):
 
             See `List Pagination`__.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/usingapi.htm#nine
 
         :param str sort_order: (optional)
             Specifies sort order to use, either `ASC` (ascending) or `DESC` (descending).
@@ -2494,14 +3248,14 @@ class DataScienceClient(object):
 
         :param str sort_by: (optional)
             Specifies the field to sort by. Accepts only one field.
-            By default, when you sort by `timeCreated`, results are shown
-            in descending order. When you sort by `displayName`, results are
-            shown in ascending order. Sort order for `displayName` field is case sensitive.
+            By default, when you sort by `timeCreated`, the results are shown
+            in descending order. When you sort by `displayName`, the results are
+            shown in ascending order. Sort order for the `displayName` field is case sensitive.
 
             Allowed values are: "timeCreated", "displayName"
 
         :param str opc_request_id: (optional)
-            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+            Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -2607,10 +3361,10 @@ class DataScienceClient(object):
         :param str work_request_id: (required)
             The `OCID`__ of the work request.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param str opc_request_id: (optional)
-            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+            Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -2684,10 +3438,10 @@ class DataScienceClient(object):
         :param str work_request_id: (required)
             The `OCID`__ of the work request.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param str opc_request_id: (optional)
-            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+            Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -2761,17 +3515,17 @@ class DataScienceClient(object):
         :param str compartment_id: (required)
             <b>Filter</b> results by the `OCID`__ of the compartment.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param str id: (optional)
             <b>Filter</b> results by `OCID`__. Must be an OCID of the correct type for the resource type.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param str operation_type: (optional)
             <b>Filter</b> results by the type of the operation associated with the work request.
 
-            Allowed values are: "NOTEBOOK_SESSION_CREATE", "NOTEBOOK_SESSION_DELETE", "NOTEBOOK_SESSION_ACTIVATE", "NOTEBOOK_SESSION_DEACTIVATE", "PROJECT_DELETE", "WORKREQUEST_CANCEL"
+            Allowed values are: "NOTEBOOK_SESSION_CREATE", "NOTEBOOK_SESSION_DELETE", "NOTEBOOK_SESSION_ACTIVATE", "NOTEBOOK_SESSION_DEACTIVATE", "MODEL_DEPLOYMENT_CREATE", "MODEL_DEPLOYMENT_DELETE", "MODEL_DEPLOYMENT_ACTIVATE", "MODEL_DEPLOYMENT_DEACTIVATE", "MODEL_DEPLOYMENT_UPDATE", "PROJECT_DELETE", "WORKREQUEST_CANCEL"
 
         :param str status: (optional)
             <b>Filter</b> results by work request status.
@@ -2786,7 +3540,7 @@ class DataScienceClient(object):
 
             Example: `500`
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/usingapi.htm#nine
 
         :param str page: (optional)
             For list pagination. The value of the `opc-next-page` response
@@ -2794,7 +3548,7 @@ class DataScienceClient(object):
 
             See `List Pagination`__.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/usingapi.htm#nine
 
         :param str sort_order: (optional)
             Specifies sort order to use, either `ASC` (ascending) or `DESC` (descending).
@@ -2802,12 +3556,12 @@ class DataScienceClient(object):
             Allowed values are: "ASC", "DESC"
 
         :param str sort_by: (optional)
-            Specifies the field to sort by. Accepts only one field. By default, when you sort by time fields, results are shown in descending order. All other fields default to ascending order.
+            Specifies the field to sort by. Accepts only one field. By default, when you sort by time fields, the results are shown in descending order. All other fields default to ascending order.
 
             Allowed values are: "operationType", "status", "timeAccepted"
 
         :param str opc_request_id: (optional)
-            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+            Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -2844,7 +3598,7 @@ class DataScienceClient(object):
                 "list_work_requests got unknown kwargs: {!r}".format(extra_kwargs))
 
         if 'operation_type' in kwargs:
-            operation_type_allowed_values = ["NOTEBOOK_SESSION_CREATE", "NOTEBOOK_SESSION_DELETE", "NOTEBOOK_SESSION_ACTIVATE", "NOTEBOOK_SESSION_DEACTIVATE", "PROJECT_DELETE", "WORKREQUEST_CANCEL"]
+            operation_type_allowed_values = ["NOTEBOOK_SESSION_CREATE", "NOTEBOOK_SESSION_DELETE", "NOTEBOOK_SESSION_ACTIVATE", "NOTEBOOK_SESSION_DEACTIVATE", "MODEL_DEPLOYMENT_CREATE", "MODEL_DEPLOYMENT_DELETE", "MODEL_DEPLOYMENT_ACTIVATE", "MODEL_DEPLOYMENT_DEACTIVATE", "MODEL_DEPLOYMENT_UPDATE", "PROJECT_DELETE", "WORKREQUEST_CANCEL"]
             if kwargs['operation_type'] not in operation_type_allowed_values:
                 raise ValueError(
                     "Invalid value for `operation_type`, must be one of {0}".format(operation_type_allowed_values)
@@ -2918,7 +3672,7 @@ class DataScienceClient(object):
         :param str model_id: (required)
             The `OCID`__ of the model.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param oci.data_science.models.UpdateModelDetails update_model_details: (required)
             Details for updating a model. You can update the `displayName`, `description`, `freeformTags`, and `definedTags` properties.
@@ -2927,11 +3681,11 @@ class DataScienceClient(object):
             For optimistic concurrency control. In the PUT or DELETE call
             for a resource, set the `if-match` parameter to the value of the
             etag from a previous GET or POST response for that resource.
-            The resource will be updated or deleted only if the `etag` you
+            The resource is updated or deleted only if the `etag` you
             provide matches the resource's current `etag` value.
 
         :param str opc_request_id: (optional)
-            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+            Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -3001,27 +3755,121 @@ class DataScienceClient(object):
                 body=update_model_details,
                 response_type="Model")
 
-    def update_model_provenance(self, model_id, update_model_provenance_details, **kwargs):
+    def update_model_deployment(self, model_deployment_id, update_model_deployment_details, **kwargs):
         """
-        Updates provenance information for the specified model.
+        Updates the properties of a model deployment. You can update the `displayName`.
+        When the model deployment is in the ACTIVE lifecycle state, you can update `modelDeploymentConfigurationDetails` and  change `instanceShapeName` and `modelId`. Any update to
+        `bandwidthMbps` or `instanceCount` can be done when the model deployment is in the INACTIVE lifecycle state. Changes to the `bandwidthMbps` or `instanceCount` will take effect
+        the next time the `ActivateModelDeployment` action is invoked on the model deployment resource.
 
 
-        :param str model_id: (required)
-            The `OCID`__ of the model.
+        :param str model_deployment_id: (required)
+            The `OCID`__ of the model deployment.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
-        :param oci.data_science.models.UpdateModelProvenanceDetails update_model_provenance_details: (required)
-            Provenance information for the specified model.
-
-        :param str opc_request_id: (optional)
-            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+        :param oci.data_science.models.UpdateModelDeploymentDetails update_model_deployment_details: (required)
+            Details for updating a model deployment. You can update `modelDeploymentConfigurationDetails` and change `instanceShapeName` and `modelId` when the model deployment is in
+            the ACTIVE lifecycle state. The `bandwidthMbps` or `instanceCount` can only be updated while the model deployment is in the `INACTIVE` state. Changes to the `bandwidthMbps`
+            or `instanceCount` will take effect the next time the `ActivateModelDeployment` action is invoked on the model deployment resource.
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call
             for a resource, set the `if-match` parameter to the value of the
             etag from a previous GET or POST response for that resource.
-            The resource will be updated or deleted only if the `etag` you
+            The resource is updated or deleted only if the `etag` you
+            provide matches the resource's current `etag` value.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/datascience/update_model_deployment.py.html>`__ to see an example of how to use update_model_deployment API.
+        """
+        resource_path = "/modelDeployments/{modelDeploymentId}"
+        method = "PUT"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "update_model_deployment got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "modelDeploymentId": model_deployment_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_model_deployment_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_model_deployment_details)
+
+    def update_model_provenance(self, model_id, update_model_provenance_details, **kwargs):
+        """
+        Updates the provenance information for the specified model.
+
+
+        :param str model_id: (required)
+            The `OCID`__ of the model.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+        :param oci.data_science.models.UpdateModelProvenanceDetails update_model_provenance_details: (required)
+            Provenance information for the specified model.
+
+        :param str opc_request_id: (optional)
+            Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call
+            for a resource, set the `if-match` parameter to the value of the
+            etag from a previous GET or POST response for that resource.
+            The resource is updated or deleted only if the `etag` you
             provide matches the resource's current `etag` value.
 
         :param obj retry_strategy: (optional)
@@ -3096,27 +3944,27 @@ class DataScienceClient(object):
         """
         Updates the properties of a notebook session. You can update the `displayName`, `freeformTags`, and `definedTags` properties.
         When the notebook session is in the INACTIVE lifecycle state, you can update `notebookSessionConfigurationDetails` and change `shape`, `subnetId`, and `blockStorageSizeInGBs`.
-        Changes to the `notebookSessionConfigurationDetails` will take effect the next time the `ActivateNotebookSession` action is invoked on the notebook session resource.
+        Changes to the `notebookSessionConfigurationDetails` take effect the next time the `ActivateNotebookSession` action is invoked on the notebook session resource.
 
 
         :param str notebook_session_id: (required)
             The `OCID`__ of the notebook session.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param oci.data_science.models.UpdateNotebookSessionDetails update_notebook_session_details: (required)
             Details for updating a notebook session. `notebookSessionConfigurationDetails` can only be updated while the notebook session is in the `INACTIVE` state.
-            Changes to the `notebookSessionConfigurationDetails` will take effect the next time the `ActivateNotebookSession` action is invoked on the notebook session resource.
+            Changes to the `notebookSessionConfigurationDetails` take effect the next time the `ActivateNotebookSession` action is invoked on the notebook session resource.
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call
             for a resource, set the `if-match` parameter to the value of the
             etag from a previous GET or POST response for that resource.
-            The resource will be updated or deleted only if the `etag` you
+            The resource is updated or deleted only if the `etag` you
             provide matches the resource's current `etag` value.
 
         :param str opc_request_id: (optional)
-            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+            Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -3194,7 +4042,7 @@ class DataScienceClient(object):
         :param str project_id: (required)
             The `OCID`__ of the project.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param oci.data_science.models.UpdateProjectDetails update_project_details: (required)
             Details for updating a project. You can update the `displayName`, `description`, `freeformTags`, and `definedTags` properties.
@@ -3203,11 +4051,11 @@ class DataScienceClient(object):
             For optimistic concurrency control. In the PUT or DELETE call
             for a resource, set the `if-match` parameter to the value of the
             etag from a previous GET or POST response for that resource.
-            The resource will be updated or deleted only if the `etag` you
+            The resource is updated or deleted only if the `etag` you
             provide matches the resource's current `etag` value.
 
         :param str opc_request_id: (optional)
-            Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+            Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.

--- a/src/oci/data_science/data_science_client_composite_operations.py
+++ b/src/oci/data_science/data_science_client_composite_operations.py
@@ -31,7 +31,7 @@ class DataScienceClientCompositeOperations(object):
         :param str model_id: (required)
             The `OCID`__ of the model.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param list[str] wait_for_states:
             An array of states to wait on. These should be valid values for :py:attr:`~oci.data_science.models.Model.lifecycle_state`
@@ -63,6 +63,46 @@ class DataScienceClientCompositeOperations(object):
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
+    def activate_model_deployment_and_wait_for_state(self, model_deployment_id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.data_science.DataScienceClient.activate_model_deployment` and waits for the :py:class:`~oci.data_science.models.WorkRequest`
+        to enter the given state(s).
+
+        :param str model_deployment_id: (required)
+            The `OCID`__ of the model deployment.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.data_science.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.data_science.DataScienceClient.activate_model_deployment`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.activate_model_deployment(model_deployment_id, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def activate_notebook_session_and_wait_for_state(self, notebook_session_id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.data_science.DataScienceClient.activate_notebook_session` and waits for the :py:class:`~oci.data_science.models.WorkRequest`
@@ -71,7 +111,7 @@ class DataScienceClientCompositeOperations(object):
         :param str notebook_session_id: (required)
             The `OCID`__ of the notebook session.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param list[str] wait_for_states:
             An array of states to wait on. These should be valid values for :py:attr:`~oci.data_science.models.WorkRequest.status`
@@ -133,6 +173,44 @@ class DataScienceClientCompositeOperations(object):
                 self.client,
                 self.client.get_model(wait_for_resource_id),
                 evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def create_model_deployment_and_wait_for_state(self, create_model_deployment_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.data_science.DataScienceClient.create_model_deployment` and waits for the :py:class:`~oci.data_science.models.WorkRequest`
+        to enter the given state(s).
+
+        :param oci.data_science.models.CreateModelDeploymentDetails create_model_deployment_details: (required)
+            Details for creating a new model deployment.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.data_science.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.data_science.DataScienceClient.create_model_deployment`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.create_model_deployment(create_model_deployment_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
                 **waiter_kwargs
             )
             result_to_return = waiter_result
@@ -225,7 +303,7 @@ class DataScienceClientCompositeOperations(object):
         :param str model_id: (required)
             The `OCID`__ of the model.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param list[str] wait_for_states:
             An array of states to wait on. These should be valid values for :py:attr:`~oci.data_science.models.Model.lifecycle_state`
@@ -257,6 +335,46 @@ class DataScienceClientCompositeOperations(object):
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
+    def deactivate_model_deployment_and_wait_for_state(self, model_deployment_id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.data_science.DataScienceClient.deactivate_model_deployment` and waits for the :py:class:`~oci.data_science.models.WorkRequest`
+        to enter the given state(s).
+
+        :param str model_deployment_id: (required)
+            The `OCID`__ of the model deployment.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.data_science.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.data_science.DataScienceClient.deactivate_model_deployment`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.deactivate_model_deployment(model_deployment_id, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def deactivate_notebook_session_and_wait_for_state(self, notebook_session_id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.data_science.DataScienceClient.deactivate_notebook_session` and waits for the :py:class:`~oci.data_science.models.WorkRequest`
@@ -265,7 +383,7 @@ class DataScienceClientCompositeOperations(object):
         :param str notebook_session_id: (required)
             The `OCID`__ of the notebook session.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param list[str] wait_for_states:
             An array of states to wait on. These should be valid values for :py:attr:`~oci.data_science.models.WorkRequest.status`
@@ -305,7 +423,7 @@ class DataScienceClientCompositeOperations(object):
         :param str model_id: (required)
             The `OCID`__ of the model.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param list[str] wait_for_states:
             An array of states to wait on. These should be valid values for :py:attr:`~oci.data_science.models.Model.lifecycle_state`
@@ -346,6 +464,54 @@ class DataScienceClientCompositeOperations(object):
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
+    def delete_model_deployment_and_wait_for_state(self, model_deployment_id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.data_science.DataScienceClient.delete_model_deployment` and waits for the :py:class:`~oci.data_science.models.WorkRequest`
+        to enter the given state(s).
+
+        :param str model_deployment_id: (required)
+            The `OCID`__ of the model deployment.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.data_science.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.data_science.DataScienceClient.delete_model_deployment`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = None
+        try:
+            operation_result = self.client.delete_model_deployment(model_deployment_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def delete_notebook_session_and_wait_for_state(self, notebook_session_id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.data_science.DataScienceClient.delete_notebook_session` and waits for the :py:class:`~oci.data_science.models.WorkRequest`
@@ -354,7 +520,7 @@ class DataScienceClientCompositeOperations(object):
         :param str notebook_session_id: (required)
             The `OCID`__ of the notebook session.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param list[str] wait_for_states:
             An array of states to wait on. These should be valid values for :py:attr:`~oci.data_science.models.WorkRequest.status`
@@ -402,7 +568,7 @@ class DataScienceClientCompositeOperations(object):
         :param str project_id: (required)
             The `OCID`__ of the project.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param list[str] wait_for_states:
             An array of states to wait on. These should be valid values for :py:attr:`~oci.data_science.models.WorkRequest.status`
@@ -450,7 +616,7 @@ class DataScienceClientCompositeOperations(object):
         :param str model_id: (required)
             The `OCID`__ of the model.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param oci.data_science.models.UpdateModelDetails update_model_details: (required)
             Details for updating a model. You can update the `displayName`, `description`, `freeformTags`, and `definedTags` properties.
@@ -485,6 +651,51 @@ class DataScienceClientCompositeOperations(object):
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
+    def update_model_deployment_and_wait_for_state(self, model_deployment_id, update_model_deployment_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.data_science.DataScienceClient.update_model_deployment` and waits for the :py:class:`~oci.data_science.models.WorkRequest`
+        to enter the given state(s).
+
+        :param str model_deployment_id: (required)
+            The `OCID`__ of the model deployment.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+        :param oci.data_science.models.UpdateModelDeploymentDetails update_model_deployment_details: (required)
+            Details for updating a model deployment. You can update `modelDeploymentConfigurationDetails` and change `instanceShapeName` and `modelId` when the model deployment is in
+            the ACTIVE lifecycle state. The `bandwidthMbps` or `instanceCount` can only be updated while the model deployment is in the `INACTIVE` state. Changes to the `bandwidthMbps`
+            or `instanceCount` will take effect the next time the `ActivateModelDeployment` action is invoked on the model deployment resource.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.data_science.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.data_science.DataScienceClient.update_model_deployment`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_model_deployment(model_deployment_id, update_model_deployment_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def update_notebook_session_and_wait_for_state(self, notebook_session_id, update_notebook_session_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.data_science.DataScienceClient.update_notebook_session` and waits for the :py:class:`~oci.data_science.models.NotebookSession` acted upon
@@ -493,11 +704,11 @@ class DataScienceClientCompositeOperations(object):
         :param str notebook_session_id: (required)
             The `OCID`__ of the notebook session.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param oci.data_science.models.UpdateNotebookSessionDetails update_notebook_session_details: (required)
             Details for updating a notebook session. `notebookSessionConfigurationDetails` can only be updated while the notebook session is in the `INACTIVE` state.
-            Changes to the `notebookSessionConfigurationDetails` will take effect the next time the `ActivateNotebookSession` action is invoked on the notebook session resource.
+            Changes to the `notebookSessionConfigurationDetails` take effect the next time the `ActivateNotebookSession` action is invoked on the notebook session resource.
 
         :param list[str] wait_for_states:
             An array of states to wait on. These should be valid values for :py:attr:`~oci.data_science.models.NotebookSession.lifecycle_state`
@@ -537,7 +748,7 @@ class DataScienceClientCompositeOperations(object):
         :param str project_id: (required)
             The `OCID`__ of the project.
 
-            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param oci.data_science.models.UpdateProjectDetails update_project_details: (required)
             Details for updating a project. You can update the `displayName`, `description`, `freeformTags`, and `definedTags` properties.

--- a/src/oci/data_science/models/__init__.py
+++ b/src/oci/data_science/models/__init__.py
@@ -4,14 +4,25 @@
 
 from __future__ import absolute_import
 
+from .category_log_details import CategoryLogDetails
 from .change_model_compartment_details import ChangeModelCompartmentDetails
+from .change_model_deployment_compartment_details import ChangeModelDeploymentCompartmentDetails
 from .change_notebook_session_compartment_details import ChangeNotebookSessionCompartmentDetails
 from .change_project_compartment_details import ChangeProjectCompartmentDetails
+from .create_model_deployment_details import CreateModelDeploymentDetails
 from .create_model_details import CreateModelDetails
 from .create_model_provenance_details import CreateModelProvenanceDetails
 from .create_notebook_session_details import CreateNotebookSessionDetails
 from .create_project_details import CreateProjectDetails
+from .fixed_size_scaling_policy import FixedSizeScalingPolicy
+from .instance_configuration import InstanceConfiguration
+from .log_details import LogDetails
 from .model import Model
+from .model_configuration_details import ModelConfigurationDetails
+from .model_deployment import ModelDeployment
+from .model_deployment_configuration_details import ModelDeploymentConfigurationDetails
+from .model_deployment_shape_summary import ModelDeploymentShapeSummary
+from .model_deployment_summary import ModelDeploymentSummary
 from .model_provenance import ModelProvenance
 from .model_summary import ModelSummary
 from .notebook_session import NotebookSession
@@ -20,10 +31,17 @@ from .notebook_session_shape_summary import NotebookSessionShapeSummary
 from .notebook_session_summary import NotebookSessionSummary
 from .project import Project
 from .project_summary import ProjectSummary
+from .scaling_policy import ScalingPolicy
+from .single_model_deployment_configuration_details import SingleModelDeploymentConfigurationDetails
+from .update_category_log_details import UpdateCategoryLogDetails
+from .update_model_configuration_details import UpdateModelConfigurationDetails
+from .update_model_deployment_configuration_details import UpdateModelDeploymentConfigurationDetails
+from .update_model_deployment_details import UpdateModelDeploymentDetails
 from .update_model_details import UpdateModelDetails
 from .update_model_provenance_details import UpdateModelProvenanceDetails
 from .update_notebook_session_details import UpdateNotebookSessionDetails
 from .update_project_details import UpdateProjectDetails
+from .update_single_model_deployment_configuration_details import UpdateSingleModelDeploymentConfigurationDetails
 from .work_request import WorkRequest
 from .work_request_error import WorkRequestError
 from .work_request_log_entry import WorkRequestLogEntry
@@ -32,14 +50,25 @@ from .work_request_summary import WorkRequestSummary
 
 # Maps type names to classes for data_science services.
 data_science_type_mapping = {
+    "CategoryLogDetails": CategoryLogDetails,
     "ChangeModelCompartmentDetails": ChangeModelCompartmentDetails,
+    "ChangeModelDeploymentCompartmentDetails": ChangeModelDeploymentCompartmentDetails,
     "ChangeNotebookSessionCompartmentDetails": ChangeNotebookSessionCompartmentDetails,
     "ChangeProjectCompartmentDetails": ChangeProjectCompartmentDetails,
+    "CreateModelDeploymentDetails": CreateModelDeploymentDetails,
     "CreateModelDetails": CreateModelDetails,
     "CreateModelProvenanceDetails": CreateModelProvenanceDetails,
     "CreateNotebookSessionDetails": CreateNotebookSessionDetails,
     "CreateProjectDetails": CreateProjectDetails,
+    "FixedSizeScalingPolicy": FixedSizeScalingPolicy,
+    "InstanceConfiguration": InstanceConfiguration,
+    "LogDetails": LogDetails,
     "Model": Model,
+    "ModelConfigurationDetails": ModelConfigurationDetails,
+    "ModelDeployment": ModelDeployment,
+    "ModelDeploymentConfigurationDetails": ModelDeploymentConfigurationDetails,
+    "ModelDeploymentShapeSummary": ModelDeploymentShapeSummary,
+    "ModelDeploymentSummary": ModelDeploymentSummary,
     "ModelProvenance": ModelProvenance,
     "ModelSummary": ModelSummary,
     "NotebookSession": NotebookSession,
@@ -48,10 +77,17 @@ data_science_type_mapping = {
     "NotebookSessionSummary": NotebookSessionSummary,
     "Project": Project,
     "ProjectSummary": ProjectSummary,
+    "ScalingPolicy": ScalingPolicy,
+    "SingleModelDeploymentConfigurationDetails": SingleModelDeploymentConfigurationDetails,
+    "UpdateCategoryLogDetails": UpdateCategoryLogDetails,
+    "UpdateModelConfigurationDetails": UpdateModelConfigurationDetails,
+    "UpdateModelDeploymentConfigurationDetails": UpdateModelDeploymentConfigurationDetails,
+    "UpdateModelDeploymentDetails": UpdateModelDeploymentDetails,
     "UpdateModelDetails": UpdateModelDetails,
     "UpdateModelProvenanceDetails": UpdateModelProvenanceDetails,
     "UpdateNotebookSessionDetails": UpdateNotebookSessionDetails,
     "UpdateProjectDetails": UpdateProjectDetails,
+    "UpdateSingleModelDeploymentConfigurationDetails": UpdateSingleModelDeploymentConfigurationDetails,
     "WorkRequest": WorkRequest,
     "WorkRequestError": WorkRequestError,
     "WorkRequestLogEntry": WorkRequestLogEntry,

--- a/src/oci/data_science/models/category_log_details.py
+++ b/src/oci/data_science/models/category_log_details.py
@@ -1,0 +1,93 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CategoryLogDetails(object):
+    """
+    The log details for each category.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CategoryLogDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param access:
+            The value to assign to the access property of this CategoryLogDetails.
+        :type access: oci.data_science.models.LogDetails
+
+        :param predict:
+            The value to assign to the predict property of this CategoryLogDetails.
+        :type predict: oci.data_science.models.LogDetails
+
+        """
+        self.swagger_types = {
+            'access': 'LogDetails',
+            'predict': 'LogDetails'
+        }
+
+        self.attribute_map = {
+            'access': 'access',
+            'predict': 'predict'
+        }
+
+        self._access = None
+        self._predict = None
+
+    @property
+    def access(self):
+        """
+        Gets the access of this CategoryLogDetails.
+
+        :return: The access of this CategoryLogDetails.
+        :rtype: oci.data_science.models.LogDetails
+        """
+        return self._access
+
+    @access.setter
+    def access(self, access):
+        """
+        Sets the access of this CategoryLogDetails.
+
+        :param access: The access of this CategoryLogDetails.
+        :type: oci.data_science.models.LogDetails
+        """
+        self._access = access
+
+    @property
+    def predict(self):
+        """
+        Gets the predict of this CategoryLogDetails.
+
+        :return: The predict of this CategoryLogDetails.
+        :rtype: oci.data_science.models.LogDetails
+        """
+        return self._predict
+
+    @predict.setter
+    def predict(self, predict):
+        """
+        Sets the predict of this CategoryLogDetails.
+
+        :param predict: The predict of this CategoryLogDetails.
+        :type: oci.data_science.models.LogDetails
+        """
+        self._predict = predict
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_science/models/change_model_deployment_compartment_details.py
+++ b/src/oci/data_science/models/change_model_deployment_compartment_details.py
@@ -1,0 +1,74 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ChangeModelDeploymentCompartmentDetails(object):
+    """
+    Details for changing the compartment of a model deployment.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ChangeModelDeploymentCompartmentDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ChangeModelDeploymentCompartmentDetails.
+        :type compartment_id: str
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId'
+        }
+
+        self._compartment_id = None
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this ChangeModelDeploymentCompartmentDetails.
+        The `OCID`__ of the compartment where the resource should be moved.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this ChangeModelDeploymentCompartmentDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this ChangeModelDeploymentCompartmentDetails.
+        The `OCID`__ of the compartment where the resource should be moved.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this ChangeModelDeploymentCompartmentDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_science/models/create_model_deployment_details.py
+++ b/src/oci/data_science/models/create_model_deployment_details.py
@@ -1,0 +1,301 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateModelDeploymentDetails(object):
+    """
+    Parameters needed to create a new model deployment. Model deployments are used by data scientists to perform predictions from the model hosted on an HTTP server.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateModelDeploymentDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this CreateModelDeploymentDetails.
+        :type display_name: str
+
+        :param description:
+            The value to assign to the description property of this CreateModelDeploymentDetails.
+        :type description: str
+
+        :param project_id:
+            The value to assign to the project_id property of this CreateModelDeploymentDetails.
+        :type project_id: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this CreateModelDeploymentDetails.
+        :type compartment_id: str
+
+        :param model_deployment_configuration_details:
+            The value to assign to the model_deployment_configuration_details property of this CreateModelDeploymentDetails.
+        :type model_deployment_configuration_details: oci.data_science.models.ModelDeploymentConfigurationDetails
+
+        :param category_log_details:
+            The value to assign to the category_log_details property of this CreateModelDeploymentDetails.
+        :type category_log_details: oci.data_science.models.CategoryLogDetails
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this CreateModelDeploymentDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this CreateModelDeploymentDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'description': 'str',
+            'project_id': 'str',
+            'compartment_id': 'str',
+            'model_deployment_configuration_details': 'ModelDeploymentConfigurationDetails',
+            'category_log_details': 'CategoryLogDetails',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'description': 'description',
+            'project_id': 'projectId',
+            'compartment_id': 'compartmentId',
+            'model_deployment_configuration_details': 'modelDeploymentConfigurationDetails',
+            'category_log_details': 'categoryLogDetails',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._display_name = None
+        self._description = None
+        self._project_id = None
+        self._compartment_id = None
+        self._model_deployment_configuration_details = None
+        self._category_log_details = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this CreateModelDeploymentDetails.
+        A user-friendly display name for the resource. Does not have to be unique, and can be modified. Avoid entering confidential information.
+        Example: `My ModelDeployment`
+
+
+        :return: The display_name of this CreateModelDeploymentDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this CreateModelDeploymentDetails.
+        A user-friendly display name for the resource. Does not have to be unique, and can be modified. Avoid entering confidential information.
+        Example: `My ModelDeployment`
+
+
+        :param display_name: The display_name of this CreateModelDeploymentDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def description(self):
+        """
+        Gets the description of this CreateModelDeploymentDetails.
+        A short description of the model deployment.
+
+
+        :return: The description of this CreateModelDeploymentDetails.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this CreateModelDeploymentDetails.
+        A short description of the model deployment.
+
+
+        :param description: The description of this CreateModelDeploymentDetails.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def project_id(self):
+        """
+        **[Required]** Gets the project_id of this CreateModelDeploymentDetails.
+        The `OCID`__ of the project to associate with the model deployment.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :return: The project_id of this CreateModelDeploymentDetails.
+        :rtype: str
+        """
+        return self._project_id
+
+    @project_id.setter
+    def project_id(self, project_id):
+        """
+        Sets the project_id of this CreateModelDeploymentDetails.
+        The `OCID`__ of the project to associate with the model deployment.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :param project_id: The project_id of this CreateModelDeploymentDetails.
+        :type: str
+        """
+        self._project_id = project_id
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this CreateModelDeploymentDetails.
+        The `OCID`__ of the compartment where you want to create the model deployment.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this CreateModelDeploymentDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this CreateModelDeploymentDetails.
+        The `OCID`__ of the compartment where you want to create the model deployment.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this CreateModelDeploymentDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def model_deployment_configuration_details(self):
+        """
+        **[Required]** Gets the model_deployment_configuration_details of this CreateModelDeploymentDetails.
+
+        :return: The model_deployment_configuration_details of this CreateModelDeploymentDetails.
+        :rtype: oci.data_science.models.ModelDeploymentConfigurationDetails
+        """
+        return self._model_deployment_configuration_details
+
+    @model_deployment_configuration_details.setter
+    def model_deployment_configuration_details(self, model_deployment_configuration_details):
+        """
+        Sets the model_deployment_configuration_details of this CreateModelDeploymentDetails.
+
+        :param model_deployment_configuration_details: The model_deployment_configuration_details of this CreateModelDeploymentDetails.
+        :type: oci.data_science.models.ModelDeploymentConfigurationDetails
+        """
+        self._model_deployment_configuration_details = model_deployment_configuration_details
+
+    @property
+    def category_log_details(self):
+        """
+        Gets the category_log_details of this CreateModelDeploymentDetails.
+
+        :return: The category_log_details of this CreateModelDeploymentDetails.
+        :rtype: oci.data_science.models.CategoryLogDetails
+        """
+        return self._category_log_details
+
+    @category_log_details.setter
+    def category_log_details(self, category_log_details):
+        """
+        Sets the category_log_details of this CreateModelDeploymentDetails.
+
+        :param category_log_details: The category_log_details of this CreateModelDeploymentDetails.
+        :type: oci.data_science.models.CategoryLogDetails
+        """
+        self._category_log_details = category_log_details
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this CreateModelDeploymentDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. See `Resource Tags`__.
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this CreateModelDeploymentDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this CreateModelDeploymentDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. See `Resource Tags`__.
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this CreateModelDeploymentDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this CreateModelDeploymentDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace. See `Resource Tags`__.
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this CreateModelDeploymentDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this CreateModelDeploymentDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace. See `Resource Tags`__.
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this CreateModelDeploymentDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_science/models/create_model_details.py
+++ b/src/oci/data_science/models/create_model_details.py
@@ -74,7 +74,7 @@ class CreateModelDetails(object):
         **[Required]** Gets the compartment_id of this CreateModelDetails.
         The `OCID`__ of the compartment to create the model in.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :return: The compartment_id of this CreateModelDetails.
@@ -88,7 +88,7 @@ class CreateModelDetails(object):
         Sets the compartment_id of this CreateModelDetails.
         The `OCID`__ of the compartment to create the model in.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :param compartment_id: The compartment_id of this CreateModelDetails.
@@ -102,7 +102,7 @@ class CreateModelDetails(object):
         **[Required]** Gets the project_id of this CreateModelDetails.
         The `OCID`__ of the project to associate with the model.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :return: The project_id of this CreateModelDetails.
@@ -116,7 +116,7 @@ class CreateModelDetails(object):
         Sets the project_id of this CreateModelDetails.
         The `OCID`__ of the project to associate with the model.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :param project_id: The project_id of this CreateModelDetails.
@@ -128,7 +128,7 @@ class CreateModelDetails(object):
     def display_name(self):
         """
         Gets the display_name of this CreateModelDetails.
-        A user-friendly display name for the resource. Does not have to be unique, and can be modified. Avoid entering confidential information.
+        A user-friendly display name for the resource. It does not have to be unique and can be modified. Avoid entering confidential information.
         Example: `My Model`
 
 
@@ -141,7 +141,7 @@ class CreateModelDetails(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this CreateModelDetails.
-        A user-friendly display name for the resource. Does not have to be unique, and can be modified. Avoid entering confidential information.
+        A user-friendly display name for the resource. It does not have to be unique and can be modified. Avoid entering confidential information.
         Example: `My Model`
 
 
@@ -154,7 +154,7 @@ class CreateModelDetails(object):
     def description(self):
         """
         Gets the description of this CreateModelDetails.
-        A short blurb describing the model.
+        A short description of the model.
 
 
         :return: The description of this CreateModelDetails.
@@ -166,7 +166,7 @@ class CreateModelDetails(object):
     def description(self, description):
         """
         Sets the description of this CreateModelDetails.
-        A short blurb describing the model.
+        A short description of the model.
 
 
         :param description: The description of this CreateModelDetails.

--- a/src/oci/data_science/models/create_notebook_session_details.py
+++ b/src/oci/data_science/models/create_notebook_session_details.py
@@ -72,7 +72,7 @@ class CreateNotebookSessionDetails(object):
     def display_name(self):
         """
         Gets the display_name of this CreateNotebookSessionDetails.
-        A user-friendly display name for the resource. Does not have to be unique, and can be modified. Avoid entering confidential information.
+        A user-friendly display name for the resource. It does not have to be unique and can be modified. Avoid entering confidential information.
         Example: `My NotebookSession`
 
 
@@ -85,7 +85,7 @@ class CreateNotebookSessionDetails(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this CreateNotebookSessionDetails.
-        A user-friendly display name for the resource. Does not have to be unique, and can be modified. Avoid entering confidential information.
+        A user-friendly display name for the resource. It does not have to be unique and can be modified. Avoid entering confidential information.
         Example: `My NotebookSession`
 
 
@@ -100,7 +100,7 @@ class CreateNotebookSessionDetails(object):
         **[Required]** Gets the project_id of this CreateNotebookSessionDetails.
         The `OCID`__ of the project to associate with the notebook session.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :return: The project_id of this CreateNotebookSessionDetails.
@@ -114,7 +114,7 @@ class CreateNotebookSessionDetails(object):
         Sets the project_id of this CreateNotebookSessionDetails.
         The `OCID`__ of the project to associate with the notebook session.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :param project_id: The project_id of this CreateNotebookSessionDetails.
@@ -128,7 +128,7 @@ class CreateNotebookSessionDetails(object):
         **[Required]** Gets the compartment_id of this CreateNotebookSessionDetails.
         The `OCID`__ of the compartment where you want to create the notebook session.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :return: The compartment_id of this CreateNotebookSessionDetails.
@@ -142,7 +142,7 @@ class CreateNotebookSessionDetails(object):
         Sets the compartment_id of this CreateNotebookSessionDetails.
         The `OCID`__ of the compartment where you want to create the notebook session.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :param compartment_id: The compartment_id of this CreateNotebookSessionDetails.

--- a/src/oci/data_science/models/create_project_details.py
+++ b/src/oci/data_science/models/create_project_details.py
@@ -65,7 +65,7 @@ class CreateProjectDetails(object):
     def display_name(self):
         """
         Gets the display_name of this CreateProjectDetails.
-        A user-friendly display name for the resource. Does not have to be unique, and can be modified. Avoid entering confidential information.
+        A user-friendly display name for the resource. It does not have to be unique and can be modified. Avoid entering confidential information.
 
 
         :return: The display_name of this CreateProjectDetails.
@@ -77,7 +77,7 @@ class CreateProjectDetails(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this CreateProjectDetails.
-        A user-friendly display name for the resource. Does not have to be unique, and can be modified. Avoid entering confidential information.
+        A user-friendly display name for the resource. It does not have to be unique and can be modified. Avoid entering confidential information.
 
 
         :param display_name: The display_name of this CreateProjectDetails.
@@ -89,7 +89,7 @@ class CreateProjectDetails(object):
     def description(self):
         """
         Gets the description of this CreateProjectDetails.
-        A short blurb describing the project.
+        A short description of the project.
 
 
         :return: The description of this CreateProjectDetails.
@@ -101,7 +101,7 @@ class CreateProjectDetails(object):
     def description(self, description):
         """
         Sets the description of this CreateProjectDetails.
-        A short blurb describing the project.
+        A short description of the project.
 
 
         :param description: The description of this CreateProjectDetails.
@@ -115,7 +115,7 @@ class CreateProjectDetails(object):
         **[Required]** Gets the compartment_id of this CreateProjectDetails.
         The `OCID`__ of the compartment to create the project in.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :return: The compartment_id of this CreateProjectDetails.
@@ -129,7 +129,7 @@ class CreateProjectDetails(object):
         Sets the compartment_id of this CreateProjectDetails.
         The `OCID`__ of the compartment to create the project in.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :param compartment_id: The compartment_id of this CreateProjectDetails.

--- a/src/oci/data_science/models/fixed_size_scaling_policy.py
+++ b/src/oci/data_science/models/fixed_size_scaling_policy.py
@@ -1,0 +1,80 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .scaling_policy import ScalingPolicy
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class FixedSizeScalingPolicy(ScalingPolicy):
+    """
+    The fixed size scaling policy.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new FixedSizeScalingPolicy object with values from keyword arguments. The default value of the :py:attr:`~oci.data_science.models.FixedSizeScalingPolicy.policy_type` attribute
+        of this class is ``FIXED_SIZE`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param policy_type:
+            The value to assign to the policy_type property of this FixedSizeScalingPolicy.
+            Allowed values for this property are: "FIXED_SIZE"
+        :type policy_type: str
+
+        :param instance_count:
+            The value to assign to the instance_count property of this FixedSizeScalingPolicy.
+        :type instance_count: int
+
+        """
+        self.swagger_types = {
+            'policy_type': 'str',
+            'instance_count': 'int'
+        }
+
+        self.attribute_map = {
+            'policy_type': 'policyType',
+            'instance_count': 'instanceCount'
+        }
+
+        self._policy_type = None
+        self._instance_count = None
+        self._policy_type = 'FIXED_SIZE'
+
+    @property
+    def instance_count(self):
+        """
+        **[Required]** Gets the instance_count of this FixedSizeScalingPolicy.
+        The number of instances for the model deployment.
+
+
+        :return: The instance_count of this FixedSizeScalingPolicy.
+        :rtype: int
+        """
+        return self._instance_count
+
+    @instance_count.setter
+    def instance_count(self, instance_count):
+        """
+        Sets the instance_count of this FixedSizeScalingPolicy.
+        The number of instances for the model deployment.
+
+
+        :param instance_count: The instance_count of this FixedSizeScalingPolicy.
+        :type: int
+        """
+        self._instance_count = instance_count
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_science/models/instance_configuration.py
+++ b/src/oci/data_science/models/instance_configuration.py
@@ -1,0 +1,70 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class InstanceConfiguration(object):
+    """
+    The model deployment instance configuration
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new InstanceConfiguration object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param instance_shape_name:
+            The value to assign to the instance_shape_name property of this InstanceConfiguration.
+        :type instance_shape_name: str
+
+        """
+        self.swagger_types = {
+            'instance_shape_name': 'str'
+        }
+
+        self.attribute_map = {
+            'instance_shape_name': 'instanceShapeName'
+        }
+
+        self._instance_shape_name = None
+
+    @property
+    def instance_shape_name(self):
+        """
+        **[Required]** Gets the instance_shape_name of this InstanceConfiguration.
+        The shape used to launch the model deployment instances.
+
+
+        :return: The instance_shape_name of this InstanceConfiguration.
+        :rtype: str
+        """
+        return self._instance_shape_name
+
+    @instance_shape_name.setter
+    def instance_shape_name(self, instance_shape_name):
+        """
+        Sets the instance_shape_name of this InstanceConfiguration.
+        The shape used to launch the model deployment instances.
+
+
+        :param instance_shape_name: The instance_shape_name of this InstanceConfiguration.
+        :type: str
+        """
+        self._instance_shape_name = instance_shape_name
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_science/models/log_details.py
+++ b/src/oci/data_science/models/log_details.py
@@ -1,0 +1,109 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class LogDetails(object):
+    """
+    The log details.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new LogDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param log_id:
+            The value to assign to the log_id property of this LogDetails.
+        :type log_id: str
+
+        :param log_group_id:
+            The value to assign to the log_group_id property of this LogDetails.
+        :type log_group_id: str
+
+        """
+        self.swagger_types = {
+            'log_id': 'str',
+            'log_group_id': 'str'
+        }
+
+        self.attribute_map = {
+            'log_id': 'logId',
+            'log_group_id': 'logGroupId'
+        }
+
+        self._log_id = None
+        self._log_group_id = None
+
+    @property
+    def log_id(self):
+        """
+        **[Required]** Gets the log_id of this LogDetails.
+        The `OCID`__ of a log to work with.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The log_id of this LogDetails.
+        :rtype: str
+        """
+        return self._log_id
+
+    @log_id.setter
+    def log_id(self, log_id):
+        """
+        Sets the log_id of this LogDetails.
+        The `OCID`__ of a log to work with.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param log_id: The log_id of this LogDetails.
+        :type: str
+        """
+        self._log_id = log_id
+
+    @property
+    def log_group_id(self):
+        """
+        **[Required]** Gets the log_group_id of this LogDetails.
+        The `OCID`__ of a log group to work with.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The log_group_id of this LogDetails.
+        :rtype: str
+        """
+        return self._log_group_id
+
+    @log_group_id.setter
+    def log_group_id(self, log_group_id):
+        """
+        Sets the log_group_id of this LogDetails.
+        The `OCID`__ of a log group to work with.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param log_group_id: The log_group_id of this LogDetails.
+        :type: str
+        """
+        self._log_group_id = log_group_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_science/models/model.py
+++ b/src/oci/data_science/models/model.py
@@ -120,7 +120,7 @@ class Model(object):
         **[Required]** Gets the id of this Model.
         The `OCID`__ of the model.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :return: The id of this Model.
@@ -134,7 +134,7 @@ class Model(object):
         Sets the id of this Model.
         The `OCID`__ of the model.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :param id: The id of this Model.
@@ -148,7 +148,7 @@ class Model(object):
         **[Required]** Gets the compartment_id of this Model.
         The `OCID`__ of the model's compartment.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :return: The compartment_id of this Model.
@@ -162,7 +162,7 @@ class Model(object):
         Sets the compartment_id of this Model.
         The `OCID`__ of the model's compartment.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :param compartment_id: The compartment_id of this Model.
@@ -176,7 +176,7 @@ class Model(object):
         **[Required]** Gets the project_id of this Model.
         The `OCID`__ of the project associated with the model.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :return: The project_id of this Model.
@@ -190,7 +190,7 @@ class Model(object):
         Sets the project_id of this Model.
         The `OCID`__ of the project associated with the model.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :param project_id: The project_id of this Model.
@@ -202,7 +202,7 @@ class Model(object):
     def display_name(self):
         """
         **[Required]** Gets the display_name of this Model.
-        A user-friendly display name for the resource. Does not have to be unique, and can be modified. Avoid entering confidential information.
+        A user-friendly display name for the resource. It does not have to be unique and can be modified. Avoid entering confidential information.
 
 
         :return: The display_name of this Model.
@@ -214,7 +214,7 @@ class Model(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this Model.
-        A user-friendly display name for the resource. Does not have to be unique, and can be modified. Avoid entering confidential information.
+        A user-friendly display name for the resource. It does not have to be unique and can be modified. Avoid entering confidential information.
 
 
         :param display_name: The display_name of this Model.
@@ -226,7 +226,7 @@ class Model(object):
     def description(self):
         """
         Gets the description of this Model.
-        A short blurb describing the model.
+        A short description of the model.
 
 
         :return: The description of this Model.
@@ -238,7 +238,7 @@ class Model(object):
     def description(self, description):
         """
         Sets the description of this Model.
-        A short blurb describing the model.
+        A short description of the model.
 
 
         :param description: The description of this Model.
@@ -280,7 +280,7 @@ class Model(object):
     def time_created(self):
         """
         **[Required]** Gets the time_created of this Model.
-        The date and time the resource was created, in the timestamp format defined by `RFC3339`__.
+        The date and time the resource was created in the timestamp format defined by `RFC3339`__.
         Example: 2019-08-25T21:10:29.41Z
 
         __ https://tools.ietf.org/html/rfc3339
@@ -295,7 +295,7 @@ class Model(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this Model.
-        The date and time the resource was created, in the timestamp format defined by `RFC3339`__.
+        The date and time the resource was created in the timestamp format defined by `RFC3339`__.
         Example: 2019-08-25T21:10:29.41Z
 
         __ https://tools.ietf.org/html/rfc3339
@@ -312,7 +312,7 @@ class Model(object):
         **[Required]** Gets the created_by of this Model.
         The `OCID`__ of the user who created the model.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :return: The created_by of this Model.
@@ -326,7 +326,7 @@ class Model(object):
         Sets the created_by of this Model.
         The `OCID`__ of the user who created the model.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :param created_by: The created_by of this Model.

--- a/src/oci/data_science/models/model_configuration_details.py
+++ b/src/oci/data_science/models/model_configuration_details.py
@@ -1,0 +1,155 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ModelConfigurationDetails(object):
+    """
+    The model configuration details.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ModelConfigurationDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param model_id:
+            The value to assign to the model_id property of this ModelConfigurationDetails.
+        :type model_id: str
+
+        :param instance_configuration:
+            The value to assign to the instance_configuration property of this ModelConfigurationDetails.
+        :type instance_configuration: oci.data_science.models.InstanceConfiguration
+
+        :param scaling_policy:
+            The value to assign to the scaling_policy property of this ModelConfigurationDetails.
+        :type scaling_policy: oci.data_science.models.ScalingPolicy
+
+        :param bandwidth_mbps:
+            The value to assign to the bandwidth_mbps property of this ModelConfigurationDetails.
+        :type bandwidth_mbps: int
+
+        """
+        self.swagger_types = {
+            'model_id': 'str',
+            'instance_configuration': 'InstanceConfiguration',
+            'scaling_policy': 'ScalingPolicy',
+            'bandwidth_mbps': 'int'
+        }
+
+        self.attribute_map = {
+            'model_id': 'modelId',
+            'instance_configuration': 'instanceConfiguration',
+            'scaling_policy': 'scalingPolicy',
+            'bandwidth_mbps': 'bandwidthMbps'
+        }
+
+        self._model_id = None
+        self._instance_configuration = None
+        self._scaling_policy = None
+        self._bandwidth_mbps = None
+
+    @property
+    def model_id(self):
+        """
+        **[Required]** Gets the model_id of this ModelConfigurationDetails.
+        The OCID of the model you want to deploy.
+
+
+        :return: The model_id of this ModelConfigurationDetails.
+        :rtype: str
+        """
+        return self._model_id
+
+    @model_id.setter
+    def model_id(self, model_id):
+        """
+        Sets the model_id of this ModelConfigurationDetails.
+        The OCID of the model you want to deploy.
+
+
+        :param model_id: The model_id of this ModelConfigurationDetails.
+        :type: str
+        """
+        self._model_id = model_id
+
+    @property
+    def instance_configuration(self):
+        """
+        **[Required]** Gets the instance_configuration of this ModelConfigurationDetails.
+
+        :return: The instance_configuration of this ModelConfigurationDetails.
+        :rtype: oci.data_science.models.InstanceConfiguration
+        """
+        return self._instance_configuration
+
+    @instance_configuration.setter
+    def instance_configuration(self, instance_configuration):
+        """
+        Sets the instance_configuration of this ModelConfigurationDetails.
+
+        :param instance_configuration: The instance_configuration of this ModelConfigurationDetails.
+        :type: oci.data_science.models.InstanceConfiguration
+        """
+        self._instance_configuration = instance_configuration
+
+    @property
+    def scaling_policy(self):
+        """
+        Gets the scaling_policy of this ModelConfigurationDetails.
+
+        :return: The scaling_policy of this ModelConfigurationDetails.
+        :rtype: oci.data_science.models.ScalingPolicy
+        """
+        return self._scaling_policy
+
+    @scaling_policy.setter
+    def scaling_policy(self, scaling_policy):
+        """
+        Sets the scaling_policy of this ModelConfigurationDetails.
+
+        :param scaling_policy: The scaling_policy of this ModelConfigurationDetails.
+        :type: oci.data_science.models.ScalingPolicy
+        """
+        self._scaling_policy = scaling_policy
+
+    @property
+    def bandwidth_mbps(self):
+        """
+        Gets the bandwidth_mbps of this ModelConfigurationDetails.
+        The network bandwidth for the model.
+
+
+        :return: The bandwidth_mbps of this ModelConfigurationDetails.
+        :rtype: int
+        """
+        return self._bandwidth_mbps
+
+    @bandwidth_mbps.setter
+    def bandwidth_mbps(self, bandwidth_mbps):
+        """
+        Sets the bandwidth_mbps of this ModelConfigurationDetails.
+        The network bandwidth for the model.
+
+
+        :param bandwidth_mbps: The bandwidth_mbps of this ModelConfigurationDetails.
+        :type: int
+        """
+        self._bandwidth_mbps = bandwidth_mbps
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_science/models/model_deployment.py
+++ b/src/oci/data_science/models/model_deployment.py
@@ -1,0 +1,541 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ModelDeployment(object):
+    """
+    Model deployments are interactive coding environments for data scientists.
+    """
+
+    #: A constant which can be used with the lifecycle_state property of a ModelDeployment.
+    #: This constant has a value of "CREATING"
+    LIFECYCLE_STATE_CREATING = "CREATING"
+
+    #: A constant which can be used with the lifecycle_state property of a ModelDeployment.
+    #: This constant has a value of "ACTIVE"
+    LIFECYCLE_STATE_ACTIVE = "ACTIVE"
+
+    #: A constant which can be used with the lifecycle_state property of a ModelDeployment.
+    #: This constant has a value of "DELETING"
+    LIFECYCLE_STATE_DELETING = "DELETING"
+
+    #: A constant which can be used with the lifecycle_state property of a ModelDeployment.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    #: A constant which can be used with the lifecycle_state property of a ModelDeployment.
+    #: This constant has a value of "INACTIVE"
+    LIFECYCLE_STATE_INACTIVE = "INACTIVE"
+
+    #: A constant which can be used with the lifecycle_state property of a ModelDeployment.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a ModelDeployment.
+    #: This constant has a value of "DELETED"
+    LIFECYCLE_STATE_DELETED = "DELETED"
+
+    #: A constant which can be used with the lifecycle_state property of a ModelDeployment.
+    #: This constant has a value of "NEEDS_ATTENTION"
+    LIFECYCLE_STATE_NEEDS_ATTENTION = "NEEDS_ATTENTION"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ModelDeployment object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this ModelDeployment.
+        :type id: str
+
+        :param time_created:
+            The value to assign to the time_created property of this ModelDeployment.
+        :type time_created: datetime
+
+        :param display_name:
+            The value to assign to the display_name property of this ModelDeployment.
+        :type display_name: str
+
+        :param description:
+            The value to assign to the description property of this ModelDeployment.
+        :type description: str
+
+        :param project_id:
+            The value to assign to the project_id property of this ModelDeployment.
+        :type project_id: str
+
+        :param created_by:
+            The value to assign to the created_by property of this ModelDeployment.
+        :type created_by: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ModelDeployment.
+        :type compartment_id: str
+
+        :param model_deployment_configuration_details:
+            The value to assign to the model_deployment_configuration_details property of this ModelDeployment.
+        :type model_deployment_configuration_details: oci.data_science.models.ModelDeploymentConfigurationDetails
+
+        :param category_log_details:
+            The value to assign to the category_log_details property of this ModelDeployment.
+        :type category_log_details: oci.data_science.models.CategoryLogDetails
+
+        :param model_deployment_url:
+            The value to assign to the model_deployment_url property of this ModelDeployment.
+        :type model_deployment_url: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this ModelDeployment.
+            Allowed values for this property are: "CREATING", "ACTIVE", "DELETING", "FAILED", "INACTIVE", "UPDATING", "DELETED", "NEEDS_ATTENTION", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param lifecycle_details:
+            The value to assign to the lifecycle_details property of this ModelDeployment.
+        :type lifecycle_details: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this ModelDeployment.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this ModelDeployment.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'time_created': 'datetime',
+            'display_name': 'str',
+            'description': 'str',
+            'project_id': 'str',
+            'created_by': 'str',
+            'compartment_id': 'str',
+            'model_deployment_configuration_details': 'ModelDeploymentConfigurationDetails',
+            'category_log_details': 'CategoryLogDetails',
+            'model_deployment_url': 'str',
+            'lifecycle_state': 'str',
+            'lifecycle_details': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'time_created': 'timeCreated',
+            'display_name': 'displayName',
+            'description': 'description',
+            'project_id': 'projectId',
+            'created_by': 'createdBy',
+            'compartment_id': 'compartmentId',
+            'model_deployment_configuration_details': 'modelDeploymentConfigurationDetails',
+            'category_log_details': 'categoryLogDetails',
+            'model_deployment_url': 'modelDeploymentUrl',
+            'lifecycle_state': 'lifecycleState',
+            'lifecycle_details': 'lifecycleDetails',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._id = None
+        self._time_created = None
+        self._display_name = None
+        self._description = None
+        self._project_id = None
+        self._created_by = None
+        self._compartment_id = None
+        self._model_deployment_configuration_details = None
+        self._category_log_details = None
+        self._model_deployment_url = None
+        self._lifecycle_state = None
+        self._lifecycle_details = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this ModelDeployment.
+        The `OCID`__ of the model deployment.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :return: The id of this ModelDeployment.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this ModelDeployment.
+        The `OCID`__ of the model deployment.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :param id: The id of this ModelDeployment.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def time_created(self):
+        """
+        **[Required]** Gets the time_created of this ModelDeployment.
+        The date and time the resource was created, in the timestamp format defined by `RFC3339`__.
+        Example: 2019-08-25T21:10:29.41Z
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :return: The time_created of this ModelDeployment.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this ModelDeployment.
+        The date and time the resource was created, in the timestamp format defined by `RFC3339`__.
+        Example: 2019-08-25T21:10:29.41Z
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :param time_created: The time_created of this ModelDeployment.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this ModelDeployment.
+        A user-friendly display name for the resource. Does not have to be unique, and can be modified. Avoid entering confidential information.
+        Example: `My ModelDeployment`
+
+
+        :return: The display_name of this ModelDeployment.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this ModelDeployment.
+        A user-friendly display name for the resource. Does not have to be unique, and can be modified. Avoid entering confidential information.
+        Example: `My ModelDeployment`
+
+
+        :param display_name: The display_name of this ModelDeployment.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def description(self):
+        """
+        Gets the description of this ModelDeployment.
+        A short description of the model deployment.
+
+
+        :return: The description of this ModelDeployment.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this ModelDeployment.
+        A short description of the model deployment.
+
+
+        :param description: The description of this ModelDeployment.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def project_id(self):
+        """
+        **[Required]** Gets the project_id of this ModelDeployment.
+        The `OCID`__ of the project associated with the model deployment.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :return: The project_id of this ModelDeployment.
+        :rtype: str
+        """
+        return self._project_id
+
+    @project_id.setter
+    def project_id(self, project_id):
+        """
+        Sets the project_id of this ModelDeployment.
+        The `OCID`__ of the project associated with the model deployment.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :param project_id: The project_id of this ModelDeployment.
+        :type: str
+        """
+        self._project_id = project_id
+
+    @property
+    def created_by(self):
+        """
+        **[Required]** Gets the created_by of this ModelDeployment.
+        The `OCID`__ of the user who created the model deployment.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :return: The created_by of this ModelDeployment.
+        :rtype: str
+        """
+        return self._created_by
+
+    @created_by.setter
+    def created_by(self, created_by):
+        """
+        Sets the created_by of this ModelDeployment.
+        The `OCID`__ of the user who created the model deployment.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :param created_by: The created_by of this ModelDeployment.
+        :type: str
+        """
+        self._created_by = created_by
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this ModelDeployment.
+        The `OCID`__ of the model deployment's compartment.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this ModelDeployment.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this ModelDeployment.
+        The `OCID`__ of the model deployment's compartment.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this ModelDeployment.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def model_deployment_configuration_details(self):
+        """
+        Gets the model_deployment_configuration_details of this ModelDeployment.
+
+        :return: The model_deployment_configuration_details of this ModelDeployment.
+        :rtype: oci.data_science.models.ModelDeploymentConfigurationDetails
+        """
+        return self._model_deployment_configuration_details
+
+    @model_deployment_configuration_details.setter
+    def model_deployment_configuration_details(self, model_deployment_configuration_details):
+        """
+        Sets the model_deployment_configuration_details of this ModelDeployment.
+
+        :param model_deployment_configuration_details: The model_deployment_configuration_details of this ModelDeployment.
+        :type: oci.data_science.models.ModelDeploymentConfigurationDetails
+        """
+        self._model_deployment_configuration_details = model_deployment_configuration_details
+
+    @property
+    def category_log_details(self):
+        """
+        Gets the category_log_details of this ModelDeployment.
+
+        :return: The category_log_details of this ModelDeployment.
+        :rtype: oci.data_science.models.CategoryLogDetails
+        """
+        return self._category_log_details
+
+    @category_log_details.setter
+    def category_log_details(self, category_log_details):
+        """
+        Sets the category_log_details of this ModelDeployment.
+
+        :param category_log_details: The category_log_details of this ModelDeployment.
+        :type: oci.data_science.models.CategoryLogDetails
+        """
+        self._category_log_details = category_log_details
+
+    @property
+    def model_deployment_url(self):
+        """
+        **[Required]** Gets the model_deployment_url of this ModelDeployment.
+        The URL to interact with the model deployment.
+
+
+        :return: The model_deployment_url of this ModelDeployment.
+        :rtype: str
+        """
+        return self._model_deployment_url
+
+    @model_deployment_url.setter
+    def model_deployment_url(self, model_deployment_url):
+        """
+        Sets the model_deployment_url of this ModelDeployment.
+        The URL to interact with the model deployment.
+
+
+        :param model_deployment_url: The model_deployment_url of this ModelDeployment.
+        :type: str
+        """
+        self._model_deployment_url = model_deployment_url
+
+    @property
+    def lifecycle_state(self):
+        """
+        **[Required]** Gets the lifecycle_state of this ModelDeployment.
+        The state of the model deployment.
+
+        Allowed values for this property are: "CREATING", "ACTIVE", "DELETING", "FAILED", "INACTIVE", "UPDATING", "DELETED", "NEEDS_ATTENTION", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this ModelDeployment.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this ModelDeployment.
+        The state of the model deployment.
+
+
+        :param lifecycle_state: The lifecycle_state of this ModelDeployment.
+        :type: str
+        """
+        allowed_values = ["CREATING", "ACTIVE", "DELETING", "FAILED", "INACTIVE", "UPDATING", "DELETED", "NEEDS_ATTENTION"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def lifecycle_details(self):
+        """
+        Gets the lifecycle_details of this ModelDeployment.
+        Details about the state of the model deployment.
+
+
+        :return: The lifecycle_details of this ModelDeployment.
+        :rtype: str
+        """
+        return self._lifecycle_details
+
+    @lifecycle_details.setter
+    def lifecycle_details(self, lifecycle_details):
+        """
+        Sets the lifecycle_details of this ModelDeployment.
+        Details about the state of the model deployment.
+
+
+        :param lifecycle_details: The lifecycle_details of this ModelDeployment.
+        :type: str
+        """
+        self._lifecycle_details = lifecycle_details
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this ModelDeployment.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. See `Resource Tags`__.
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this ModelDeployment.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this ModelDeployment.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. See `Resource Tags`__.
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this ModelDeployment.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this ModelDeployment.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace. See `Resource Tags`__.
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this ModelDeployment.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this ModelDeployment.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace. See `Resource Tags`__.
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this ModelDeployment.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_science/models/model_deployment_configuration_details.py
+++ b/src/oci/data_science/models/model_deployment_configuration_details.py
@@ -1,0 +1,99 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ModelDeploymentConfigurationDetails(object):
+    """
+    The model deployment configuration details.
+    """
+
+    #: A constant which can be used with the deployment_type property of a ModelDeploymentConfigurationDetails.
+    #: This constant has a value of "SINGLE_MODEL"
+    DEPLOYMENT_TYPE_SINGLE_MODEL = "SINGLE_MODEL"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ModelDeploymentConfigurationDetails object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
+        to a service operations then you should favor using a subclass over the base class:
+
+        * :class:`~oci.data_science.models.SingleModelDeploymentConfigurationDetails`
+
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param deployment_type:
+            The value to assign to the deployment_type property of this ModelDeploymentConfigurationDetails.
+            Allowed values for this property are: "SINGLE_MODEL", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type deployment_type: str
+
+        """
+        self.swagger_types = {
+            'deployment_type': 'str'
+        }
+
+        self.attribute_map = {
+            'deployment_type': 'deploymentType'
+        }
+
+        self._deployment_type = None
+
+    @staticmethod
+    def get_subtype(object_dictionary):
+        """
+        Given the hash representation of a subtype of this class,
+        use the info in the hash to return the class of the subtype.
+        """
+        type = object_dictionary['deploymentType']
+
+        if type == 'SINGLE_MODEL':
+            return 'SingleModelDeploymentConfigurationDetails'
+        else:
+            return 'ModelDeploymentConfigurationDetails'
+
+    @property
+    def deployment_type(self):
+        """
+        **[Required]** Gets the deployment_type of this ModelDeploymentConfigurationDetails.
+        The type of the model deployment.
+
+        Allowed values for this property are: "SINGLE_MODEL", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The deployment_type of this ModelDeploymentConfigurationDetails.
+        :rtype: str
+        """
+        return self._deployment_type
+
+    @deployment_type.setter
+    def deployment_type(self, deployment_type):
+        """
+        Sets the deployment_type of this ModelDeploymentConfigurationDetails.
+        The type of the model deployment.
+
+
+        :param deployment_type: The deployment_type of this ModelDeploymentConfigurationDetails.
+        :type: str
+        """
+        allowed_values = ["SINGLE_MODEL"]
+        if not value_allowed_none_or_none_sentinel(deployment_type, allowed_values):
+            deployment_type = 'UNKNOWN_ENUM_VALUE'
+        self._deployment_type = deployment_type
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_science/models/model_deployment_shape_summary.py
+++ b/src/oci/data_science/models/model_deployment_shape_summary.py
@@ -1,0 +1,132 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ModelDeploymentShapeSummary(object):
+    """
+    The compute shape used to launch a model deployment compute instance.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ModelDeploymentShapeSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param name:
+            The value to assign to the name property of this ModelDeploymentShapeSummary.
+        :type name: str
+
+        :param core_count:
+            The value to assign to the core_count property of this ModelDeploymentShapeSummary.
+        :type core_count: int
+
+        :param memory_in_gbs:
+            The value to assign to the memory_in_gbs property of this ModelDeploymentShapeSummary.
+        :type memory_in_gbs: int
+
+        """
+        self.swagger_types = {
+            'name': 'str',
+            'core_count': 'int',
+            'memory_in_gbs': 'int'
+        }
+
+        self.attribute_map = {
+            'name': 'name',
+            'core_count': 'coreCount',
+            'memory_in_gbs': 'memoryInGBs'
+        }
+
+        self._name = None
+        self._core_count = None
+        self._memory_in_gbs = None
+
+    @property
+    def name(self):
+        """
+        **[Required]** Gets the name of this ModelDeploymentShapeSummary.
+        The name of the model deployment shape.
+
+
+        :return: The name of this ModelDeploymentShapeSummary.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this ModelDeploymentShapeSummary.
+        The name of the model deployment shape.
+
+
+        :param name: The name of this ModelDeploymentShapeSummary.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def core_count(self):
+        """
+        **[Required]** Gets the core_count of this ModelDeploymentShapeSummary.
+        The number of cores associated with this model deployment shape.
+
+
+        :return: The core_count of this ModelDeploymentShapeSummary.
+        :rtype: int
+        """
+        return self._core_count
+
+    @core_count.setter
+    def core_count(self, core_count):
+        """
+        Sets the core_count of this ModelDeploymentShapeSummary.
+        The number of cores associated with this model deployment shape.
+
+
+        :param core_count: The core_count of this ModelDeploymentShapeSummary.
+        :type: int
+        """
+        self._core_count = core_count
+
+    @property
+    def memory_in_gbs(self):
+        """
+        **[Required]** Gets the memory_in_gbs of this ModelDeploymentShapeSummary.
+        The amount of memory in GBs associated with this model deployment shape.
+
+
+        :return: The memory_in_gbs of this ModelDeploymentShapeSummary.
+        :rtype: int
+        """
+        return self._memory_in_gbs
+
+    @memory_in_gbs.setter
+    def memory_in_gbs(self, memory_in_gbs):
+        """
+        Sets the memory_in_gbs of this ModelDeploymentShapeSummary.
+        The amount of memory in GBs associated with this model deployment shape.
+
+
+        :param memory_in_gbs: The memory_in_gbs of this ModelDeploymentShapeSummary.
+        :type: int
+        """
+        self._memory_in_gbs = memory_in_gbs
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_science/models/model_deployment_summary.py
+++ b/src/oci/data_science/models/model_deployment_summary.py
@@ -1,0 +1,510 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ModelDeploymentSummary(object):
+    """
+    Summary information for a model deployment.
+    """
+
+    #: A constant which can be used with the lifecycle_state property of a ModelDeploymentSummary.
+    #: This constant has a value of "CREATING"
+    LIFECYCLE_STATE_CREATING = "CREATING"
+
+    #: A constant which can be used with the lifecycle_state property of a ModelDeploymentSummary.
+    #: This constant has a value of "ACTIVE"
+    LIFECYCLE_STATE_ACTIVE = "ACTIVE"
+
+    #: A constant which can be used with the lifecycle_state property of a ModelDeploymentSummary.
+    #: This constant has a value of "DELETING"
+    LIFECYCLE_STATE_DELETING = "DELETING"
+
+    #: A constant which can be used with the lifecycle_state property of a ModelDeploymentSummary.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    #: A constant which can be used with the lifecycle_state property of a ModelDeploymentSummary.
+    #: This constant has a value of "INACTIVE"
+    LIFECYCLE_STATE_INACTIVE = "INACTIVE"
+
+    #: A constant which can be used with the lifecycle_state property of a ModelDeploymentSummary.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a ModelDeploymentSummary.
+    #: This constant has a value of "DELETED"
+    LIFECYCLE_STATE_DELETED = "DELETED"
+
+    #: A constant which can be used with the lifecycle_state property of a ModelDeploymentSummary.
+    #: This constant has a value of "NEEDS_ATTENTION"
+    LIFECYCLE_STATE_NEEDS_ATTENTION = "NEEDS_ATTENTION"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ModelDeploymentSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this ModelDeploymentSummary.
+        :type id: str
+
+        :param time_created:
+            The value to assign to the time_created property of this ModelDeploymentSummary.
+        :type time_created: datetime
+
+        :param display_name:
+            The value to assign to the display_name property of this ModelDeploymentSummary.
+        :type display_name: str
+
+        :param description:
+            The value to assign to the description property of this ModelDeploymentSummary.
+        :type description: str
+
+        :param project_id:
+            The value to assign to the project_id property of this ModelDeploymentSummary.
+        :type project_id: str
+
+        :param created_by:
+            The value to assign to the created_by property of this ModelDeploymentSummary.
+        :type created_by: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ModelDeploymentSummary.
+        :type compartment_id: str
+
+        :param model_deployment_configuration_details:
+            The value to assign to the model_deployment_configuration_details property of this ModelDeploymentSummary.
+        :type model_deployment_configuration_details: oci.data_science.models.ModelDeploymentConfigurationDetails
+
+        :param category_log_details:
+            The value to assign to the category_log_details property of this ModelDeploymentSummary.
+        :type category_log_details: oci.data_science.models.CategoryLogDetails
+
+        :param model_deployment_url:
+            The value to assign to the model_deployment_url property of this ModelDeploymentSummary.
+        :type model_deployment_url: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this ModelDeploymentSummary.
+            Allowed values for this property are: "CREATING", "ACTIVE", "DELETING", "FAILED", "INACTIVE", "UPDATING", "DELETED", "NEEDS_ATTENTION", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this ModelDeploymentSummary.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this ModelDeploymentSummary.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'time_created': 'datetime',
+            'display_name': 'str',
+            'description': 'str',
+            'project_id': 'str',
+            'created_by': 'str',
+            'compartment_id': 'str',
+            'model_deployment_configuration_details': 'ModelDeploymentConfigurationDetails',
+            'category_log_details': 'CategoryLogDetails',
+            'model_deployment_url': 'str',
+            'lifecycle_state': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'time_created': 'timeCreated',
+            'display_name': 'displayName',
+            'description': 'description',
+            'project_id': 'projectId',
+            'created_by': 'createdBy',
+            'compartment_id': 'compartmentId',
+            'model_deployment_configuration_details': 'modelDeploymentConfigurationDetails',
+            'category_log_details': 'categoryLogDetails',
+            'model_deployment_url': 'modelDeploymentUrl',
+            'lifecycle_state': 'lifecycleState',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._id = None
+        self._time_created = None
+        self._display_name = None
+        self._description = None
+        self._project_id = None
+        self._created_by = None
+        self._compartment_id = None
+        self._model_deployment_configuration_details = None
+        self._category_log_details = None
+        self._model_deployment_url = None
+        self._lifecycle_state = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this ModelDeploymentSummary.
+        The `OCID`__ of the model deployment.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :return: The id of this ModelDeploymentSummary.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this ModelDeploymentSummary.
+        The `OCID`__ of the model deployment.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :param id: The id of this ModelDeploymentSummary.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def time_created(self):
+        """
+        **[Required]** Gets the time_created of this ModelDeploymentSummary.
+        The date and time the resource was created, in the timestamp format defined by `RFC3339`__.
+        Example: 2019-08-25T21:10:29.41Z
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :return: The time_created of this ModelDeploymentSummary.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this ModelDeploymentSummary.
+        The date and time the resource was created, in the timestamp format defined by `RFC3339`__.
+        Example: 2019-08-25T21:10:29.41Z
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :param time_created: The time_created of this ModelDeploymentSummary.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this ModelDeploymentSummary.
+        A user-friendly display name for the resource. Does not have to be unique, and can be modified. Avoid entering confidential information.
+        Example: `My ModelDeployment`
+
+
+        :return: The display_name of this ModelDeploymentSummary.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this ModelDeploymentSummary.
+        A user-friendly display name for the resource. Does not have to be unique, and can be modified. Avoid entering confidential information.
+        Example: `My ModelDeployment`
+
+
+        :param display_name: The display_name of this ModelDeploymentSummary.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def description(self):
+        """
+        Gets the description of this ModelDeploymentSummary.
+        A short description of the model deployment.
+
+
+        :return: The description of this ModelDeploymentSummary.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this ModelDeploymentSummary.
+        A short description of the model deployment.
+
+
+        :param description: The description of this ModelDeploymentSummary.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def project_id(self):
+        """
+        **[Required]** Gets the project_id of this ModelDeploymentSummary.
+        The `OCID`__ of the project associated with the model deployment.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :return: The project_id of this ModelDeploymentSummary.
+        :rtype: str
+        """
+        return self._project_id
+
+    @project_id.setter
+    def project_id(self, project_id):
+        """
+        Sets the project_id of this ModelDeploymentSummary.
+        The `OCID`__ of the project associated with the model deployment.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :param project_id: The project_id of this ModelDeploymentSummary.
+        :type: str
+        """
+        self._project_id = project_id
+
+    @property
+    def created_by(self):
+        """
+        **[Required]** Gets the created_by of this ModelDeploymentSummary.
+        The `OCID`__ of the user who created the model deployment.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :return: The created_by of this ModelDeploymentSummary.
+        :rtype: str
+        """
+        return self._created_by
+
+    @created_by.setter
+    def created_by(self, created_by):
+        """
+        Sets the created_by of this ModelDeploymentSummary.
+        The `OCID`__ of the user who created the model deployment.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :param created_by: The created_by of this ModelDeploymentSummary.
+        :type: str
+        """
+        self._created_by = created_by
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this ModelDeploymentSummary.
+        The `OCID`__ of the model deployment's compartment.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :return: The compartment_id of this ModelDeploymentSummary.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this ModelDeploymentSummary.
+        The `OCID`__ of the model deployment's compartment.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :param compartment_id: The compartment_id of this ModelDeploymentSummary.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def model_deployment_configuration_details(self):
+        """
+        Gets the model_deployment_configuration_details of this ModelDeploymentSummary.
+
+        :return: The model_deployment_configuration_details of this ModelDeploymentSummary.
+        :rtype: oci.data_science.models.ModelDeploymentConfigurationDetails
+        """
+        return self._model_deployment_configuration_details
+
+    @model_deployment_configuration_details.setter
+    def model_deployment_configuration_details(self, model_deployment_configuration_details):
+        """
+        Sets the model_deployment_configuration_details of this ModelDeploymentSummary.
+
+        :param model_deployment_configuration_details: The model_deployment_configuration_details of this ModelDeploymentSummary.
+        :type: oci.data_science.models.ModelDeploymentConfigurationDetails
+        """
+        self._model_deployment_configuration_details = model_deployment_configuration_details
+
+    @property
+    def category_log_details(self):
+        """
+        Gets the category_log_details of this ModelDeploymentSummary.
+
+        :return: The category_log_details of this ModelDeploymentSummary.
+        :rtype: oci.data_science.models.CategoryLogDetails
+        """
+        return self._category_log_details
+
+    @category_log_details.setter
+    def category_log_details(self, category_log_details):
+        """
+        Sets the category_log_details of this ModelDeploymentSummary.
+
+        :param category_log_details: The category_log_details of this ModelDeploymentSummary.
+        :type: oci.data_science.models.CategoryLogDetails
+        """
+        self._category_log_details = category_log_details
+
+    @property
+    def model_deployment_url(self):
+        """
+        **[Required]** Gets the model_deployment_url of this ModelDeploymentSummary.
+        The URL to interact with the model deployment.
+
+
+        :return: The model_deployment_url of this ModelDeploymentSummary.
+        :rtype: str
+        """
+        return self._model_deployment_url
+
+    @model_deployment_url.setter
+    def model_deployment_url(self, model_deployment_url):
+        """
+        Sets the model_deployment_url of this ModelDeploymentSummary.
+        The URL to interact with the model deployment.
+
+
+        :param model_deployment_url: The model_deployment_url of this ModelDeploymentSummary.
+        :type: str
+        """
+        self._model_deployment_url = model_deployment_url
+
+    @property
+    def lifecycle_state(self):
+        """
+        **[Required]** Gets the lifecycle_state of this ModelDeploymentSummary.
+        The state of the model deployment.
+
+        Allowed values for this property are: "CREATING", "ACTIVE", "DELETING", "FAILED", "INACTIVE", "UPDATING", "DELETED", "NEEDS_ATTENTION", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this ModelDeploymentSummary.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this ModelDeploymentSummary.
+        The state of the model deployment.
+
+
+        :param lifecycle_state: The lifecycle_state of this ModelDeploymentSummary.
+        :type: str
+        """
+        allowed_values = ["CREATING", "ACTIVE", "DELETING", "FAILED", "INACTIVE", "UPDATING", "DELETED", "NEEDS_ATTENTION"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this ModelDeploymentSummary.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. See `Resource Tags`__.
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this ModelDeploymentSummary.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this ModelDeploymentSummary.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. See `Resource Tags`__.
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this ModelDeploymentSummary.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this ModelDeploymentSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace. See `Resource Tags`__.
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this ModelDeploymentSummary.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this ModelDeploymentSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace. See `Resource Tags`__.
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this ModelDeploymentSummary.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_science/models/model_summary.py
+++ b/src/oci/data_science/models/model_summary.py
@@ -113,7 +113,7 @@ class ModelSummary(object):
         **[Required]** Gets the compartment_id of this ModelSummary.
         The `OCID`__ of the model's compartment.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :return: The compartment_id of this ModelSummary.
@@ -127,7 +127,7 @@ class ModelSummary(object):
         Sets the compartment_id of this ModelSummary.
         The `OCID`__ of the model's compartment.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :param compartment_id: The compartment_id of this ModelSummary.
@@ -141,7 +141,7 @@ class ModelSummary(object):
         **[Required]** Gets the project_id of this ModelSummary.
         The `OCID`__ of the project associated with the model.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :return: The project_id of this ModelSummary.
@@ -155,7 +155,7 @@ class ModelSummary(object):
         Sets the project_id of this ModelSummary.
         The `OCID`__ of the project associated with the model.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :param project_id: The project_id of this ModelSummary.
@@ -169,7 +169,7 @@ class ModelSummary(object):
         **[Required]** Gets the id of this ModelSummary.
         The `OCID`__ of the model.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :return: The id of this ModelSummary.
@@ -183,7 +183,7 @@ class ModelSummary(object):
         Sets the id of this ModelSummary.
         The `OCID`__ of the model.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :param id: The id of this ModelSummary.
@@ -195,7 +195,7 @@ class ModelSummary(object):
     def display_name(self):
         """
         **[Required]** Gets the display_name of this ModelSummary.
-        A user-friendly display name for the resource. Does not have to be unique, and can be modified. Avoid entering confidential information.
+        A user-friendly display name for the resource. It does not have to be unique and can be modified. Avoid entering confidential information.
 
 
         :return: The display_name of this ModelSummary.
@@ -207,7 +207,7 @@ class ModelSummary(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this ModelSummary.
-        A user-friendly display name for the resource. Does not have to be unique, and can be modified. Avoid entering confidential information.
+        A user-friendly display name for the resource. It does not have to be unique and can be modified. Avoid entering confidential information.
 
 
         :param display_name: The display_name of this ModelSummary.
@@ -221,7 +221,7 @@ class ModelSummary(object):
         **[Required]** Gets the created_by of this ModelSummary.
         The `OCID`__ of the user who created the model.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :return: The created_by of this ModelSummary.
@@ -235,7 +235,7 @@ class ModelSummary(object):
         Sets the created_by of this ModelSummary.
         The `OCID`__ of the user who created the model.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :param created_by: The created_by of this ModelSummary.
@@ -247,7 +247,7 @@ class ModelSummary(object):
     def time_created(self):
         """
         **[Required]** Gets the time_created of this ModelSummary.
-        The date and time the resource was created, in the timestamp format defined by `RFC3339`__.
+        The date and time the resource was created in the timestamp format defined by `RFC3339`__.
         Example: 2019-08-25T21:10:29.41Z
 
         __ https://tools.ietf.org/html/rfc3339
@@ -262,7 +262,7 @@ class ModelSummary(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this ModelSummary.
-        The date and time the resource was created, in the timestamp format defined by `RFC3339`__.
+        The date and time the resource was created in the timestamp format defined by `RFC3339`__.
         Example: 2019-08-25T21:10:29.41Z
 
         __ https://tools.ietf.org/html/rfc3339

--- a/src/oci/data_science/models/notebook_session.py
+++ b/src/oci/data_science/models/notebook_session.py
@@ -146,7 +146,7 @@ class NotebookSession(object):
         **[Required]** Gets the id of this NotebookSession.
         The `OCID`__ of the notebook session.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :return: The id of this NotebookSession.
@@ -160,7 +160,7 @@ class NotebookSession(object):
         Sets the id of this NotebookSession.
         The `OCID`__ of the notebook session.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :param id: The id of this NotebookSession.
@@ -172,7 +172,7 @@ class NotebookSession(object):
     def time_created(self):
         """
         **[Required]** Gets the time_created of this NotebookSession.
-        The date and time the resource was created, in the timestamp format defined by `RFC3339`__.
+        The date and time the resource was created in the timestamp format defined by `RFC3339`__.
         Example: 2019-08-25T21:10:29.41Z
 
         __ https://tools.ietf.org/html/rfc3339
@@ -187,7 +187,7 @@ class NotebookSession(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this NotebookSession.
-        The date and time the resource was created, in the timestamp format defined by `RFC3339`__.
+        The date and time the resource was created in the timestamp format defined by `RFC3339`__.
         Example: 2019-08-25T21:10:29.41Z
 
         __ https://tools.ietf.org/html/rfc3339
@@ -202,7 +202,7 @@ class NotebookSession(object):
     def display_name(self):
         """
         **[Required]** Gets the display_name of this NotebookSession.
-        A user-friendly display name for the resource. Does not have to be unique, and can be modified. Avoid entering confidential information.
+        A user-friendly display name for the resource. It does not have to be unique and can be modified. Avoid entering confidential information.
         Example: `My NotebookSession`
 
 
@@ -215,7 +215,7 @@ class NotebookSession(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this NotebookSession.
-        A user-friendly display name for the resource. Does not have to be unique, and can be modified. Avoid entering confidential information.
+        A user-friendly display name for the resource. It does not have to be unique and can be modified. Avoid entering confidential information.
         Example: `My NotebookSession`
 
 
@@ -230,7 +230,7 @@ class NotebookSession(object):
         **[Required]** Gets the project_id of this NotebookSession.
         The `OCID`__ of the project associated with the notebook session.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :return: The project_id of this NotebookSession.
@@ -244,7 +244,7 @@ class NotebookSession(object):
         Sets the project_id of this NotebookSession.
         The `OCID`__ of the project associated with the notebook session.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :param project_id: The project_id of this NotebookSession.
@@ -258,7 +258,7 @@ class NotebookSession(object):
         **[Required]** Gets the created_by of this NotebookSession.
         The `OCID`__ of the user who created the notebook session.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :return: The created_by of this NotebookSession.
@@ -272,7 +272,7 @@ class NotebookSession(object):
         Sets the created_by of this NotebookSession.
         The `OCID`__ of the user who created the notebook session.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :param created_by: The created_by of this NotebookSession.
@@ -286,7 +286,7 @@ class NotebookSession(object):
         **[Required]** Gets the compartment_id of this NotebookSession.
         The `OCID`__ of the notebook session's compartment.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :return: The compartment_id of this NotebookSession.
@@ -300,7 +300,7 @@ class NotebookSession(object):
         Sets the compartment_id of this NotebookSession.
         The `OCID`__ of the notebook session's compartment.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :param compartment_id: The compartment_id of this NotebookSession.

--- a/src/oci/data_science/models/notebook_session_configuration_details.py
+++ b/src/oci/data_science/models/notebook_session_configuration_details.py
@@ -51,7 +51,7 @@ class NotebookSessionConfigurationDetails(object):
     def shape(self):
         """
         **[Required]** Gets the shape of this NotebookSessionConfigurationDetails.
-        The shape used to launch the notebook session compute instance.  The list of available shapes in a given compartment can be retrieved from the `ListNotebookSessionShapes` endpoint.
+        The shape used to launch the notebook session compute instance.  The list of available shapes in a given compartment can be retrieved using the `ListNotebookSessionShapes` endpoint.
 
 
         :return: The shape of this NotebookSessionConfigurationDetails.
@@ -63,7 +63,7 @@ class NotebookSessionConfigurationDetails(object):
     def shape(self, shape):
         """
         Sets the shape of this NotebookSessionConfigurationDetails.
-        The shape used to launch the notebook session compute instance.  The list of available shapes in a given compartment can be retrieved from the `ListNotebookSessionShapes` endpoint.
+        The shape used to launch the notebook session compute instance.  The list of available shapes in a given compartment can be retrieved using the `ListNotebookSessionShapes` endpoint.
 
 
         :param shape: The shape of this NotebookSessionConfigurationDetails.
@@ -101,7 +101,7 @@ class NotebookSessionConfigurationDetails(object):
         **[Required]** Gets the subnet_id of this NotebookSessionConfigurationDetails.
         A notebook session instance is provided with a VNIC for network access.  This specifies the `OCID`__ of the subnet to create a VNIC in.  The subnet should be in a VCN with a NAT gateway for egress to the internet.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :return: The subnet_id of this NotebookSessionConfigurationDetails.
@@ -115,7 +115,7 @@ class NotebookSessionConfigurationDetails(object):
         Sets the subnet_id of this NotebookSessionConfigurationDetails.
         A notebook session instance is provided with a VNIC for network access.  This specifies the `OCID`__ of the subnet to create a VNIC in.  The subnet should be in a VCN with a NAT gateway for egress to the internet.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :param subnet_id: The subnet_id of this NotebookSessionConfigurationDetails.

--- a/src/oci/data_science/models/notebook_session_summary.py
+++ b/src/oci/data_science/models/notebook_session_summary.py
@@ -139,7 +139,7 @@ class NotebookSessionSummary(object):
         **[Required]** Gets the id of this NotebookSessionSummary.
         The `OCID`__ of the notebook session.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :return: The id of this NotebookSessionSummary.
@@ -153,7 +153,7 @@ class NotebookSessionSummary(object):
         Sets the id of this NotebookSessionSummary.
         The `OCID`__ of the notebook session.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :param id: The id of this NotebookSessionSummary.
@@ -165,7 +165,7 @@ class NotebookSessionSummary(object):
     def time_created(self):
         """
         **[Required]** Gets the time_created of this NotebookSessionSummary.
-        The date and time the resource was created, in the timestamp format defined by `RFC3339`__.
+        The date and time the resource was created in the timestamp format defined by `RFC3339`__.
         Example: 2019-08-25T21:10:29.41Z
 
         __ https://tools.ietf.org/html/rfc3339
@@ -180,7 +180,7 @@ class NotebookSessionSummary(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this NotebookSessionSummary.
-        The date and time the resource was created, in the timestamp format defined by `RFC3339`__.
+        The date and time the resource was created in the timestamp format defined by `RFC3339`__.
         Example: 2019-08-25T21:10:29.41Z
 
         __ https://tools.ietf.org/html/rfc3339
@@ -195,7 +195,7 @@ class NotebookSessionSummary(object):
     def display_name(self):
         """
         **[Required]** Gets the display_name of this NotebookSessionSummary.
-        A user-friendly display name for the resource. Does not have to be unique, and can be modified. Avoid entering confidential information.
+        A user-friendly display name for the resource. It does not have to be unique and can be modified. Avoid entering confidential information.
         Example: `My NotebookSession`
 
 
@@ -208,7 +208,7 @@ class NotebookSessionSummary(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this NotebookSessionSummary.
-        A user-friendly display name for the resource. Does not have to be unique, and can be modified. Avoid entering confidential information.
+        A user-friendly display name for the resource. It does not have to be unique and can be modified. Avoid entering confidential information.
         Example: `My NotebookSession`
 
 
@@ -223,7 +223,7 @@ class NotebookSessionSummary(object):
         **[Required]** Gets the project_id of this NotebookSessionSummary.
         The `OCID`__ of the project associated with the notebook session.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :return: The project_id of this NotebookSessionSummary.
@@ -237,7 +237,7 @@ class NotebookSessionSummary(object):
         Sets the project_id of this NotebookSessionSummary.
         The `OCID`__ of the project associated with the notebook session.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :param project_id: The project_id of this NotebookSessionSummary.
@@ -251,7 +251,7 @@ class NotebookSessionSummary(object):
         **[Required]** Gets the created_by of this NotebookSessionSummary.
         The `OCID`__ of the user who created the notebook session.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :return: The created_by of this NotebookSessionSummary.
@@ -265,7 +265,7 @@ class NotebookSessionSummary(object):
         Sets the created_by of this NotebookSessionSummary.
         The `OCID`__ of the user who created the notebook session.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :param created_by: The created_by of this NotebookSessionSummary.
@@ -279,7 +279,7 @@ class NotebookSessionSummary(object):
         **[Required]** Gets the compartment_id of this NotebookSessionSummary.
         The `OCID`__ of the notebook session's compartment.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :return: The compartment_id of this NotebookSessionSummary.
@@ -293,7 +293,7 @@ class NotebookSessionSummary(object):
         Sets the compartment_id of this NotebookSessionSummary.
         The `OCID`__ of the notebook session's compartment.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :param compartment_id: The compartment_id of this NotebookSessionSummary.

--- a/src/oci/data_science/models/project.py
+++ b/src/oci/data_science/models/project.py
@@ -109,7 +109,7 @@ class Project(object):
         **[Required]** Gets the id of this Project.
         The `OCID`__ of the project.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :return: The id of this Project.
@@ -123,7 +123,7 @@ class Project(object):
         Sets the id of this Project.
         The `OCID`__ of the project.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :param id: The id of this Project.
@@ -135,7 +135,7 @@ class Project(object):
     def time_created(self):
         """
         **[Required]** Gets the time_created of this Project.
-        The date and time the resource was created, in the timestamp format defined by `RFC3339`__.
+        The date and time the resource was created in the timestamp format defined by `RFC3339`__.
         Example: 2019-08-25T21:10:29.41Z
 
         __ https://tools.ietf.org/html/rfc3339
@@ -150,7 +150,7 @@ class Project(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this Project.
-        The date and time the resource was created, in the timestamp format defined by `RFC3339`__.
+        The date and time the resource was created in the timestamp format defined by `RFC3339`__.
         Example: 2019-08-25T21:10:29.41Z
 
         __ https://tools.ietf.org/html/rfc3339
@@ -165,7 +165,7 @@ class Project(object):
     def display_name(self):
         """
         **[Required]** Gets the display_name of this Project.
-        A user-friendly display name for the resource. Does not have to be unique, and can be modified. Avoid entering confidential information.
+        A user-friendly display name for the resource. It does not have to be unique and can be modified. Avoid entering confidential information.
 
 
         :return: The display_name of this Project.
@@ -177,7 +177,7 @@ class Project(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this Project.
-        A user-friendly display name for the resource. Does not have to be unique, and can be modified. Avoid entering confidential information.
+        A user-friendly display name for the resource. It does not have to be unique and can be modified. Avoid entering confidential information.
 
 
         :param display_name: The display_name of this Project.
@@ -189,7 +189,7 @@ class Project(object):
     def description(self):
         """
         Gets the description of this Project.
-        A short blurb describing the project.
+        A short description of the project.
 
 
         :return: The description of this Project.
@@ -201,7 +201,7 @@ class Project(object):
     def description(self, description):
         """
         Sets the description of this Project.
-        A short blurb describing the project.
+        A short description of the project.
 
 
         :param description: The description of this Project.
@@ -215,7 +215,7 @@ class Project(object):
         **[Required]** Gets the compartment_id of this Project.
         The `OCID`__ of the project's compartment.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :return: The compartment_id of this Project.
@@ -229,7 +229,7 @@ class Project(object):
         Sets the compartment_id of this Project.
         The `OCID`__ of the project's compartment.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :param compartment_id: The compartment_id of this Project.
@@ -243,7 +243,7 @@ class Project(object):
         **[Required]** Gets the created_by of this Project.
         The `OCID`__ of the user who created this project.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :return: The created_by of this Project.
@@ -257,7 +257,7 @@ class Project(object):
         Sets the created_by of this Project.
         The `OCID`__ of the user who created this project.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :param created_by: The created_by of this Project.

--- a/src/oci/data_science/models/project_summary.py
+++ b/src/oci/data_science/models/project_summary.py
@@ -109,7 +109,7 @@ class ProjectSummary(object):
         **[Required]** Gets the id of this ProjectSummary.
         The `OCID`__ of the project.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :return: The id of this ProjectSummary.
@@ -123,7 +123,7 @@ class ProjectSummary(object):
         Sets the id of this ProjectSummary.
         The `OCID`__ of the project.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :param id: The id of this ProjectSummary.
@@ -135,7 +135,7 @@ class ProjectSummary(object):
     def time_created(self):
         """
         **[Required]** Gets the time_created of this ProjectSummary.
-        The date and time the resource was created, in the timestamp format defined by `RFC3339`__.
+        The date and time the resource was created in the timestamp format defined by `RFC3339`__.
         Example: 2019-08-25T21:10:29.41Z
 
         __ https://tools.ietf.org/html/rfc3339
@@ -150,7 +150,7 @@ class ProjectSummary(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this ProjectSummary.
-        The date and time the resource was created, in the timestamp format defined by `RFC3339`__.
+        The date and time the resource was created in the timestamp format defined by `RFC3339`__.
         Example: 2019-08-25T21:10:29.41Z
 
         __ https://tools.ietf.org/html/rfc3339
@@ -165,7 +165,7 @@ class ProjectSummary(object):
     def display_name(self):
         """
         **[Required]** Gets the display_name of this ProjectSummary.
-        A user-friendly display name for the resource. Does not have to be unique, and can be modified. Avoid entering confidential information.
+        A user-friendly display name for the resource. It does not have to be unique and can be modified. Avoid entering confidential information.
 
 
         :return: The display_name of this ProjectSummary.
@@ -177,7 +177,7 @@ class ProjectSummary(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this ProjectSummary.
-        A user-friendly display name for the resource. Does not have to be unique, and can be modified. Avoid entering confidential information.
+        A user-friendly display name for the resource. It does not have to be unique and can be modified. Avoid entering confidential information.
 
 
         :param display_name: The display_name of this ProjectSummary.
@@ -189,7 +189,7 @@ class ProjectSummary(object):
     def description(self):
         """
         Gets the description of this ProjectSummary.
-        A short blurb describing the project.
+        A short description of the project.
 
 
         :return: The description of this ProjectSummary.
@@ -201,7 +201,7 @@ class ProjectSummary(object):
     def description(self, description):
         """
         Sets the description of this ProjectSummary.
-        A short blurb describing the project.
+        A short description of the project.
 
 
         :param description: The description of this ProjectSummary.
@@ -215,7 +215,7 @@ class ProjectSummary(object):
         **[Required]** Gets the compartment_id of this ProjectSummary.
         The `OCID`__ of the project's compartment.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :return: The compartment_id of this ProjectSummary.
@@ -229,7 +229,7 @@ class ProjectSummary(object):
         Sets the compartment_id of this ProjectSummary.
         The `OCID`__ of the project's compartment.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :param compartment_id: The compartment_id of this ProjectSummary.
@@ -241,9 +241,9 @@ class ProjectSummary(object):
     def created_by(self):
         """
         **[Required]** Gets the created_by of this ProjectSummary.
-        The `OCID`__ of the user who created this project.
+        The `OCID`__ of the user who created the project.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :return: The created_by of this ProjectSummary.
@@ -255,9 +255,9 @@ class ProjectSummary(object):
     def created_by(self, created_by):
         """
         Sets the created_by of this ProjectSummary.
-        The `OCID`__ of the user who created this project.
+        The `OCID`__ of the user who created the project.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :param created_by: The created_by of this ProjectSummary.

--- a/src/oci/data_science/models/scaling_policy.py
+++ b/src/oci/data_science/models/scaling_policy.py
@@ -1,0 +1,99 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ScalingPolicy(object):
+    """
+    The scaling policy to apply to each model of the deployment.
+    """
+
+    #: A constant which can be used with the policy_type property of a ScalingPolicy.
+    #: This constant has a value of "FIXED_SIZE"
+    POLICY_TYPE_FIXED_SIZE = "FIXED_SIZE"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ScalingPolicy object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
+        to a service operations then you should favor using a subclass over the base class:
+
+        * :class:`~oci.data_science.models.FixedSizeScalingPolicy`
+
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param policy_type:
+            The value to assign to the policy_type property of this ScalingPolicy.
+            Allowed values for this property are: "FIXED_SIZE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type policy_type: str
+
+        """
+        self.swagger_types = {
+            'policy_type': 'str'
+        }
+
+        self.attribute_map = {
+            'policy_type': 'policyType'
+        }
+
+        self._policy_type = None
+
+    @staticmethod
+    def get_subtype(object_dictionary):
+        """
+        Given the hash representation of a subtype of this class,
+        use the info in the hash to return the class of the subtype.
+        """
+        type = object_dictionary['policyType']
+
+        if type == 'FIXED_SIZE':
+            return 'FixedSizeScalingPolicy'
+        else:
+            return 'ScalingPolicy'
+
+    @property
+    def policy_type(self):
+        """
+        **[Required]** Gets the policy_type of this ScalingPolicy.
+        The type of scaling policy.
+
+        Allowed values for this property are: "FIXED_SIZE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The policy_type of this ScalingPolicy.
+        :rtype: str
+        """
+        return self._policy_type
+
+    @policy_type.setter
+    def policy_type(self, policy_type):
+        """
+        Sets the policy_type of this ScalingPolicy.
+        The type of scaling policy.
+
+
+        :param policy_type: The policy_type of this ScalingPolicy.
+        :type: str
+        """
+        allowed_values = ["FIXED_SIZE"]
+        if not value_allowed_none_or_none_sentinel(policy_type, allowed_values):
+            policy_type = 'UNKNOWN_ENUM_VALUE'
+        self._policy_type = policy_type
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_science/models/single_model_deployment_configuration_details.py
+++ b/src/oci/data_science/models/single_model_deployment_configuration_details.py
@@ -1,0 +1,76 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .model_deployment_configuration_details import ModelDeploymentConfigurationDetails
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class SingleModelDeploymentConfigurationDetails(ModelDeploymentConfigurationDetails):
+    """
+    The single model type deployment.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new SingleModelDeploymentConfigurationDetails object with values from keyword arguments. The default value of the :py:attr:`~oci.data_science.models.SingleModelDeploymentConfigurationDetails.deployment_type` attribute
+        of this class is ``SINGLE_MODEL`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param deployment_type:
+            The value to assign to the deployment_type property of this SingleModelDeploymentConfigurationDetails.
+            Allowed values for this property are: "SINGLE_MODEL"
+        :type deployment_type: str
+
+        :param model_configuration_details:
+            The value to assign to the model_configuration_details property of this SingleModelDeploymentConfigurationDetails.
+        :type model_configuration_details: oci.data_science.models.ModelConfigurationDetails
+
+        """
+        self.swagger_types = {
+            'deployment_type': 'str',
+            'model_configuration_details': 'ModelConfigurationDetails'
+        }
+
+        self.attribute_map = {
+            'deployment_type': 'deploymentType',
+            'model_configuration_details': 'modelConfigurationDetails'
+        }
+
+        self._deployment_type = None
+        self._model_configuration_details = None
+        self._deployment_type = 'SINGLE_MODEL'
+
+    @property
+    def model_configuration_details(self):
+        """
+        **[Required]** Gets the model_configuration_details of this SingleModelDeploymentConfigurationDetails.
+
+        :return: The model_configuration_details of this SingleModelDeploymentConfigurationDetails.
+        :rtype: oci.data_science.models.ModelConfigurationDetails
+        """
+        return self._model_configuration_details
+
+    @model_configuration_details.setter
+    def model_configuration_details(self, model_configuration_details):
+        """
+        Sets the model_configuration_details of this SingleModelDeploymentConfigurationDetails.
+
+        :param model_configuration_details: The model_configuration_details of this SingleModelDeploymentConfigurationDetails.
+        :type: oci.data_science.models.ModelConfigurationDetails
+        """
+        self._model_configuration_details = model_configuration_details
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_science/models/update_category_log_details.py
+++ b/src/oci/data_science/models/update_category_log_details.py
@@ -1,0 +1,93 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateCategoryLogDetails(object):
+    """
+    The log details for each category for update.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateCategoryLogDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param access:
+            The value to assign to the access property of this UpdateCategoryLogDetails.
+        :type access: oci.data_science.models.LogDetails
+
+        :param predict:
+            The value to assign to the predict property of this UpdateCategoryLogDetails.
+        :type predict: oci.data_science.models.LogDetails
+
+        """
+        self.swagger_types = {
+            'access': 'LogDetails',
+            'predict': 'LogDetails'
+        }
+
+        self.attribute_map = {
+            'access': 'access',
+            'predict': 'predict'
+        }
+
+        self._access = None
+        self._predict = None
+
+    @property
+    def access(self):
+        """
+        Gets the access of this UpdateCategoryLogDetails.
+
+        :return: The access of this UpdateCategoryLogDetails.
+        :rtype: oci.data_science.models.LogDetails
+        """
+        return self._access
+
+    @access.setter
+    def access(self, access):
+        """
+        Sets the access of this UpdateCategoryLogDetails.
+
+        :param access: The access of this UpdateCategoryLogDetails.
+        :type: oci.data_science.models.LogDetails
+        """
+        self._access = access
+
+    @property
+    def predict(self):
+        """
+        Gets the predict of this UpdateCategoryLogDetails.
+
+        :return: The predict of this UpdateCategoryLogDetails.
+        :rtype: oci.data_science.models.LogDetails
+        """
+        return self._predict
+
+    @predict.setter
+    def predict(self, predict):
+        """
+        Sets the predict of this UpdateCategoryLogDetails.
+
+        :param predict: The predict of this UpdateCategoryLogDetails.
+        :type: oci.data_science.models.LogDetails
+        """
+        self._predict = predict
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_science/models/update_model_configuration_details.py
+++ b/src/oci/data_science/models/update_model_configuration_details.py
@@ -1,0 +1,155 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateModelConfigurationDetails(object):
+    """
+    The model configuration details for update.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateModelConfigurationDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param model_id:
+            The value to assign to the model_id property of this UpdateModelConfigurationDetails.
+        :type model_id: str
+
+        :param instance_configuration:
+            The value to assign to the instance_configuration property of this UpdateModelConfigurationDetails.
+        :type instance_configuration: oci.data_science.models.InstanceConfiguration
+
+        :param scaling_policy:
+            The value to assign to the scaling_policy property of this UpdateModelConfigurationDetails.
+        :type scaling_policy: oci.data_science.models.ScalingPolicy
+
+        :param bandwidth_mbps:
+            The value to assign to the bandwidth_mbps property of this UpdateModelConfigurationDetails.
+        :type bandwidth_mbps: int
+
+        """
+        self.swagger_types = {
+            'model_id': 'str',
+            'instance_configuration': 'InstanceConfiguration',
+            'scaling_policy': 'ScalingPolicy',
+            'bandwidth_mbps': 'int'
+        }
+
+        self.attribute_map = {
+            'model_id': 'modelId',
+            'instance_configuration': 'instanceConfiguration',
+            'scaling_policy': 'scalingPolicy',
+            'bandwidth_mbps': 'bandwidthMbps'
+        }
+
+        self._model_id = None
+        self._instance_configuration = None
+        self._scaling_policy = None
+        self._bandwidth_mbps = None
+
+    @property
+    def model_id(self):
+        """
+        **[Required]** Gets the model_id of this UpdateModelConfigurationDetails.
+        The OCID of the model you want to update.
+
+
+        :return: The model_id of this UpdateModelConfigurationDetails.
+        :rtype: str
+        """
+        return self._model_id
+
+    @model_id.setter
+    def model_id(self, model_id):
+        """
+        Sets the model_id of this UpdateModelConfigurationDetails.
+        The OCID of the model you want to update.
+
+
+        :param model_id: The model_id of this UpdateModelConfigurationDetails.
+        :type: str
+        """
+        self._model_id = model_id
+
+    @property
+    def instance_configuration(self):
+        """
+        Gets the instance_configuration of this UpdateModelConfigurationDetails.
+
+        :return: The instance_configuration of this UpdateModelConfigurationDetails.
+        :rtype: oci.data_science.models.InstanceConfiguration
+        """
+        return self._instance_configuration
+
+    @instance_configuration.setter
+    def instance_configuration(self, instance_configuration):
+        """
+        Sets the instance_configuration of this UpdateModelConfigurationDetails.
+
+        :param instance_configuration: The instance_configuration of this UpdateModelConfigurationDetails.
+        :type: oci.data_science.models.InstanceConfiguration
+        """
+        self._instance_configuration = instance_configuration
+
+    @property
+    def scaling_policy(self):
+        """
+        Gets the scaling_policy of this UpdateModelConfigurationDetails.
+
+        :return: The scaling_policy of this UpdateModelConfigurationDetails.
+        :rtype: oci.data_science.models.ScalingPolicy
+        """
+        return self._scaling_policy
+
+    @scaling_policy.setter
+    def scaling_policy(self, scaling_policy):
+        """
+        Sets the scaling_policy of this UpdateModelConfigurationDetails.
+
+        :param scaling_policy: The scaling_policy of this UpdateModelConfigurationDetails.
+        :type: oci.data_science.models.ScalingPolicy
+        """
+        self._scaling_policy = scaling_policy
+
+    @property
+    def bandwidth_mbps(self):
+        """
+        Gets the bandwidth_mbps of this UpdateModelConfigurationDetails.
+        The network bandwidth for the model.
+
+
+        :return: The bandwidth_mbps of this UpdateModelConfigurationDetails.
+        :rtype: int
+        """
+        return self._bandwidth_mbps
+
+    @bandwidth_mbps.setter
+    def bandwidth_mbps(self, bandwidth_mbps):
+        """
+        Sets the bandwidth_mbps of this UpdateModelConfigurationDetails.
+        The network bandwidth for the model.
+
+
+        :param bandwidth_mbps: The bandwidth_mbps of this UpdateModelConfigurationDetails.
+        :type: int
+        """
+        self._bandwidth_mbps = bandwidth_mbps
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_science/models/update_model_deployment_configuration_details.py
+++ b/src/oci/data_science/models/update_model_deployment_configuration_details.py
@@ -1,0 +1,100 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateModelDeploymentConfigurationDetails(object):
+    """
+    The model deployment configuration details for update.
+    """
+
+    #: A constant which can be used with the deployment_type property of a UpdateModelDeploymentConfigurationDetails.
+    #: This constant has a value of "SINGLE_MODEL"
+    DEPLOYMENT_TYPE_SINGLE_MODEL = "SINGLE_MODEL"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateModelDeploymentConfigurationDetails object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
+        to a service operations then you should favor using a subclass over the base class:
+
+        * :class:`~oci.data_science.models.UpdateSingleModelDeploymentConfigurationDetails`
+
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param deployment_type:
+            The value to assign to the deployment_type property of this UpdateModelDeploymentConfigurationDetails.
+            Allowed values for this property are: "SINGLE_MODEL"
+        :type deployment_type: str
+
+        """
+        self.swagger_types = {
+            'deployment_type': 'str'
+        }
+
+        self.attribute_map = {
+            'deployment_type': 'deploymentType'
+        }
+
+        self._deployment_type = None
+
+    @staticmethod
+    def get_subtype(object_dictionary):
+        """
+        Given the hash representation of a subtype of this class,
+        use the info in the hash to return the class of the subtype.
+        """
+        type = object_dictionary['deploymentType']
+
+        if type == 'SINGLE_MODEL':
+            return 'UpdateSingleModelDeploymentConfigurationDetails'
+        else:
+            return 'UpdateModelDeploymentConfigurationDetails'
+
+    @property
+    def deployment_type(self):
+        """
+        Gets the deployment_type of this UpdateModelDeploymentConfigurationDetails.
+        The type of the model deployment.
+
+        Allowed values for this property are: "SINGLE_MODEL"
+
+
+        :return: The deployment_type of this UpdateModelDeploymentConfigurationDetails.
+        :rtype: str
+        """
+        return self._deployment_type
+
+    @deployment_type.setter
+    def deployment_type(self, deployment_type):
+        """
+        Sets the deployment_type of this UpdateModelDeploymentConfigurationDetails.
+        The type of the model deployment.
+
+
+        :param deployment_type: The deployment_type of this UpdateModelDeploymentConfigurationDetails.
+        :type: str
+        """
+        allowed_values = ["SINGLE_MODEL"]
+        if not value_allowed_none_or_none_sentinel(deployment_type, allowed_values):
+            raise ValueError(
+                "Invalid value for `deployment_type`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._deployment_type = deployment_type
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_science/models/update_model_deployment_details.py
+++ b/src/oci/data_science/models/update_model_deployment_details.py
@@ -1,0 +1,233 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateModelDeploymentDetails(object):
+    """
+    Details for updating a model deployment. You can update `modelDeploymentConfigurationDetails` and change `instanceShapeName` and `modelId` when the model deployment is in
+    the ACTIVE lifecycle state. The `bandwidthMbps` or `instanceCount` can only be updated while the model deployment is in the `INACTIVE` state. Changes to the `bandwidthMbps`
+    or `instanceCount` will take effect the next time the `ActivateModelDeployment` action is invoked on the model deployment resource.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateModelDeploymentDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this UpdateModelDeploymentDetails.
+        :type display_name: str
+
+        :param description:
+            The value to assign to the description property of this UpdateModelDeploymentDetails.
+        :type description: str
+
+        :param model_deployment_configuration_details:
+            The value to assign to the model_deployment_configuration_details property of this UpdateModelDeploymentDetails.
+        :type model_deployment_configuration_details: oci.data_science.models.UpdateModelDeploymentConfigurationDetails
+
+        :param category_log_details:
+            The value to assign to the category_log_details property of this UpdateModelDeploymentDetails.
+        :type category_log_details: oci.data_science.models.UpdateCategoryLogDetails
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this UpdateModelDeploymentDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this UpdateModelDeploymentDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'description': 'str',
+            'model_deployment_configuration_details': 'UpdateModelDeploymentConfigurationDetails',
+            'category_log_details': 'UpdateCategoryLogDetails',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'description': 'description',
+            'model_deployment_configuration_details': 'modelDeploymentConfigurationDetails',
+            'category_log_details': 'categoryLogDetails',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._display_name = None
+        self._description = None
+        self._model_deployment_configuration_details = None
+        self._category_log_details = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this UpdateModelDeploymentDetails.
+        A user-friendly display name for the resource. Does not have to be unique, and can be modified. Avoid entering confidential information.
+        Example: `My ModelDeployment`
+
+
+        :return: The display_name of this UpdateModelDeploymentDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this UpdateModelDeploymentDetails.
+        A user-friendly display name for the resource. Does not have to be unique, and can be modified. Avoid entering confidential information.
+        Example: `My ModelDeployment`
+
+
+        :param display_name: The display_name of this UpdateModelDeploymentDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def description(self):
+        """
+        Gets the description of this UpdateModelDeploymentDetails.
+        A short description of the model deployment.
+
+
+        :return: The description of this UpdateModelDeploymentDetails.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this UpdateModelDeploymentDetails.
+        A short description of the model deployment.
+
+
+        :param description: The description of this UpdateModelDeploymentDetails.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def model_deployment_configuration_details(self):
+        """
+        Gets the model_deployment_configuration_details of this UpdateModelDeploymentDetails.
+
+        :return: The model_deployment_configuration_details of this UpdateModelDeploymentDetails.
+        :rtype: oci.data_science.models.UpdateModelDeploymentConfigurationDetails
+        """
+        return self._model_deployment_configuration_details
+
+    @model_deployment_configuration_details.setter
+    def model_deployment_configuration_details(self, model_deployment_configuration_details):
+        """
+        Sets the model_deployment_configuration_details of this UpdateModelDeploymentDetails.
+
+        :param model_deployment_configuration_details: The model_deployment_configuration_details of this UpdateModelDeploymentDetails.
+        :type: oci.data_science.models.UpdateModelDeploymentConfigurationDetails
+        """
+        self._model_deployment_configuration_details = model_deployment_configuration_details
+
+    @property
+    def category_log_details(self):
+        """
+        Gets the category_log_details of this UpdateModelDeploymentDetails.
+
+        :return: The category_log_details of this UpdateModelDeploymentDetails.
+        :rtype: oci.data_science.models.UpdateCategoryLogDetails
+        """
+        return self._category_log_details
+
+    @category_log_details.setter
+    def category_log_details(self, category_log_details):
+        """
+        Sets the category_log_details of this UpdateModelDeploymentDetails.
+
+        :param category_log_details: The category_log_details of this UpdateModelDeploymentDetails.
+        :type: oci.data_science.models.UpdateCategoryLogDetails
+        """
+        self._category_log_details = category_log_details
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this UpdateModelDeploymentDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. See `Resource Tags`__.
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this UpdateModelDeploymentDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this UpdateModelDeploymentDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. See `Resource Tags`__.
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this UpdateModelDeploymentDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this UpdateModelDeploymentDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace. See `Resource Tags`__.
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this UpdateModelDeploymentDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this UpdateModelDeploymentDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace. See `Resource Tags`__.
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this UpdateModelDeploymentDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_science/models/update_model_details.py
+++ b/src/oci/data_science/models/update_model_details.py
@@ -58,7 +58,7 @@ class UpdateModelDetails(object):
     def display_name(self):
         """
         Gets the display_name of this UpdateModelDetails.
-        A user-friendly display name for the resource. Does not have to be unique, and can be modified. Avoid entering confidential information.
+        A user-friendly display name for the resource. It does not have to be unique and can be modified. Avoid entering confidential information.
          Example: `My Model`
 
 
@@ -71,7 +71,7 @@ class UpdateModelDetails(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this UpdateModelDetails.
-        A user-friendly display name for the resource. Does not have to be unique, and can be modified. Avoid entering confidential information.
+        A user-friendly display name for the resource. It does not have to be unique and can be modified. Avoid entering confidential information.
          Example: `My Model`
 
 
@@ -84,7 +84,7 @@ class UpdateModelDetails(object):
     def description(self):
         """
         Gets the description of this UpdateModelDetails.
-        A short blurb describing the model.
+        A short description of the model.
 
 
         :return: The description of this UpdateModelDetails.
@@ -96,7 +96,7 @@ class UpdateModelDetails(object):
     def description(self, description):
         """
         Sets the description of this UpdateModelDetails.
-        A short blurb describing the model.
+        A short description of the model.
 
 
         :param description: The description of this UpdateModelDetails.

--- a/src/oci/data_science/models/update_notebook_session_details.py
+++ b/src/oci/data_science/models/update_notebook_session_details.py
@@ -11,7 +11,7 @@ from oci.decorators import init_model_state_from_kwargs
 class UpdateNotebookSessionDetails(object):
     """
     Details for updating a notebook session. `notebookSessionConfigurationDetails` can only be updated while the notebook session is in the `INACTIVE` state.
-    Changes to the `notebookSessionConfigurationDetails` will take effect the next time the `ActivateNotebookSession` action is invoked on the notebook session resource.
+    Changes to the `notebookSessionConfigurationDetails` take effect the next time the `ActivateNotebookSession` action is invoked on the notebook session resource.
     """
 
     def __init__(self, **kwargs):
@@ -59,7 +59,7 @@ class UpdateNotebookSessionDetails(object):
     def display_name(self):
         """
         Gets the display_name of this UpdateNotebookSessionDetails.
-        A user-friendly display name for the resource. Does not have to be unique, and can be modified. Avoid entering confidential information.
+        A user-friendly display name for the resource. It does not have to be unique and can be modified. Avoid entering confidential information.
         Example: `My NotebookSession`
 
 
@@ -72,7 +72,7 @@ class UpdateNotebookSessionDetails(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this UpdateNotebookSessionDetails.
-        A user-friendly display name for the resource. Does not have to be unique, and can be modified. Avoid entering confidential information.
+        A user-friendly display name for the resource. It does not have to be unique and can be modified. Avoid entering confidential information.
         Example: `My NotebookSession`
 
 

--- a/src/oci/data_science/models/update_project_details.py
+++ b/src/oci/data_science/models/update_project_details.py
@@ -58,7 +58,7 @@ class UpdateProjectDetails(object):
     def display_name(self):
         """
         Gets the display_name of this UpdateProjectDetails.
-        A user-friendly display name for the resource. Does not have to be unique, and can be modified. Avoid entering confidential information.
+        A user-friendly display name for the resource. It does not have to be unique and can be modified. Avoid entering confidential information.
 
 
         :return: The display_name of this UpdateProjectDetails.
@@ -70,7 +70,7 @@ class UpdateProjectDetails(object):
     def display_name(self, display_name):
         """
         Sets the display_name of this UpdateProjectDetails.
-        A user-friendly display name for the resource. Does not have to be unique, and can be modified. Avoid entering confidential information.
+        A user-friendly display name for the resource. It does not have to be unique and can be modified. Avoid entering confidential information.
 
 
         :param display_name: The display_name of this UpdateProjectDetails.
@@ -82,7 +82,7 @@ class UpdateProjectDetails(object):
     def description(self):
         """
         Gets the description of this UpdateProjectDetails.
-        A short blurb describing the project.
+        A short description of the project.
 
 
         :return: The description of this UpdateProjectDetails.
@@ -94,7 +94,7 @@ class UpdateProjectDetails(object):
     def description(self, description):
         """
         Sets the description of this UpdateProjectDetails.
-        A short blurb describing the project.
+        A short description of the project.
 
 
         :param description: The description of this UpdateProjectDetails.

--- a/src/oci/data_science/models/update_single_model_deployment_configuration_details.py
+++ b/src/oci/data_science/models/update_single_model_deployment_configuration_details.py
@@ -1,0 +1,76 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .update_model_deployment_configuration_details import UpdateModelDeploymentConfigurationDetails
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateSingleModelDeploymentConfigurationDetails(UpdateModelDeploymentConfigurationDetails):
+    """
+    The single model type deployment for update.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateSingleModelDeploymentConfigurationDetails object with values from keyword arguments. The default value of the :py:attr:`~oci.data_science.models.UpdateSingleModelDeploymentConfigurationDetails.deployment_type` attribute
+        of this class is ``SINGLE_MODEL`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param deployment_type:
+            The value to assign to the deployment_type property of this UpdateSingleModelDeploymentConfigurationDetails.
+            Allowed values for this property are: "SINGLE_MODEL"
+        :type deployment_type: str
+
+        :param model_configuration_details:
+            The value to assign to the model_configuration_details property of this UpdateSingleModelDeploymentConfigurationDetails.
+        :type model_configuration_details: oci.data_science.models.UpdateModelConfigurationDetails
+
+        """
+        self.swagger_types = {
+            'deployment_type': 'str',
+            'model_configuration_details': 'UpdateModelConfigurationDetails'
+        }
+
+        self.attribute_map = {
+            'deployment_type': 'deploymentType',
+            'model_configuration_details': 'modelConfigurationDetails'
+        }
+
+        self._deployment_type = None
+        self._model_configuration_details = None
+        self._deployment_type = 'SINGLE_MODEL'
+
+    @property
+    def model_configuration_details(self):
+        """
+        Gets the model_configuration_details of this UpdateSingleModelDeploymentConfigurationDetails.
+
+        :return: The model_configuration_details of this UpdateSingleModelDeploymentConfigurationDetails.
+        :rtype: oci.data_science.models.UpdateModelConfigurationDetails
+        """
+        return self._model_configuration_details
+
+    @model_configuration_details.setter
+    def model_configuration_details(self, model_configuration_details):
+        """
+        Sets the model_configuration_details of this UpdateSingleModelDeploymentConfigurationDetails.
+
+        :param model_configuration_details: The model_configuration_details of this UpdateSingleModelDeploymentConfigurationDetails.
+        :type: oci.data_science.models.UpdateModelConfigurationDetails
+        """
+        self._model_configuration_details = model_configuration_details
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_science/models/work_request.py
+++ b/src/oci/data_science/models/work_request.py
@@ -30,6 +30,26 @@ class WorkRequest(object):
     OPERATION_TYPE_NOTEBOOK_SESSION_DEACTIVATE = "NOTEBOOK_SESSION_DEACTIVATE"
 
     #: A constant which can be used with the operation_type property of a WorkRequest.
+    #: This constant has a value of "MODEL_DEPLOYMENT_CREATE"
+    OPERATION_TYPE_MODEL_DEPLOYMENT_CREATE = "MODEL_DEPLOYMENT_CREATE"
+
+    #: A constant which can be used with the operation_type property of a WorkRequest.
+    #: This constant has a value of "MODEL_DEPLOYMENT_DELETE"
+    OPERATION_TYPE_MODEL_DEPLOYMENT_DELETE = "MODEL_DEPLOYMENT_DELETE"
+
+    #: A constant which can be used with the operation_type property of a WorkRequest.
+    #: This constant has a value of "MODEL_DEPLOYMENT_ACTIVATE"
+    OPERATION_TYPE_MODEL_DEPLOYMENT_ACTIVATE = "MODEL_DEPLOYMENT_ACTIVATE"
+
+    #: A constant which can be used with the operation_type property of a WorkRequest.
+    #: This constant has a value of "MODEL_DEPLOYMENT_DEACTIVATE"
+    OPERATION_TYPE_MODEL_DEPLOYMENT_DEACTIVATE = "MODEL_DEPLOYMENT_DEACTIVATE"
+
+    #: A constant which can be used with the operation_type property of a WorkRequest.
+    #: This constant has a value of "MODEL_DEPLOYMENT_UPDATE"
+    OPERATION_TYPE_MODEL_DEPLOYMENT_UPDATE = "MODEL_DEPLOYMENT_UPDATE"
+
+    #: A constant which can be used with the operation_type property of a WorkRequest.
     #: This constant has a value of "PROJECT_DELETE"
     OPERATION_TYPE_PROJECT_DELETE = "PROJECT_DELETE"
 
@@ -72,7 +92,7 @@ class WorkRequest(object):
 
         :param operation_type:
             The value to assign to the operation_type property of this WorkRequest.
-            Allowed values for this property are: "NOTEBOOK_SESSION_CREATE", "NOTEBOOK_SESSION_DELETE", "NOTEBOOK_SESSION_ACTIVATE", "NOTEBOOK_SESSION_DEACTIVATE", "PROJECT_DELETE", "WORKREQUEST_CANCEL", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "NOTEBOOK_SESSION_CREATE", "NOTEBOOK_SESSION_DELETE", "NOTEBOOK_SESSION_ACTIVATE", "NOTEBOOK_SESSION_DEACTIVATE", "MODEL_DEPLOYMENT_CREATE", "MODEL_DEPLOYMENT_DELETE", "MODEL_DEPLOYMENT_ACTIVATE", "MODEL_DEPLOYMENT_DEACTIVATE", "MODEL_DEPLOYMENT_UPDATE", "PROJECT_DELETE", "WORKREQUEST_CANCEL", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type operation_type: str
 
@@ -147,7 +167,7 @@ class WorkRequest(object):
         **[Required]** Gets the id of this WorkRequest.
         The `OCID`__ of the work request.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :return: The id of this WorkRequest.
@@ -161,7 +181,7 @@ class WorkRequest(object):
         Sets the id of this WorkRequest.
         The `OCID`__ of the work request.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :param id: The id of this WorkRequest.
@@ -175,7 +195,7 @@ class WorkRequest(object):
         **[Required]** Gets the operation_type of this WorkRequest.
         The type of work the work request is doing.
 
-        Allowed values for this property are: "NOTEBOOK_SESSION_CREATE", "NOTEBOOK_SESSION_DELETE", "NOTEBOOK_SESSION_ACTIVATE", "NOTEBOOK_SESSION_DEACTIVATE", "PROJECT_DELETE", "WORKREQUEST_CANCEL", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "NOTEBOOK_SESSION_CREATE", "NOTEBOOK_SESSION_DELETE", "NOTEBOOK_SESSION_ACTIVATE", "NOTEBOOK_SESSION_DEACTIVATE", "MODEL_DEPLOYMENT_CREATE", "MODEL_DEPLOYMENT_DELETE", "MODEL_DEPLOYMENT_ACTIVATE", "MODEL_DEPLOYMENT_DEACTIVATE", "MODEL_DEPLOYMENT_UPDATE", "PROJECT_DELETE", "WORKREQUEST_CANCEL", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -194,7 +214,7 @@ class WorkRequest(object):
         :param operation_type: The operation_type of this WorkRequest.
         :type: str
         """
-        allowed_values = ["NOTEBOOK_SESSION_CREATE", "NOTEBOOK_SESSION_DELETE", "NOTEBOOK_SESSION_ACTIVATE", "NOTEBOOK_SESSION_DEACTIVATE", "PROJECT_DELETE", "WORKREQUEST_CANCEL"]
+        allowed_values = ["NOTEBOOK_SESSION_CREATE", "NOTEBOOK_SESSION_DELETE", "NOTEBOOK_SESSION_ACTIVATE", "NOTEBOOK_SESSION_DEACTIVATE", "MODEL_DEPLOYMENT_CREATE", "MODEL_DEPLOYMENT_DELETE", "MODEL_DEPLOYMENT_ACTIVATE", "MODEL_DEPLOYMENT_DEACTIVATE", "MODEL_DEPLOYMENT_UPDATE", "PROJECT_DELETE", "WORKREQUEST_CANCEL"]
         if not value_allowed_none_or_none_sentinel(operation_type, allowed_values):
             operation_type = 'UNKNOWN_ENUM_VALUE'
         self._operation_type = operation_type
@@ -235,7 +255,7 @@ class WorkRequest(object):
         **[Required]** Gets the compartment_id of this WorkRequest.
         The `OCID`__ of the work request's compartment.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :return: The compartment_id of this WorkRequest.
@@ -249,7 +269,7 @@ class WorkRequest(object):
         Sets the compartment_id of this WorkRequest.
         The `OCID`__ of the work request's compartment.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :param compartment_id: The compartment_id of this WorkRequest.
@@ -309,7 +329,7 @@ class WorkRequest(object):
     def time_accepted(self):
         """
         **[Required]** Gets the time_accepted of this WorkRequest.
-        The time the work request was accepted, in the timestamp format defined by `RFC3339`__.
+        The time the work request was accepted in the timestamp format defined by `RFC3339`__.
 
         __ https://tools.ietf.org/html/rfc3339
 
@@ -323,7 +343,7 @@ class WorkRequest(object):
     def time_accepted(self, time_accepted):
         """
         Sets the time_accepted of this WorkRequest.
-        The time the work request was accepted, in the timestamp format defined by `RFC3339`__.
+        The time the work request was accepted in the timestamp format defined by `RFC3339`__.
 
         __ https://tools.ietf.org/html/rfc3339
 
@@ -337,7 +357,7 @@ class WorkRequest(object):
     def time_started(self):
         """
         Gets the time_started of this WorkRequest.
-        The time the work request was started, in the timestamp format defined by `RFC3339`__.
+        The time the work request was started in the timestamp format defined by `RFC3339`__.
 
         __ https://tools.ietf.org/html/rfc3339
 
@@ -351,7 +371,7 @@ class WorkRequest(object):
     def time_started(self, time_started):
         """
         Sets the time_started of this WorkRequest.
-        The time the work request was started, in the timestamp format defined by `RFC3339`__.
+        The time the work request was started in the timestamp format defined by `RFC3339`__.
 
         __ https://tools.ietf.org/html/rfc3339
 
@@ -365,7 +385,7 @@ class WorkRequest(object):
     def time_finished(self):
         """
         Gets the time_finished of this WorkRequest.
-        The time the work request was finished, in the timestamp format defined by `RFC3339`__.
+        The time the work request was finished in the timestamp format defined by `RFC3339`__.
 
         __ https://tools.ietf.org/html/rfc3339
 
@@ -379,7 +399,7 @@ class WorkRequest(object):
     def time_finished(self, time_finished):
         """
         Sets the time_finished of this WorkRequest.
-        The time the work request was finished, in the timestamp format defined by `RFC3339`__.
+        The time the work request was finished in the timestamp format defined by `RFC3339`__.
 
         __ https://tools.ietf.org/html/rfc3339
 

--- a/src/oci/data_science/models/work_request_error.py
+++ b/src/oci/data_science/models/work_request_error.py
@@ -51,9 +51,9 @@ class WorkRequestError(object):
     def code(self):
         """
         **[Required]** Gets the code of this WorkRequestError.
-        A short error code that defines the error, meant for programmatic parsing. See `API Errors`__.
+        A short error code that defines the error, which is meant for programmatic parsing. See `API Errors`__.
 
-        __ https://docs.cloud.oracle.com/Content/API/References/apierrors.htm
+        __ https://docs.cloud.oracle.com/Content/General/References/apierrors.htm
 
 
         :return: The code of this WorkRequestError.
@@ -65,9 +65,9 @@ class WorkRequestError(object):
     def code(self, code):
         """
         Sets the code of this WorkRequestError.
-        A short error code that defines the error, meant for programmatic parsing. See `API Errors`__.
+        A short error code that defines the error, which is meant for programmatic parsing. See `API Errors`__.
 
-        __ https://docs.cloud.oracle.com/Content/API/References/apierrors.htm
+        __ https://docs.cloud.oracle.com/Content/General/References/apierrors.htm
 
 
         :param code: The code of this WorkRequestError.

--- a/src/oci/data_science/models/work_request_resource.py
+++ b/src/oci/data_science/models/work_request_resource.py
@@ -136,7 +136,7 @@ class WorkRequestResource(object):
         **[Required]** Gets the identifier of this WorkRequestResource.
         The `OCID`__ of the resource the work request affects.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :return: The identifier of this WorkRequestResource.
@@ -150,7 +150,7 @@ class WorkRequestResource(object):
         Sets the identifier of this WorkRequestResource.
         The `OCID`__ of the resource the work request affects.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :param identifier: The identifier of this WorkRequestResource.

--- a/src/oci/data_science/models/work_request_summary.py
+++ b/src/oci/data_science/models/work_request_summary.py
@@ -30,6 +30,26 @@ class WorkRequestSummary(object):
     OPERATION_TYPE_NOTEBOOK_SESSION_DEACTIVATE = "NOTEBOOK_SESSION_DEACTIVATE"
 
     #: A constant which can be used with the operation_type property of a WorkRequestSummary.
+    #: This constant has a value of "MODEL_DEPLOYMENT_CREATE"
+    OPERATION_TYPE_MODEL_DEPLOYMENT_CREATE = "MODEL_DEPLOYMENT_CREATE"
+
+    #: A constant which can be used with the operation_type property of a WorkRequestSummary.
+    #: This constant has a value of "MODEL_DEPLOYMENT_DELETE"
+    OPERATION_TYPE_MODEL_DEPLOYMENT_DELETE = "MODEL_DEPLOYMENT_DELETE"
+
+    #: A constant which can be used with the operation_type property of a WorkRequestSummary.
+    #: This constant has a value of "MODEL_DEPLOYMENT_ACTIVATE"
+    OPERATION_TYPE_MODEL_DEPLOYMENT_ACTIVATE = "MODEL_DEPLOYMENT_ACTIVATE"
+
+    #: A constant which can be used with the operation_type property of a WorkRequestSummary.
+    #: This constant has a value of "MODEL_DEPLOYMENT_DEACTIVATE"
+    OPERATION_TYPE_MODEL_DEPLOYMENT_DEACTIVATE = "MODEL_DEPLOYMENT_DEACTIVATE"
+
+    #: A constant which can be used with the operation_type property of a WorkRequestSummary.
+    #: This constant has a value of "MODEL_DEPLOYMENT_UPDATE"
+    OPERATION_TYPE_MODEL_DEPLOYMENT_UPDATE = "MODEL_DEPLOYMENT_UPDATE"
+
+    #: A constant which can be used with the operation_type property of a WorkRequestSummary.
     #: This constant has a value of "PROJECT_DELETE"
     OPERATION_TYPE_PROJECT_DELETE = "PROJECT_DELETE"
 
@@ -72,7 +92,7 @@ class WorkRequestSummary(object):
 
         :param operation_type:
             The value to assign to the operation_type property of this WorkRequestSummary.
-            Allowed values for this property are: "NOTEBOOK_SESSION_CREATE", "NOTEBOOK_SESSION_DELETE", "NOTEBOOK_SESSION_ACTIVATE", "NOTEBOOK_SESSION_DEACTIVATE", "PROJECT_DELETE", "WORKREQUEST_CANCEL", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "NOTEBOOK_SESSION_CREATE", "NOTEBOOK_SESSION_DELETE", "NOTEBOOK_SESSION_ACTIVATE", "NOTEBOOK_SESSION_DEACTIVATE", "MODEL_DEPLOYMENT_CREATE", "MODEL_DEPLOYMENT_DELETE", "MODEL_DEPLOYMENT_ACTIVATE", "MODEL_DEPLOYMENT_DEACTIVATE", "MODEL_DEPLOYMENT_UPDATE", "PROJECT_DELETE", "WORKREQUEST_CANCEL", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type operation_type: str
 
@@ -147,7 +167,7 @@ class WorkRequestSummary(object):
         **[Required]** Gets the id of this WorkRequestSummary.
         The `OCID`__ of the work request.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :return: The id of this WorkRequestSummary.
@@ -161,7 +181,7 @@ class WorkRequestSummary(object):
         Sets the id of this WorkRequestSummary.
         The `OCID`__ of the work request.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :param id: The id of this WorkRequestSummary.
@@ -175,7 +195,7 @@ class WorkRequestSummary(object):
         **[Required]** Gets the operation_type of this WorkRequestSummary.
         The type of work the work request is doing.
 
-        Allowed values for this property are: "NOTEBOOK_SESSION_CREATE", "NOTEBOOK_SESSION_DELETE", "NOTEBOOK_SESSION_ACTIVATE", "NOTEBOOK_SESSION_DEACTIVATE", "PROJECT_DELETE", "WORKREQUEST_CANCEL", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "NOTEBOOK_SESSION_CREATE", "NOTEBOOK_SESSION_DELETE", "NOTEBOOK_SESSION_ACTIVATE", "NOTEBOOK_SESSION_DEACTIVATE", "MODEL_DEPLOYMENT_CREATE", "MODEL_DEPLOYMENT_DELETE", "MODEL_DEPLOYMENT_ACTIVATE", "MODEL_DEPLOYMENT_DEACTIVATE", "MODEL_DEPLOYMENT_UPDATE", "PROJECT_DELETE", "WORKREQUEST_CANCEL", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -194,7 +214,7 @@ class WorkRequestSummary(object):
         :param operation_type: The operation_type of this WorkRequestSummary.
         :type: str
         """
-        allowed_values = ["NOTEBOOK_SESSION_CREATE", "NOTEBOOK_SESSION_DELETE", "NOTEBOOK_SESSION_ACTIVATE", "NOTEBOOK_SESSION_DEACTIVATE", "PROJECT_DELETE", "WORKREQUEST_CANCEL"]
+        allowed_values = ["NOTEBOOK_SESSION_CREATE", "NOTEBOOK_SESSION_DELETE", "NOTEBOOK_SESSION_ACTIVATE", "NOTEBOOK_SESSION_DEACTIVATE", "MODEL_DEPLOYMENT_CREATE", "MODEL_DEPLOYMENT_DELETE", "MODEL_DEPLOYMENT_ACTIVATE", "MODEL_DEPLOYMENT_DEACTIVATE", "MODEL_DEPLOYMENT_UPDATE", "PROJECT_DELETE", "WORKREQUEST_CANCEL"]
         if not value_allowed_none_or_none_sentinel(operation_type, allowed_values):
             operation_type = 'UNKNOWN_ENUM_VALUE'
         self._operation_type = operation_type
@@ -235,7 +255,7 @@ class WorkRequestSummary(object):
         **[Required]** Gets the compartment_id of this WorkRequestSummary.
         The `OCID`__ of the work request's compartment.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :return: The compartment_id of this WorkRequestSummary.
@@ -249,7 +269,7 @@ class WorkRequestSummary(object):
         Sets the compartment_id of this WorkRequestSummary.
         The `OCID`__ of the work request's compartment.
 
-        __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
 
         :param compartment_id: The compartment_id of this WorkRequestSummary.
@@ -309,7 +329,7 @@ class WorkRequestSummary(object):
     def time_accepted(self):
         """
         **[Required]** Gets the time_accepted of this WorkRequestSummary.
-        The date and time the work request was accepted, in the timestamp format defined by `RFC3339`__.
+        The date and time the work request was accepted in the timestamp format defined by `RFC3339`__.
 
         __ https://tools.ietf.org/html/rfc3339
 
@@ -323,7 +343,7 @@ class WorkRequestSummary(object):
     def time_accepted(self, time_accepted):
         """
         Sets the time_accepted of this WorkRequestSummary.
-        The date and time the work request was accepted, in the timestamp format defined by `RFC3339`__.
+        The date and time the work request was accepted in the timestamp format defined by `RFC3339`__.
 
         __ https://tools.ietf.org/html/rfc3339
 
@@ -337,7 +357,7 @@ class WorkRequestSummary(object):
     def time_started(self):
         """
         Gets the time_started of this WorkRequestSummary.
-        The date and time the work request was started, in the timestamp format defined by `RFC3339`__.
+        The date and time the work request was started in the timestamp format defined by `RFC3339`__.
 
         __ https://tools.ietf.org/html/rfc3339
 
@@ -351,7 +371,7 @@ class WorkRequestSummary(object):
     def time_started(self, time_started):
         """
         Sets the time_started of this WorkRequestSummary.
-        The date and time the work request was started, in the timestamp format defined by `RFC3339`__.
+        The date and time the work request was started in the timestamp format defined by `RFC3339`__.
 
         __ https://tools.ietf.org/html/rfc3339
 
@@ -365,7 +385,7 @@ class WorkRequestSummary(object):
     def time_finished(self):
         """
         Gets the time_finished of this WorkRequestSummary.
-        The date and time the work request was finished, in the timestamp format defined by `RFC3339`__.
+        The date and time the work request was finished in the timestamp format defined by `RFC3339`__.
 
         __ https://tools.ietf.org/html/rfc3339
 
@@ -379,7 +399,7 @@ class WorkRequestSummary(object):
     def time_finished(self, time_finished):
         """
         Sets the time_finished of this WorkRequestSummary.
-        The date and time the work request was finished, in the timestamp format defined by `RFC3339`__.
+        The date and time the work request was finished in the timestamp format defined by `RFC3339`__.
 
         __ https://tools.ietf.org/html/rfc3339
 

--- a/src/oci/functions/functions_invoke_client.py
+++ b/src/oci/functions/functions_invoke_client.py
@@ -181,9 +181,6 @@ class FunctionsInvokeClient(object):
         if kwargs.get('retry_strategy'):
             retry_strategy = kwargs.get('retry_strategy')
 
-        # Disable the retry_strategy to work around data corruption issue temporarily
-        if retry_strategy:
-            retry_strategy = None
         if retry_strategy:
             return retry_strategy.make_retrying_call(
                 self.base_client.call_api,

--- a/src/oci/key_management/kms_management_client.py
+++ b/src/oci/key_management/kms_management_client.py
@@ -1715,9 +1715,6 @@ class KmsManagementClient(object):
         if kwargs.get('retry_strategy'):
             retry_strategy = kwargs.get('retry_strategy')
 
-        # Disable the retry_strategy to work around data corruption issue temporarily
-        if retry_strategy:
-            retry_strategy = None
         if retry_strategy:
             if not isinstance(retry_strategy, retry.NoneRetryStrategy):
                 self.base_client.add_opc_retry_token_if_needed(header_params)

--- a/src/oci/key_management/kms_vault_client.py
+++ b/src/oci/key_management/kms_vault_client.py
@@ -882,9 +882,6 @@ class KmsVaultClient(object):
         if kwargs.get('retry_strategy'):
             retry_strategy = kwargs.get('retry_strategy')
 
-        # Disable the retry_strategy to work around data corruption issue temporarily
-        if retry_strategy:
-            retry_strategy = None
         if retry_strategy:
             if not isinstance(retry_strategy, retry.NoneRetryStrategy):
                 self.base_client.add_opc_retry_token_if_needed(header_params)

--- a/src/oci/load_balancer/load_balancer_client.py
+++ b/src/oci/load_balancer/load_balancer_client.py
@@ -860,6 +860,101 @@ class LoadBalancerClient(object):
                 header_params=header_params,
                 body=create_path_route_set_details)
 
+    def create_routing_policy(self, create_routing_policy_details, load_balancer_id, **kwargs):
+        """
+        Adds a routing policy to a load balancer. For more information, see
+        `Managing Request Routing`__.
+
+        __ https://docs.cloud.oracle.com/Content/Balance/Tasks/managingrequest.htm
+
+
+        :param oci.load_balancer.models.CreateRoutingPolicyDetails create_routing_policy_details: (required)
+            The details of the routing policy rules to add.
+
+        :param str load_balancer_id: (required)
+            The `OCID`__ of the load balancer to add the routing policy rule list to.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_request_id: (optional)
+            The unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+            particular request, please provide the request ID.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (e.g., if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/loadbalancer/create_routing_policy.py.html>`__ to see an example of how to use create_routing_policy API.
+        """
+        resource_path = "/loadBalancers/{loadBalancerId}/routingPolicies"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "create_routing_policy got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "loadBalancerId": load_balancer_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=create_routing_policy_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=create_routing_policy_details)
+
     def create_rule_set(self, load_balancer_id, create_rule_set_details, **kwargs):
         """
         Creates a new rule set associated with the specified load balancer. For more information, see
@@ -1583,6 +1678,91 @@ class LoadBalancerClient(object):
         path_params = {
             "loadBalancerId": load_balancer_id,
             "pathRouteSetName": path_route_set_name
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
+    def delete_routing_policy(self, load_balancer_id, routing_policy_name, **kwargs):
+        """
+        Deletes a routing policy from the specified load balancer.
+
+        To delete a routing rule from a routing policy, use the
+        :func:`update_routing_policy` operation.
+
+
+        :param str load_balancer_id: (required)
+            The `OCID`__ of the load balancer associated with the routing policy to delete.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str routing_policy_name: (required)
+            The name of the routing policy to delete.
+
+            Example: `example_routing_policy`
+
+        :param str opc_request_id: (optional)
+            The unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+            particular request, please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/loadbalancer/delete_routing_policy.py.html>`__ to see an example of how to use delete_routing_policy API.
+        """
+        resource_path = "/loadBalancers/{loadBalancerId}/routingPolicies/{routingPolicyName}"
+        method = "DELETE"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "delete_routing_policy got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "loadBalancerId": load_balancer_id,
+            "routingPolicyName": routing_policy_name
         }
 
         path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
@@ -2538,6 +2718,90 @@ class LoadBalancerClient(object):
                 path_params=path_params,
                 header_params=header_params,
                 response_type="PathRouteSet")
+
+    def get_routing_policy(self, load_balancer_id, routing_policy_name, **kwargs):
+        """
+        Gets the specified routing policy.
+
+
+        :param str load_balancer_id: (required)
+            The `OCID`__ of the specified load balancer.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str routing_policy_name: (required)
+            The name of the routing policy to retrieve.
+
+            Example: `example_routing_policy`
+
+        :param str opc_request_id: (optional)
+            The unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+            particular request, please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.load_balancer.models.RoutingPolicy`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/loadbalancer/get_routing_policy.py.html>`__ to see an example of how to use get_routing_policy API.
+        """
+        resource_path = "/loadBalancers/{loadBalancerId}/routingPolicies/{routingPolicyName}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_routing_policy got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "loadBalancerId": load_balancer_id,
+            "routingPolicyName": routing_policy_name
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="RoutingPolicy")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="RoutingPolicy")
 
     def get_rule_set(self, load_balancer_id, rule_set_name, **kwargs):
         """
@@ -3702,6 +3966,110 @@ class LoadBalancerClient(object):
                 query_params=query_params,
                 header_params=header_params,
                 response_type="list[LoadBalancerProtocol]")
+
+    def list_routing_policies(self, load_balancer_id, **kwargs):
+        """
+        Lists all routing policies associated with the specified load balancer.
+
+
+        :param str load_balancer_id: (required)
+            The `OCID`__ of the load balancer associated with the routing policies.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_request_id: (optional)
+            The unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+            particular request, please provide the request ID.
+
+        :param int limit: (optional)
+            For list pagination. The maximum number of results per page, or items to return in a paginated \"List\" call.
+            For important details about how pagination works, see `List Pagination`__.
+
+            Example: `50`
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+
+        :param str page: (optional)
+            For list pagination. The value of the `opc-next-page` response header from the previous \"List\" call.
+            For important details about how pagination works, see `List Pagination`__.
+
+            Example: `3`
+
+            __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type list of :class:`~oci.load_balancer.models.RoutingPolicy`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/loadbalancer/list_routing_policies.py.html>`__ to see an example of how to use list_routing_policies API.
+        """
+        resource_path = "/loadBalancers/{loadBalancerId}/routingPolicies"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "limit",
+            "page"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_routing_policies got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "loadBalancerId": load_balancer_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        query_params = {
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[RoutingPolicy]")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="list[RoutingPolicy]")
 
     def list_rule_sets(self, load_balancer_id, **kwargs):
         """
@@ -4926,6 +5294,107 @@ class LoadBalancerClient(object):
                 path_params=path_params,
                 header_params=header_params,
                 body=update_path_route_set_details)
+
+    def update_routing_policy(self, update_routing_policy_details, load_balancer_id, routing_policy_name, **kwargs):
+        """
+        Overwrites an existing routing policy on the specified load balancer. Use this operation to add, delete, or alter
+        routing policy rules in a routing policy.
+
+        To add a new routing rule to a routing policy, the body must include both the new routing rule to add and the existing rules to retain.
+
+
+        :param oci.load_balancer.models.UpdateRoutingPolicyDetails update_routing_policy_details: (required)
+            The configuration details needed to update a routing policy.
+
+        :param str load_balancer_id: (required)
+            The `OCID`__ of the load balancer associated with the routing policy to update.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str routing_policy_name: (required)
+            The name of the routing policy to update.
+
+            Example: `example_routing_policy_name`
+
+        :param str opc_request_id: (optional)
+            The unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+            particular request, please provide the request ID.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (e.g., if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/loadbalancer/update_routing_policy.py.html>`__ to see an example of how to use update_routing_policy API.
+        """
+        resource_path = "/loadBalancers/{loadBalancerId}/routingPolicies/{routingPolicyName}"
+        method = "PUT"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "update_routing_policy got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "loadBalancerId": load_balancer_id,
+            "routingPolicyName": routing_policy_name
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_routing_policy_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_routing_policy_details)
 
     def update_rule_set(self, load_balancer_id, rule_set_name, update_rule_set_details, **kwargs):
         """

--- a/src/oci/load_balancer/load_balancer_client_composite_operations.py
+++ b/src/oci/load_balancer/load_balancer_client_composite_operations.py
@@ -367,6 +367,49 @@ class LoadBalancerClientCompositeOperations(object):
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
+    def create_routing_policy_and_wait_for_state(self, create_routing_policy_details, load_balancer_id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.load_balancer.LoadBalancerClient.create_routing_policy` and waits for the :py:class:`~oci.load_balancer.models.WorkRequest`
+        to enter the given state(s).
+
+        :param oci.load_balancer.models.CreateRoutingPolicyDetails create_routing_policy_details: (required)
+            The details of the routing policy rules to add.
+
+        :param str load_balancer_id: (required)
+            The `OCID`__ of the load balancer to add the routing policy rule list to.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.load_balancer.models.WorkRequest.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.load_balancer.LoadBalancerClient.create_routing_policy`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.create_routing_policy(create_routing_policy_details, load_balancer_id, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def create_rule_set_and_wait_for_state(self, load_balancer_id, create_rule_set_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.load_balancer.LoadBalancerClient.create_rule_set` and waits for the :py:class:`~oci.load_balancer.models.WorkRequest`
@@ -800,6 +843,59 @@ class LoadBalancerClientCompositeOperations(object):
         operation_result = None
         try:
             operation_result = self.client.delete_path_route_set(load_balancer_id, path_route_set_name, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def delete_routing_policy_and_wait_for_state(self, load_balancer_id, routing_policy_name, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.load_balancer.LoadBalancerClient.delete_routing_policy` and waits for the :py:class:`~oci.load_balancer.models.WorkRequest`
+        to enter the given state(s).
+
+        :param str load_balancer_id: (required)
+            The `OCID`__ of the load balancer associated with the routing policy to delete.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str routing_policy_name: (required)
+            The name of the routing policy to delete.
+
+            Example: `example_routing_policy`
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.load_balancer.models.WorkRequest.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.load_balancer.LoadBalancerClient.delete_routing_policy`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = None
+        try:
+            operation_result = self.client.delete_routing_policy(load_balancer_id, routing_policy_name, **operation_kwargs)
         except oci.exceptions.ServiceError as e:
             if e.status == 404:
                 return WAIT_RESOURCE_NOT_FOUND
@@ -1335,6 +1431,54 @@ class LoadBalancerClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         operation_result = self.client.update_path_route_set(update_path_route_set_details, load_balancer_id, path_route_set_name, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def update_routing_policy_and_wait_for_state(self, update_routing_policy_details, load_balancer_id, routing_policy_name, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.load_balancer.LoadBalancerClient.update_routing_policy` and waits for the :py:class:`~oci.load_balancer.models.WorkRequest`
+        to enter the given state(s).
+
+        :param oci.load_balancer.models.UpdateRoutingPolicyDetails update_routing_policy_details: (required)
+            The configuration details needed to update a routing policy.
+
+        :param str load_balancer_id: (required)
+            The `OCID`__ of the load balancer associated with the routing policy to update.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str routing_policy_name: (required)
+            The name of the routing policy to update.
+
+            Example: `example_routing_policy_name`
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.load_balancer.models.WorkRequest.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.load_balancer.LoadBalancerClient.update_routing_policy`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_routing_policy(update_routing_policy_details, load_balancer_id, routing_policy_name, **operation_kwargs)
         if not wait_for_states:
             return operation_result
 

--- a/src/oci/load_balancer/models/__init__.py
+++ b/src/oci/load_balancer/models/__init__.py
@@ -4,6 +4,7 @@
 
 from __future__ import absolute_import
 
+from .action import Action
 from .add_http_request_header_rule import AddHttpRequestHeaderRule
 from .add_http_response_header_rule import AddHttpResponseHeaderRule
 from .allow_rule import AllowRule
@@ -25,10 +26,12 @@ from .create_hostname_details import CreateHostnameDetails
 from .create_listener_details import CreateListenerDetails
 from .create_load_balancer_details import CreateLoadBalancerDetails
 from .create_path_route_set_details import CreatePathRouteSetDetails
+from .create_routing_policy_details import CreateRoutingPolicyDetails
 from .create_rule_set_details import CreateRuleSetDetails
 from .create_ssl_cipher_suite_details import CreateSSLCipherSuiteDetails
 from .extend_http_request_header_value_rule import ExtendHttpRequestHeaderValueRule
 from .extend_http_response_header_value_rule import ExtendHttpResponseHeaderValueRule
+from .forward_to_backend_set import ForwardToBackendSet
 from .health_check_result import HealthCheckResult
 from .health_checker import HealthChecker
 from .health_checker_details import HealthCheckerDetails
@@ -56,6 +59,9 @@ from .redirect_uri import RedirectUri
 from .remove_http_request_header_rule import RemoveHttpRequestHeaderRule
 from .remove_http_response_header_rule import RemoveHttpResponseHeaderRule
 from .reserved_ip import ReservedIP
+from .routing_policy import RoutingPolicy
+from .routing_policy_details import RoutingPolicyDetails
+from .routing_rule import RoutingRule
 from .rule import Rule
 from .rule_condition import RuleCondition
 from .rule_set import RuleSet
@@ -78,6 +84,7 @@ from .update_load_balancer_details import UpdateLoadBalancerDetails
 from .update_load_balancer_shape_details import UpdateLoadBalancerShapeDetails
 from .update_network_security_groups_details import UpdateNetworkSecurityGroupsDetails
 from .update_path_route_set_details import UpdatePathRouteSetDetails
+from .update_routing_policy_details import UpdateRoutingPolicyDetails
 from .update_rule_set_details import UpdateRuleSetDetails
 from .update_ssl_cipher_suite_details import UpdateSSLCipherSuiteDetails
 from .work_request import WorkRequest
@@ -85,6 +92,7 @@ from .work_request_error import WorkRequestError
 
 # Maps type names to classes for load_balancer services.
 load_balancer_type_mapping = {
+    "Action": Action,
     "AddHttpRequestHeaderRule": AddHttpRequestHeaderRule,
     "AddHttpResponseHeaderRule": AddHttpResponseHeaderRule,
     "AllowRule": AllowRule,
@@ -106,10 +114,12 @@ load_balancer_type_mapping = {
     "CreateListenerDetails": CreateListenerDetails,
     "CreateLoadBalancerDetails": CreateLoadBalancerDetails,
     "CreatePathRouteSetDetails": CreatePathRouteSetDetails,
+    "CreateRoutingPolicyDetails": CreateRoutingPolicyDetails,
     "CreateRuleSetDetails": CreateRuleSetDetails,
     "CreateSSLCipherSuiteDetails": CreateSSLCipherSuiteDetails,
     "ExtendHttpRequestHeaderValueRule": ExtendHttpRequestHeaderValueRule,
     "ExtendHttpResponseHeaderValueRule": ExtendHttpResponseHeaderValueRule,
+    "ForwardToBackendSet": ForwardToBackendSet,
     "HealthCheckResult": HealthCheckResult,
     "HealthChecker": HealthChecker,
     "HealthCheckerDetails": HealthCheckerDetails,
@@ -137,6 +147,9 @@ load_balancer_type_mapping = {
     "RemoveHttpRequestHeaderRule": RemoveHttpRequestHeaderRule,
     "RemoveHttpResponseHeaderRule": RemoveHttpResponseHeaderRule,
     "ReservedIP": ReservedIP,
+    "RoutingPolicy": RoutingPolicy,
+    "RoutingPolicyDetails": RoutingPolicyDetails,
+    "RoutingRule": RoutingRule,
     "Rule": Rule,
     "RuleCondition": RuleCondition,
     "RuleSet": RuleSet,
@@ -159,6 +172,7 @@ load_balancer_type_mapping = {
     "UpdateLoadBalancerShapeDetails": UpdateLoadBalancerShapeDetails,
     "UpdateNetworkSecurityGroupsDetails": UpdateNetworkSecurityGroupsDetails,
     "UpdatePathRouteSetDetails": UpdatePathRouteSetDetails,
+    "UpdateRoutingPolicyDetails": UpdateRoutingPolicyDetails,
     "UpdateRuleSetDetails": UpdateRuleSetDetails,
     "UpdateSSLCipherSuiteDetails": UpdateSSLCipherSuiteDetails,
     "WorkRequest": WorkRequest,

--- a/src/oci/load_balancer/models/action.py
+++ b/src/oci/load_balancer/models/action.py
@@ -1,0 +1,95 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class Action(object):
+    """
+    An entity that represents an action to apply for a routing rule.
+    """
+
+    #: A constant which can be used with the name property of a Action.
+    #: This constant has a value of "FORWARD_TO_BACKENDSET"
+    NAME_FORWARD_TO_BACKENDSET = "FORWARD_TO_BACKENDSET"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new Action object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
+        to a service operations then you should favor using a subclass over the base class:
+
+        * :class:`~oci.load_balancer.models.ForwardToBackendSet`
+
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param name:
+            The value to assign to the name property of this Action.
+            Allowed values for this property are: "FORWARD_TO_BACKENDSET", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type name: str
+
+        """
+        self.swagger_types = {
+            'name': 'str'
+        }
+
+        self.attribute_map = {
+            'name': 'name'
+        }
+
+        self._name = None
+
+    @staticmethod
+    def get_subtype(object_dictionary):
+        """
+        Given the hash representation of a subtype of this class,
+        use the info in the hash to return the class of the subtype.
+        """
+        type = object_dictionary['name']
+
+        if type == 'FORWARD_TO_BACKENDSET':
+            return 'ForwardToBackendSet'
+        else:
+            return 'Action'
+
+    @property
+    def name(self):
+        """
+        **[Required]** Gets the name of this Action.
+        Allowed values for this property are: "FORWARD_TO_BACKENDSET", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The name of this Action.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this Action.
+
+        :param name: The name of this Action.
+        :type: str
+        """
+        allowed_values = ["FORWARD_TO_BACKENDSET"]
+        if not value_allowed_none_or_none_sentinel(name, allowed_values):
+            name = 'UNKNOWN_ENUM_VALUE'
+        self._name = name
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/load_balancer/models/add_http_request_header_rule.py
+++ b/src/oci/load_balancer/models/add_http_request_header_rule.py
@@ -17,8 +17,6 @@ class AddHttpRequestHeaderRule(Rule):
     *  If a matching header already exists in the request, the system removes all of its occurrences, and then adds the
     new header.
 
-    * If a customer adds empty value, it has the same effect as dropping that header.
-
     *  The system does not distinquish between underscore and dash characters in headers. That is, it treats
     `example_header_name` and `example-header-name` as identical. Oracle recommends that you do not rely on underscore
     or dash characters to uniquely distinguish header names.
@@ -93,7 +91,9 @@ class AddHttpRequestHeaderRule(Rule):
     def value(self):
         """
         **[Required]** Gets the value of this AddHttpRequestHeaderRule.
-        A header value that conforms to RFC 7230.
+        A header value that conforms to RFC 7230. With the following exceptions:
+        *  value cannot contain `$`
+        *  value cannot contain patterns like `{variable_name}`. They are reserved for future extensions. Currently, such values are invalid.
 
         Example: `example_value`
 
@@ -107,7 +107,9 @@ class AddHttpRequestHeaderRule(Rule):
     def value(self, value):
         """
         Sets the value of this AddHttpRequestHeaderRule.
-        A header value that conforms to RFC 7230.
+        A header value that conforms to RFC 7230. With the following exceptions:
+        *  value cannot contain `$`
+        *  value cannot contain patterns like `{variable_name}`. They are reserved for future extensions. Currently, such values are invalid.
 
         Example: `example_value`
 

--- a/src/oci/load_balancer/models/add_http_response_header_rule.py
+++ b/src/oci/load_balancer/models/add_http_response_header_rule.py
@@ -93,6 +93,9 @@ class AddHttpResponseHeaderRule(Rule):
         """
         **[Required]** Gets the value of this AddHttpResponseHeaderRule.
         A header value that conforms to RFC 7230.
+        With the following exceptions:
+        *  value cannot contain `$`
+        *  value cannot contain patterns like `{variable_name}`. They are reserved for future extensions. Currently, such values are invalid.
 
         Example: `example_value`
 
@@ -107,6 +110,9 @@ class AddHttpResponseHeaderRule(Rule):
         """
         Sets the value of this AddHttpResponseHeaderRule.
         A header value that conforms to RFC 7230.
+        With the following exceptions:
+        *  value cannot contain `$`
+        *  value cannot contain patterns like `{variable_name}`. They are reserved for future extensions. Currently, such values are invalid.
 
         Example: `example_value`
 

--- a/src/oci/load_balancer/models/create_listener_details.py
+++ b/src/oci/load_balancer/models/create_listener_details.py
@@ -56,6 +56,10 @@ class CreateListenerDetails(object):
             The value to assign to the name property of this CreateListenerDetails.
         :type name: str
 
+        :param routing_policy_name:
+            The value to assign to the routing_policy_name property of this CreateListenerDetails.
+        :type routing_policy_name: str
+
         :param rule_set_names:
             The value to assign to the rule_set_names property of this CreateListenerDetails.
         :type rule_set_names: list[str]
@@ -70,6 +74,7 @@ class CreateListenerDetails(object):
             'ssl_configuration': 'SSLConfigurationDetails',
             'connection_configuration': 'ConnectionConfiguration',
             'name': 'str',
+            'routing_policy_name': 'str',
             'rule_set_names': 'list[str]'
         }
 
@@ -82,6 +87,7 @@ class CreateListenerDetails(object):
             'ssl_configuration': 'sslConfiguration',
             'connection_configuration': 'connectionConfiguration',
             'name': 'name',
+            'routing_policy_name': 'routingPolicyName',
             'rule_set_names': 'ruleSetNames'
         }
 
@@ -93,6 +99,7 @@ class CreateListenerDetails(object):
         self._ssl_configuration = None
         self._connection_configuration = None
         self._name = None
+        self._routing_policy_name = None
         self._rule_set_names = None
 
     @property
@@ -211,6 +218,8 @@ class CreateListenerDetails(object):
     def path_route_set_name(self):
         """
         Gets the path_route_set_name of this CreateListenerDetails.
+        Deprecated. Please use `routingPolicies` instead.
+
         The name of the set of path-based routing rules, :class:`PathRouteSet`,
         applied to this listener's traffic.
 
@@ -226,6 +235,8 @@ class CreateListenerDetails(object):
     def path_route_set_name(self, path_route_set_name):
         """
         Sets the path_route_set_name of this CreateListenerDetails.
+        Deprecated. Please use `routingPolicies` instead.
+
         The name of the set of path-based routing rules, :class:`PathRouteSet`,
         applied to this listener's traffic.
 
@@ -306,6 +317,34 @@ class CreateListenerDetails(object):
         :type: str
         """
         self._name = name
+
+    @property
+    def routing_policy_name(self):
+        """
+        Gets the routing_policy_name of this CreateListenerDetails.
+        The name of the routing policy applied to this listener's traffic.
+
+        Example: `example_routing_policy`
+
+
+        :return: The routing_policy_name of this CreateListenerDetails.
+        :rtype: str
+        """
+        return self._routing_policy_name
+
+    @routing_policy_name.setter
+    def routing_policy_name(self, routing_policy_name):
+        """
+        Sets the routing_policy_name of this CreateListenerDetails.
+        The name of the routing policy applied to this listener's traffic.
+
+        Example: `example_routing_policy`
+
+
+        :param routing_policy_name: The routing_policy_name of this CreateListenerDetails.
+        :type: str
+        """
+        self._routing_policy_name = routing_policy_name
 
     @property
     def rule_set_names(self):

--- a/src/oci/load_balancer/models/create_routing_policy_details.py
+++ b/src/oci/load_balancer/models/create_routing_policy_details.py
@@ -1,0 +1,153 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateRoutingPolicyDetails(object):
+    """
+    An ordered list of routing rules.
+
+    **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using the API.
+    """
+
+    #: A constant which can be used with the condition_language_version property of a CreateRoutingPolicyDetails.
+    #: This constant has a value of "V1"
+    CONDITION_LANGUAGE_VERSION_V1 = "V1"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateRoutingPolicyDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param name:
+            The value to assign to the name property of this CreateRoutingPolicyDetails.
+        :type name: str
+
+        :param condition_language_version:
+            The value to assign to the condition_language_version property of this CreateRoutingPolicyDetails.
+            Allowed values for this property are: "V1"
+        :type condition_language_version: str
+
+        :param rules:
+            The value to assign to the rules property of this CreateRoutingPolicyDetails.
+        :type rules: list[oci.load_balancer.models.RoutingRule]
+
+        """
+        self.swagger_types = {
+            'name': 'str',
+            'condition_language_version': 'str',
+            'rules': 'list[RoutingRule]'
+        }
+
+        self.attribute_map = {
+            'name': 'name',
+            'condition_language_version': 'conditionLanguageVersion',
+            'rules': 'rules'
+        }
+
+        self._name = None
+        self._condition_language_version = None
+        self._rules = None
+
+    @property
+    def name(self):
+        """
+        **[Required]** Gets the name of this CreateRoutingPolicyDetails.
+        The name for this list of routing rules. It must be unique and it cannot be changed. Avoid entering
+        confidential information.
+
+        Example: `example_routing_rules`
+
+
+        :return: The name of this CreateRoutingPolicyDetails.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this CreateRoutingPolicyDetails.
+        The name for this list of routing rules. It must be unique and it cannot be changed. Avoid entering
+        confidential information.
+
+        Example: `example_routing_rules`
+
+
+        :param name: The name of this CreateRoutingPolicyDetails.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def condition_language_version(self):
+        """
+        **[Required]** Gets the condition_language_version of this CreateRoutingPolicyDetails.
+        The version of the language in which `condition` of `rules` are composed.
+
+        Allowed values for this property are: "V1"
+
+
+        :return: The condition_language_version of this CreateRoutingPolicyDetails.
+        :rtype: str
+        """
+        return self._condition_language_version
+
+    @condition_language_version.setter
+    def condition_language_version(self, condition_language_version):
+        """
+        Sets the condition_language_version of this CreateRoutingPolicyDetails.
+        The version of the language in which `condition` of `rules` are composed.
+
+
+        :param condition_language_version: The condition_language_version of this CreateRoutingPolicyDetails.
+        :type: str
+        """
+        allowed_values = ["V1"]
+        if not value_allowed_none_or_none_sentinel(condition_language_version, allowed_values):
+            raise ValueError(
+                "Invalid value for `condition_language_version`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._condition_language_version = condition_language_version
+
+    @property
+    def rules(self):
+        """
+        **[Required]** Gets the rules of this CreateRoutingPolicyDetails.
+        The list of routing rules.
+
+
+        :return: The rules of this CreateRoutingPolicyDetails.
+        :rtype: list[oci.load_balancer.models.RoutingRule]
+        """
+        return self._rules
+
+    @rules.setter
+    def rules(self, rules):
+        """
+        Sets the rules of this CreateRoutingPolicyDetails.
+        The list of routing rules.
+
+
+        :param rules: The rules of this CreateRoutingPolicyDetails.
+        :type: list[oci.load_balancer.models.RoutingRule]
+        """
+        self._rules = rules
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/load_balancer/models/extend_http_request_header_value_rule.py
+++ b/src/oci/load_balancer/models/extend_http_request_header_value_rule.py
@@ -103,6 +103,9 @@ class ExtendHttpRequestHeaderValueRule(Rule):
         """
         Gets the prefix of this ExtendHttpRequestHeaderValueRule.
         A string to prepend to the header value. The resulting header value must conform to RFC 7230.
+        With the following exceptions:
+        *  value cannot contain `$`
+        *  value cannot contain patterns like `{variable_name}`. They are reserved for future extensions. Currently, such values are invalid.
 
         Example: `example_prefix_value`
 
@@ -117,6 +120,9 @@ class ExtendHttpRequestHeaderValueRule(Rule):
         """
         Sets the prefix of this ExtendHttpRequestHeaderValueRule.
         A string to prepend to the header value. The resulting header value must conform to RFC 7230.
+        With the following exceptions:
+        *  value cannot contain `$`
+        *  value cannot contain patterns like `{variable_name}`. They are reserved for future extensions. Currently, such values are invalid.
 
         Example: `example_prefix_value`
 
@@ -131,6 +137,9 @@ class ExtendHttpRequestHeaderValueRule(Rule):
         """
         Gets the suffix of this ExtendHttpRequestHeaderValueRule.
         A string to append to the header value. The resulting header value must conform to RFC 7230.
+        With the following exceptions:
+        *  value cannot contain `$`
+        *  value cannot contain patterns like `{variable_name}`. They are reserved for future extensions. Currently, such values are invalid.
 
         Example: `example_suffix_value`
 
@@ -145,6 +154,9 @@ class ExtendHttpRequestHeaderValueRule(Rule):
         """
         Sets the suffix of this ExtendHttpRequestHeaderValueRule.
         A string to append to the header value. The resulting header value must conform to RFC 7230.
+        With the following exceptions:
+        *  value cannot contain `$`
+        *  value cannot contain patterns like `{variable_name}`. They are reserved for future extensions. Currently, such values are invalid.
 
         Example: `example_suffix_value`
 

--- a/src/oci/load_balancer/models/extend_http_response_header_value_rule.py
+++ b/src/oci/load_balancer/models/extend_http_response_header_value_rule.py
@@ -103,6 +103,9 @@ class ExtendHttpResponseHeaderValueRule(Rule):
         """
         Gets the prefix of this ExtendHttpResponseHeaderValueRule.
         A string to prepend to the header value. The resulting header value must still conform to RFC 7230.
+        With the following exceptions:
+        *  value cannot contain `$`
+        *  value cannot contain patterns like `{variable_name}`. They are reserved for future extensions. Currently, such values are invalid.
 
         Example: `example_prefix_value`
 
@@ -117,6 +120,9 @@ class ExtendHttpResponseHeaderValueRule(Rule):
         """
         Sets the prefix of this ExtendHttpResponseHeaderValueRule.
         A string to prepend to the header value. The resulting header value must still conform to RFC 7230.
+        With the following exceptions:
+        *  value cannot contain `$`
+        *  value cannot contain patterns like `{variable_name}`. They are reserved for future extensions. Currently, such values are invalid.
 
         Example: `example_prefix_value`
 
@@ -131,6 +137,9 @@ class ExtendHttpResponseHeaderValueRule(Rule):
         """
         Gets the suffix of this ExtendHttpResponseHeaderValueRule.
         A string to append to the header value. The resulting header value must still conform to RFC 7230.
+        With the following exceptions:
+        *  value cannot contain `$`
+        *  value cannot contain patterns like `{variable_name}`. They are reserved for future extensions. Currently, such values are invalid.
 
         Example: `example_suffix_value`
 
@@ -145,6 +154,9 @@ class ExtendHttpResponseHeaderValueRule(Rule):
         """
         Sets the suffix of this ExtendHttpResponseHeaderValueRule.
         A string to append to the header value. The resulting header value must still conform to RFC 7230.
+        With the following exceptions:
+        *  value cannot contain `$`
+        *  value cannot contain patterns like `{variable_name}`. They are reserved for future extensions. Currently, such values are invalid.
 
         Example: `example_suffix_value`
 

--- a/src/oci/load_balancer/models/forward_to_backend_set.py
+++ b/src/oci/load_balancer/models/forward_to_backend_set.py
@@ -1,0 +1,84 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .action import Action
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ForwardToBackendSet(Action):
+    """
+    Action to forward requests to a given backend set.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ForwardToBackendSet object with values from keyword arguments. The default value of the :py:attr:`~oci.load_balancer.models.ForwardToBackendSet.name` attribute
+        of this class is ``FORWARD_TO_BACKENDSET`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param name:
+            The value to assign to the name property of this ForwardToBackendSet.
+            Allowed values for this property are: "FORWARD_TO_BACKENDSET"
+        :type name: str
+
+        :param backend_set_name:
+            The value to assign to the backend_set_name property of this ForwardToBackendSet.
+        :type backend_set_name: str
+
+        """
+        self.swagger_types = {
+            'name': 'str',
+            'backend_set_name': 'str'
+        }
+
+        self.attribute_map = {
+            'name': 'name',
+            'backend_set_name': 'backendSetName'
+        }
+
+        self._name = None
+        self._backend_set_name = None
+        self._name = 'FORWARD_TO_BACKENDSET'
+
+    @property
+    def backend_set_name(self):
+        """
+        Gets the backend_set_name of this ForwardToBackendSet.
+        Name of the backend set the listener will forward the traffic to.
+
+        Example: `backendSetForImages`
+
+
+        :return: The backend_set_name of this ForwardToBackendSet.
+        :rtype: str
+        """
+        return self._backend_set_name
+
+    @backend_set_name.setter
+    def backend_set_name(self, backend_set_name):
+        """
+        Sets the backend_set_name of this ForwardToBackendSet.
+        Name of the backend set the listener will forward the traffic to.
+
+        Example: `backendSetForImages`
+
+
+        :param backend_set_name: The backend_set_name of this ForwardToBackendSet.
+        :type: str
+        """
+        self._backend_set_name = backend_set_name
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/load_balancer/models/listener.py
+++ b/src/oci/load_balancer/models/listener.py
@@ -58,6 +58,10 @@ class Listener(object):
             The value to assign to the rule_set_names property of this Listener.
         :type rule_set_names: list[str]
 
+        :param routing_policy_name:
+            The value to assign to the routing_policy_name property of this Listener.
+        :type routing_policy_name: str
+
         """
         self.swagger_types = {
             'name': 'str',
@@ -68,7 +72,8 @@ class Listener(object):
             'path_route_set_name': 'str',
             'ssl_configuration': 'SSLConfiguration',
             'connection_configuration': 'ConnectionConfiguration',
-            'rule_set_names': 'list[str]'
+            'rule_set_names': 'list[str]',
+            'routing_policy_name': 'str'
         }
 
         self.attribute_map = {
@@ -80,7 +85,8 @@ class Listener(object):
             'path_route_set_name': 'pathRouteSetName',
             'ssl_configuration': 'sslConfiguration',
             'connection_configuration': 'connectionConfiguration',
-            'rule_set_names': 'ruleSetNames'
+            'rule_set_names': 'ruleSetNames',
+            'routing_policy_name': 'routingPolicyName'
         }
 
         self._name = None
@@ -92,6 +98,7 @@ class Listener(object):
         self._ssl_configuration = None
         self._connection_configuration = None
         self._rule_set_names = None
+        self._routing_policy_name = None
 
     @property
     def name(self):
@@ -237,6 +244,8 @@ class Listener(object):
     def path_route_set_name(self):
         """
         Gets the path_route_set_name of this Listener.
+        Deprecated. Please use `routingPolicies` instead.
+
         The name of the set of path-based routing rules, :class:`PathRouteSet`,
         applied to this listener's traffic.
 
@@ -252,6 +261,8 @@ class Listener(object):
     def path_route_set_name(self, path_route_set_name):
         """
         Sets the path_route_set_name of this Listener.
+        Deprecated. Please use `routingPolicies` instead.
+
         The name of the set of path-based routing rules, :class:`PathRouteSet`,
         applied to this listener's traffic.
 
@@ -330,6 +341,34 @@ class Listener(object):
         :type: list[str]
         """
         self._rule_set_names = rule_set_names
+
+    @property
+    def routing_policy_name(self):
+        """
+        Gets the routing_policy_name of this Listener.
+        The name of the routing policy applied to this listener's traffic.
+
+        Example: `example_routing_policy_name`
+
+
+        :return: The routing_policy_name of this Listener.
+        :rtype: str
+        """
+        return self._routing_policy_name
+
+    @routing_policy_name.setter
+    def routing_policy_name(self, routing_policy_name):
+        """
+        Sets the routing_policy_name of this Listener.
+        The name of the routing policy applied to this listener's traffic.
+
+        Example: `example_routing_policy_name`
+
+
+        :param routing_policy_name: The routing_policy_name of this Listener.
+        :type: str
+        """
+        self._routing_policy_name = routing_policy_name
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/load_balancer/models/listener_details.py
+++ b/src/oci/load_balancer/models/listener_details.py
@@ -46,6 +46,10 @@ class ListenerDetails(object):
             The value to assign to the connection_configuration property of this ListenerDetails.
         :type connection_configuration: oci.load_balancer.models.ConnectionConfiguration
 
+        :param routing_policy_name:
+            The value to assign to the routing_policy_name property of this ListenerDetails.
+        :type routing_policy_name: str
+
         :param rule_set_names:
             The value to assign to the rule_set_names property of this ListenerDetails.
         :type rule_set_names: list[str]
@@ -59,6 +63,7 @@ class ListenerDetails(object):
             'path_route_set_name': 'str',
             'ssl_configuration': 'SSLConfigurationDetails',
             'connection_configuration': 'ConnectionConfiguration',
+            'routing_policy_name': 'str',
             'rule_set_names': 'list[str]'
         }
 
@@ -70,6 +75,7 @@ class ListenerDetails(object):
             'path_route_set_name': 'pathRouteSetName',
             'ssl_configuration': 'sslConfiguration',
             'connection_configuration': 'connectionConfiguration',
+            'routing_policy_name': 'routingPolicyName',
             'rule_set_names': 'ruleSetNames'
         }
 
@@ -80,6 +86,7 @@ class ListenerDetails(object):
         self._path_route_set_name = None
         self._ssl_configuration = None
         self._connection_configuration = None
+        self._routing_policy_name = None
         self._rule_set_names = None
 
     @property
@@ -198,6 +205,8 @@ class ListenerDetails(object):
     def path_route_set_name(self):
         """
         Gets the path_route_set_name of this ListenerDetails.
+        Deprecated. Please use `routingPolicies` instead.
+
         The name of the set of path-based routing rules, :class:`PathRouteSet`,
         applied to this listener's traffic.
 
@@ -213,6 +222,8 @@ class ListenerDetails(object):
     def path_route_set_name(self, path_route_set_name):
         """
         Sets the path_route_set_name of this ListenerDetails.
+        Deprecated. Please use `routingPolicies` instead.
+
         The name of the set of path-based routing rules, :class:`PathRouteSet`,
         applied to this listener's traffic.
 
@@ -263,6 +274,34 @@ class ListenerDetails(object):
         :type: oci.load_balancer.models.ConnectionConfiguration
         """
         self._connection_configuration = connection_configuration
+
+    @property
+    def routing_policy_name(self):
+        """
+        Gets the routing_policy_name of this ListenerDetails.
+        The name of the routing policy applied to this listener's traffic.
+
+        Example: `example_routing_policy`
+
+
+        :return: The routing_policy_name of this ListenerDetails.
+        :rtype: str
+        """
+        return self._routing_policy_name
+
+    @routing_policy_name.setter
+    def routing_policy_name(self, routing_policy_name):
+        """
+        Sets the routing_policy_name of this ListenerDetails.
+        The name of the routing policy applied to this listener's traffic.
+
+        Example: `example_routing_policy`
+
+
+        :param routing_policy_name: The routing_policy_name of this ListenerDetails.
+        :type: str
+        """
+        self._routing_policy_name = routing_policy_name
 
     @property
     def rule_set_names(self):

--- a/src/oci/load_balancer/models/load_balancer.py
+++ b/src/oci/load_balancer/models/load_balancer.py
@@ -138,6 +138,10 @@ class LoadBalancer(object):
             The value to assign to the rule_sets property of this LoadBalancer.
         :type rule_sets: dict(str, RuleSet)
 
+        :param routing_policies:
+            The value to assign to the routing_policies property of this LoadBalancer.
+        :type routing_policies: dict(str, RoutingPolicy)
+
         """
         self.swagger_types = {
             'id': 'str',
@@ -160,7 +164,8 @@ class LoadBalancer(object):
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
             'system_tags': 'dict(str, dict(str, object))',
-            'rule_sets': 'dict(str, RuleSet)'
+            'rule_sets': 'dict(str, RuleSet)',
+            'routing_policies': 'dict(str, RoutingPolicy)'
         }
 
         self.attribute_map = {
@@ -184,7 +189,8 @@ class LoadBalancer(object):
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
             'system_tags': 'systemTags',
-            'rule_sets': 'ruleSets'
+            'rule_sets': 'ruleSets',
+            'routing_policies': 'routingPolicies'
         }
 
         self._id = None
@@ -208,6 +214,7 @@ class LoadBalancer(object):
         self._defined_tags = None
         self._system_tags = None
         self._rule_sets = None
+        self._routing_policies = None
 
     @property
     def id(self):
@@ -800,6 +807,26 @@ class LoadBalancer(object):
         :type: dict(str, RuleSet)
         """
         self._rule_sets = rule_sets
+
+    @property
+    def routing_policies(self):
+        """
+        Gets the routing_policies of this LoadBalancer.
+
+        :return: The routing_policies of this LoadBalancer.
+        :rtype: dict(str, RoutingPolicy)
+        """
+        return self._routing_policies
+
+    @routing_policies.setter
+    def routing_policies(self, routing_policies):
+        """
+        Sets the routing_policies of this LoadBalancer.
+
+        :param routing_policies: The routing_policies of this LoadBalancer.
+        :type: dict(str, RoutingPolicy)
+        """
+        self._routing_policies = routing_policies
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/load_balancer/models/routing_policy.py
+++ b/src/oci/load_balancer/models/routing_policy.py
@@ -1,0 +1,150 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class RoutingPolicy(object):
+    """
+    A named ordered list of routing rules that is applied to a listener.
+
+    **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using the API.
+    """
+
+    #: A constant which can be used with the condition_language_version property of a RoutingPolicy.
+    #: This constant has a value of "V1"
+    CONDITION_LANGUAGE_VERSION_V1 = "V1"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new RoutingPolicy object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param name:
+            The value to assign to the name property of this RoutingPolicy.
+        :type name: str
+
+        :param condition_language_version:
+            The value to assign to the condition_language_version property of this RoutingPolicy.
+            Allowed values for this property are: "V1", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type condition_language_version: str
+
+        :param rules:
+            The value to assign to the rules property of this RoutingPolicy.
+        :type rules: list[oci.load_balancer.models.RoutingRule]
+
+        """
+        self.swagger_types = {
+            'name': 'str',
+            'condition_language_version': 'str',
+            'rules': 'list[RoutingRule]'
+        }
+
+        self.attribute_map = {
+            'name': 'name',
+            'condition_language_version': 'conditionLanguageVersion',
+            'rules': 'rules'
+        }
+
+        self._name = None
+        self._condition_language_version = None
+        self._rules = None
+
+    @property
+    def name(self):
+        """
+        **[Required]** Gets the name of this RoutingPolicy.
+        The unique name for this list of routing rules. Avoid entering confidential information.
+
+        Example: `example_routing_policy`
+
+
+        :return: The name of this RoutingPolicy.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this RoutingPolicy.
+        The unique name for this list of routing rules. Avoid entering confidential information.
+
+        Example: `example_routing_policy`
+
+
+        :param name: The name of this RoutingPolicy.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def condition_language_version(self):
+        """
+        **[Required]** Gets the condition_language_version of this RoutingPolicy.
+        The version of the language in which `condition` of `rules` are composed.
+
+        Allowed values for this property are: "V1", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The condition_language_version of this RoutingPolicy.
+        :rtype: str
+        """
+        return self._condition_language_version
+
+    @condition_language_version.setter
+    def condition_language_version(self, condition_language_version):
+        """
+        Sets the condition_language_version of this RoutingPolicy.
+        The version of the language in which `condition` of `rules` are composed.
+
+
+        :param condition_language_version: The condition_language_version of this RoutingPolicy.
+        :type: str
+        """
+        allowed_values = ["V1"]
+        if not value_allowed_none_or_none_sentinel(condition_language_version, allowed_values):
+            condition_language_version = 'UNKNOWN_ENUM_VALUE'
+        self._condition_language_version = condition_language_version
+
+    @property
+    def rules(self):
+        """
+        **[Required]** Gets the rules of this RoutingPolicy.
+        The ordered list of routing rules.
+
+
+        :return: The rules of this RoutingPolicy.
+        :rtype: list[oci.load_balancer.models.RoutingRule]
+        """
+        return self._rules
+
+    @rules.setter
+    def rules(self, rules):
+        """
+        Sets the rules of this RoutingPolicy.
+        The ordered list of routing rules.
+
+
+        :param rules: The rules of this RoutingPolicy.
+        :type: list[oci.load_balancer.models.RoutingRule]
+        """
+        self._rules = rules
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/load_balancer/models/routing_policy_details.py
+++ b/src/oci/load_balancer/models/routing_policy_details.py
@@ -1,0 +1,71 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class RoutingPolicyDetails(object):
+    """
+    An ordered list of routing rules.
+    **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using the API.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new RoutingPolicyDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param rules:
+            The value to assign to the rules property of this RoutingPolicyDetails.
+        :type rules: list[oci.load_balancer.models.RoutingRule]
+
+        """
+        self.swagger_types = {
+            'rules': 'list[RoutingRule]'
+        }
+
+        self.attribute_map = {
+            'rules': 'rules'
+        }
+
+        self._rules = None
+
+    @property
+    def rules(self):
+        """
+        **[Required]** Gets the rules of this RoutingPolicyDetails.
+        The list of routing rules.
+
+
+        :return: The rules of this RoutingPolicyDetails.
+        :rtype: list[oci.load_balancer.models.RoutingRule]
+        """
+        return self._rules
+
+    @rules.setter
+    def rules(self, rules):
+        """
+        Sets the rules of this RoutingPolicyDetails.
+        The list of routing rules.
+
+
+        :param rules: The rules of this RoutingPolicyDetails.
+        :type: list[oci.load_balancer.models.RoutingRule]
+        """
+        self._rules = rules
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/load_balancer/models/routing_rule.py
+++ b/src/oci/load_balancer/models/routing_rule.py
@@ -1,0 +1,133 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class RoutingRule(object):
+    """
+    A routing rule examines an incoming request, routing matching requests to the specified backend set.
+    Routing rules apply only to HTTP and HTTPS requests. They have no effect on TCP requests.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new RoutingRule object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param name:
+            The value to assign to the name property of this RoutingRule.
+        :type name: str
+
+        :param condition:
+            The value to assign to the condition property of this RoutingRule.
+        :type condition: str
+
+        :param actions:
+            The value to assign to the actions property of this RoutingRule.
+        :type actions: list[oci.load_balancer.models.Action]
+
+        """
+        self.swagger_types = {
+            'name': 'str',
+            'condition': 'str',
+            'actions': 'list[Action]'
+        }
+
+        self.attribute_map = {
+            'name': 'name',
+            'condition': 'condition',
+            'actions': 'actions'
+        }
+
+        self._name = None
+        self._condition = None
+        self._actions = None
+
+    @property
+    def name(self):
+        """
+        **[Required]** Gets the name of this RoutingRule.
+        A unique name for the routing policy rule. Avoid entering confidential information.
+
+
+        :return: The name of this RoutingRule.
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the name of this RoutingRule.
+        A unique name for the routing policy rule. Avoid entering confidential information.
+
+
+        :param name: The name of this RoutingRule.
+        :type: str
+        """
+        self._name = name
+
+    @property
+    def condition(self):
+        """
+        **[Required]** Gets the condition of this RoutingRule.
+        A routing rule to evaluate defined conditions against the incoming HTTP request and perform an action.
+
+
+        :return: The condition of this RoutingRule.
+        :rtype: str
+        """
+        return self._condition
+
+    @condition.setter
+    def condition(self, condition):
+        """
+        Sets the condition of this RoutingRule.
+        A routing rule to evaluate defined conditions against the incoming HTTP request and perform an action.
+
+
+        :param condition: The condition of this RoutingRule.
+        :type: str
+        """
+        self._condition = condition
+
+    @property
+    def actions(self):
+        """
+        **[Required]** Gets the actions of this RoutingRule.
+        A list of actions to be applied when conditions of the routing rule are met.
+
+
+        :return: The actions of this RoutingRule.
+        :rtype: list[oci.load_balancer.models.Action]
+        """
+        return self._actions
+
+    @actions.setter
+    def actions(self, actions):
+        """
+        Sets the actions of this RoutingRule.
+        A list of actions to be applied when conditions of the routing rule are met.
+
+
+        :param actions: The actions of this RoutingRule.
+        :type: list[oci.load_balancer.models.Action]
+        """
+        self._actions = actions
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/load_balancer/models/source_ip_address_condition.py
+++ b/src/oci/load_balancer/models/source_ip_address_condition.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class SourceIpAddressCondition(RuleCondition):
     """
-    An access control rule condition that requires a match on the specified source IP address or address range.
+    A rule condition that checks client source IP against specified IP address or address range.
     """
 
     def __init__(self, **kwargs):

--- a/src/oci/load_balancer/models/update_listener_details.py
+++ b/src/oci/load_balancer/models/update_listener_details.py
@@ -38,6 +38,10 @@ class UpdateListenerDetails(object):
             The value to assign to the path_route_set_name property of this UpdateListenerDetails.
         :type path_route_set_name: str
 
+        :param routing_policy_name:
+            The value to assign to the routing_policy_name property of this UpdateListenerDetails.
+        :type routing_policy_name: str
+
         :param ssl_configuration:
             The value to assign to the ssl_configuration property of this UpdateListenerDetails.
         :type ssl_configuration: oci.load_balancer.models.SSLConfigurationDetails
@@ -57,6 +61,7 @@ class UpdateListenerDetails(object):
             'protocol': 'str',
             'hostname_names': 'list[str]',
             'path_route_set_name': 'str',
+            'routing_policy_name': 'str',
             'ssl_configuration': 'SSLConfigurationDetails',
             'connection_configuration': 'ConnectionConfiguration',
             'rule_set_names': 'list[str]'
@@ -68,6 +73,7 @@ class UpdateListenerDetails(object):
             'protocol': 'protocol',
             'hostname_names': 'hostnameNames',
             'path_route_set_name': 'pathRouteSetName',
+            'routing_policy_name': 'routingPolicyName',
             'ssl_configuration': 'sslConfiguration',
             'connection_configuration': 'connectionConfiguration',
             'rule_set_names': 'ruleSetNames'
@@ -78,6 +84,7 @@ class UpdateListenerDetails(object):
         self._protocol = None
         self._hostname_names = None
         self._path_route_set_name = None
+        self._routing_policy_name = None
         self._ssl_configuration = None
         self._connection_configuration = None
         self._rule_set_names = None
@@ -198,6 +205,8 @@ class UpdateListenerDetails(object):
     def path_route_set_name(self):
         """
         Gets the path_route_set_name of this UpdateListenerDetails.
+        Deprecated. Please use `routingPolicies` instead.
+
         The name of the set of path-based routing rules, :class:`PathRouteSet`,
         applied to this listener's traffic.
 
@@ -213,6 +222,8 @@ class UpdateListenerDetails(object):
     def path_route_set_name(self, path_route_set_name):
         """
         Sets the path_route_set_name of this UpdateListenerDetails.
+        Deprecated. Please use `routingPolicies` instead.
+
         The name of the set of path-based routing rules, :class:`PathRouteSet`,
         applied to this listener's traffic.
 
@@ -223,6 +234,34 @@ class UpdateListenerDetails(object):
         :type: str
         """
         self._path_route_set_name = path_route_set_name
+
+    @property
+    def routing_policy_name(self):
+        """
+        Gets the routing_policy_name of this UpdateListenerDetails.
+        The name of the routing policy applied to this listener's traffic.
+
+        Example: `example_routing_policy`
+
+
+        :return: The routing_policy_name of this UpdateListenerDetails.
+        :rtype: str
+        """
+        return self._routing_policy_name
+
+    @routing_policy_name.setter
+    def routing_policy_name(self, routing_policy_name):
+        """
+        Sets the routing_policy_name of this UpdateListenerDetails.
+        The name of the routing policy applied to this listener's traffic.
+
+        Example: `example_routing_policy`
+
+
+        :param routing_policy_name: The routing_policy_name of this UpdateListenerDetails.
+        :type: str
+        """
+        self._routing_policy_name = routing_policy_name
 
     @property
     def ssl_configuration(self):

--- a/src/oci/load_balancer/models/update_routing_policy_details.py
+++ b/src/oci/load_balancer/models/update_routing_policy_details.py
@@ -1,0 +1,114 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateRoutingPolicyDetails(object):
+    """
+    An updated list of routing rules that overwrites the existing list of routing rules.
+    """
+
+    #: A constant which can be used with the condition_language_version property of a UpdateRoutingPolicyDetails.
+    #: This constant has a value of "V1"
+    CONDITION_LANGUAGE_VERSION_V1 = "V1"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateRoutingPolicyDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param condition_language_version:
+            The value to assign to the condition_language_version property of this UpdateRoutingPolicyDetails.
+            Allowed values for this property are: "V1"
+        :type condition_language_version: str
+
+        :param rules:
+            The value to assign to the rules property of this UpdateRoutingPolicyDetails.
+        :type rules: list[oci.load_balancer.models.RoutingRule]
+
+        """
+        self.swagger_types = {
+            'condition_language_version': 'str',
+            'rules': 'list[RoutingRule]'
+        }
+
+        self.attribute_map = {
+            'condition_language_version': 'conditionLanguageVersion',
+            'rules': 'rules'
+        }
+
+        self._condition_language_version = None
+        self._rules = None
+
+    @property
+    def condition_language_version(self):
+        """
+        Gets the condition_language_version of this UpdateRoutingPolicyDetails.
+        The version of the language in which `condition` of `rules` are composed.
+
+        Allowed values for this property are: "V1"
+
+
+        :return: The condition_language_version of this UpdateRoutingPolicyDetails.
+        :rtype: str
+        """
+        return self._condition_language_version
+
+    @condition_language_version.setter
+    def condition_language_version(self, condition_language_version):
+        """
+        Sets the condition_language_version of this UpdateRoutingPolicyDetails.
+        The version of the language in which `condition` of `rules` are composed.
+
+
+        :param condition_language_version: The condition_language_version of this UpdateRoutingPolicyDetails.
+        :type: str
+        """
+        allowed_values = ["V1"]
+        if not value_allowed_none_or_none_sentinel(condition_language_version, allowed_values):
+            raise ValueError(
+                "Invalid value for `condition_language_version`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._condition_language_version = condition_language_version
+
+    @property
+    def rules(self):
+        """
+        **[Required]** Gets the rules of this UpdateRoutingPolicyDetails.
+        The list of routing rules.
+
+
+        :return: The rules of this UpdateRoutingPolicyDetails.
+        :rtype: list[oci.load_balancer.models.RoutingRule]
+        """
+        return self._rules
+
+    @rules.setter
+    def rules(self, rules):
+        """
+        Sets the rules of this UpdateRoutingPolicyDetails.
+        The list of routing rules.
+
+
+        :param rules: The rules of this UpdateRoutingPolicyDetails.
+        :type: list[oci.load_balancer.models.RoutingRule]
+        """
+        self._rules = rules
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/log_analytics/log_analytics_client.py
+++ b/src/oci/log_analytics/log_analytics_client.py
@@ -300,9 +300,6 @@ class LogAnalyticsClient(object):
         if kwargs.get('retry_strategy'):
             retry_strategy = kwargs.get('retry_strategy')
 
-        # Disable the retry_strategy to work around data corruption issue temporarily
-        if retry_strategy:
-            retry_strategy = None
         if retry_strategy:
             if not isinstance(retry_strategy, retry.NoneRetryStrategy):
                 self.base_client.add_opc_retry_token_if_needed(header_params)
@@ -5970,9 +5967,6 @@ class LogAnalyticsClient(object):
         if kwargs.get('retry_strategy'):
             retry_strategy = kwargs.get('retry_strategy')
 
-        # Disable the retry_strategy to work around data corruption issue temporarily
-        if retry_strategy:
-            retry_strategy = None
         if retry_strategy:
             if not isinstance(retry_strategy, retry.NoneRetryStrategy):
                 self.base_client.add_opc_retry_token_if_needed(header_params)
@@ -11884,9 +11878,6 @@ class LogAnalyticsClient(object):
         if kwargs.get('retry_strategy'):
             retry_strategy = kwargs.get('retry_strategy')
 
-        # Disable the retry_strategy to work around data corruption issue temporarily
-        if retry_strategy:
-            retry_strategy = None
         if retry_strategy:
             if not isinstance(retry_strategy, retry.NoneRetryStrategy):
                 self.base_client.add_opc_retry_token_if_needed(header_params)
@@ -13294,9 +13285,6 @@ class LogAnalyticsClient(object):
         if kwargs.get('retry_strategy'):
             retry_strategy = kwargs.get('retry_strategy')
 
-        # Disable the retry_strategy to work around data corruption issue temporarily
-        if retry_strategy:
-            retry_strategy = None
         if retry_strategy:
             if not isinstance(retry_strategy, retry.NoneRetryStrategy):
                 self.base_client.add_opc_retry_token_if_needed(header_params)
@@ -13651,9 +13639,6 @@ class LogAnalyticsClient(object):
         if kwargs.get('retry_strategy'):
             retry_strategy = kwargs.get('retry_strategy')
 
-        # Disable the retry_strategy to work around data corruption issue temporarily
-        if retry_strategy:
-            retry_strategy = None
         if retry_strategy:
             if not isinstance(retry_strategy, retry.NoneRetryStrategy):
                 self.base_client.add_opc_retry_token_if_needed(header_params)

--- a/src/oci/object_storage/object_storage_client.py
+++ b/src/oci/object_storage/object_storage_client.py
@@ -4197,9 +4197,6 @@ class ObjectStorageClient(object):
         if kwargs.get('retry_strategy'):
             retry_strategy = kwargs.get('retry_strategy')
 
-        # Disable the retry_strategy to work around data corruption issue temporarily
-        if retry_strategy:
-            retry_strategy = None
         if retry_strategy:
             return retry_strategy.make_retrying_call(
                 self.base_client.call_api,
@@ -5207,9 +5204,6 @@ class ObjectStorageClient(object):
         if kwargs.get('retry_strategy'):
             retry_strategy = kwargs.get('retry_strategy')
 
-        # Disable the retry_strategy to work around data corruption issue temporarily
-        if retry_strategy:
-            retry_strategy = None
         if retry_strategy:
             return retry_strategy.make_retrying_call(
                 self.base_client.call_api,

--- a/src/oci/object_storage/transfer/internal/multipart_object_assembler.py
+++ b/src/oci/object_storage/transfer/internal/multipart_object_assembler.py
@@ -22,7 +22,7 @@ from oci.fips import is_fips_mode
 
 READ_BUFFER_SIZE = 8 * 1024
 DEFAULT_PARALLEL_PROCESS_COUNT = 3
-DEFAULT_MAX_RETRIES = 3
+DEFAULT_MAX_RETRIES = 5
 SSEC_PARAM_NAMES = [
     'opc_sse_customer_algorithm',
     'opc_sse_customer_key',

--- a/src/oci/oce/models/update_oce_instance_details.py
+++ b/src/oci/oce/models/update_oce_instance_details.py
@@ -21,6 +21,14 @@ class UpdateOceInstanceDetails(object):
     #: This constant has a value of "BYOL"
     INSTANCE_LICENSE_TYPE_BYOL = "BYOL"
 
+    #: A constant which can be used with the instance_usage_type property of a UpdateOceInstanceDetails.
+    #: This constant has a value of "PRIMARY"
+    INSTANCE_USAGE_TYPE_PRIMARY = "PRIMARY"
+
+    #: A constant which can be used with the instance_usage_type property of a UpdateOceInstanceDetails.
+    #: This constant has a value of "NONPRIMARY"
+    INSTANCE_USAGE_TYPE_NONPRIMARY = "NONPRIMARY"
+
     def __init__(self, **kwargs):
         """
         Initializes a new UpdateOceInstanceDetails object with values from keyword arguments.
@@ -39,6 +47,11 @@ class UpdateOceInstanceDetails(object):
             Allowed values for this property are: "NEW", "BYOL"
         :type instance_license_type: str
 
+        :param instance_usage_type:
+            The value to assign to the instance_usage_type property of this UpdateOceInstanceDetails.
+            Allowed values for this property are: "PRIMARY", "NONPRIMARY"
+        :type instance_usage_type: str
+
         :param freeform_tags:
             The value to assign to the freeform_tags property of this UpdateOceInstanceDetails.
         :type freeform_tags: dict(str, str)
@@ -52,6 +65,7 @@ class UpdateOceInstanceDetails(object):
             'description': 'str',
             'waf_primary_domain': 'str',
             'instance_license_type': 'str',
+            'instance_usage_type': 'str',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))'
         }
@@ -60,6 +74,7 @@ class UpdateOceInstanceDetails(object):
             'description': 'description',
             'waf_primary_domain': 'wafPrimaryDomain',
             'instance_license_type': 'instanceLicenseType',
+            'instance_usage_type': 'instanceUsageType',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags'
         }
@@ -67,6 +82,7 @@ class UpdateOceInstanceDetails(object):
         self._description = None
         self._waf_primary_domain = None
         self._instance_license_type = None
+        self._instance_usage_type = None
         self._freeform_tags = None
         self._defined_tags = None
 
@@ -149,6 +165,38 @@ class UpdateOceInstanceDetails(object):
                 .format(allowed_values)
             )
         self._instance_license_type = instance_license_type
+
+    @property
+    def instance_usage_type(self):
+        """
+        Gets the instance_usage_type of this UpdateOceInstanceDetails.
+        Instance type based on its usage
+
+        Allowed values for this property are: "PRIMARY", "NONPRIMARY"
+
+
+        :return: The instance_usage_type of this UpdateOceInstanceDetails.
+        :rtype: str
+        """
+        return self._instance_usage_type
+
+    @instance_usage_type.setter
+    def instance_usage_type(self, instance_usage_type):
+        """
+        Sets the instance_usage_type of this UpdateOceInstanceDetails.
+        Instance type based on its usage
+
+
+        :param instance_usage_type: The instance_usage_type of this UpdateOceInstanceDetails.
+        :type: str
+        """
+        allowed_values = ["PRIMARY", "NONPRIMARY"]
+        if not value_allowed_none_or_none_sentinel(instance_usage_type, allowed_values):
+            raise ValueError(
+                "Invalid value for `instance_usage_type`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._instance_usage_type = instance_usage_type
 
     @property
     def freeform_tags(self):

--- a/src/oci/resource_search/resource_search_client.py
+++ b/src/oci/resource_search/resource_search_client.py
@@ -79,7 +79,7 @@ class ResourceSearchClient(object):
             'service_endpoint': kwargs.get('service_endpoint'),
             'timeout': kwargs.get('timeout'),
             'base_path': '/20180409',
-            'service_endpoint_template': 'https://query.{region}.{secondLevelDomain}',
+            'service_endpoint_template': 'https://query.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
         self.base_client = BaseClient("resource_search", config, signer, resource_search_type_mapping, **base_client_init_kwargs)
@@ -246,7 +246,7 @@ class ResourceSearchClient(object):
 
 
         :param oci.resource_search.models.SearchDetails search_details: (required)
-            Request parameters that describe query criteria.
+            Request parameters that describe query criteria. For more information, see :func:`search_details`.
 
         :param int limit: (optional)
             The maximum number of items to return. The value must be between 1 and 1000.

--- a/src/oci/retry/retry_utils.py
+++ b/src/oci/retry/retry_utils.py
@@ -1,0 +1,53 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from io import SEEK_SET
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def should_record_body_position_for_retry(func_ref, **func_kwargs):
+    func_name = func_ref.__name__
+    # TODO: remove Python 2 requirements, use qualname
+    if func_name == 'call_api':
+        body = func_kwargs.get('body')
+        # A file-like object body should be treated differently for retry
+        if body and hasattr(body, 'read'):
+            return True
+        return False
+    return False
+
+
+def record_body_position_for_retry(body):
+    is_body_retryable = True
+    if getattr(body, 'tell', None) is not None:
+        try:
+            # Attempt to record current body position
+            body_position = body.tell()
+        except (IOError, OSError):
+            # If we cannot record the current body position for a file-like body, then we should not retry
+            is_body_retryable = False
+            body_position = None
+            logger.warning("Unable to record body position for retrying. This request will not be retried")
+    else:
+        # If the body does not support tell, then don't retry
+        is_body_retryable = False
+        body_position = None
+        logger.warning("Unable to record body position for retrying. This request will not be retried")
+    return is_body_retryable, body_position
+
+
+def rewind_body_for_retry(body, body_position):
+    if getattr(body, 'seek', None) is not None:
+        try:
+            body.seek(body_position, SEEK_SET)
+        except (IOError, OSError):
+            # If we're unable to reset the body position, then we should not retry
+            logger.warning("Unable to reset body position for retrying. This request will not be retried")
+            return False
+        return True
+    # if the body does not support seek, then we should not retry
+    logger.warning("Unable to reset body position for retrying. This request will not be retried")
+    return False

--- a/src/oci/version.py
+++ b/src/oci/version.py
@@ -2,4 +2,4 @@
 # Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
 # This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 
-__version__ = "2.32.1"
+__version__ = "2.33.0"


### PR DESCRIPTION
## Added
* Support for routing policies and HTTP2 listener protocols in the Load Balancing service
* Support for model deployments in the Data Science service
* Support for private clusters in the Container Engine for Kubernetes service
* Support for updating an instance's usage type in the Content and Experience service
## Breaking
* Retries are now enabled on all operations performing binary data upload, except upload manager. The SDK used to explicitly override retry configuration on binary upload operations because of potential data corruption issue (https://github.com/oracle/oci-python-sdk/issues/203).

