### PR TITLE
Releasing version 2.37.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 ====================
+2.37.0 - 2020-04-20
+====================
+
+Added
+-----
+* Support for opting in/out of live migration on instances in the Compute service
+* Support for enabling/disabling Operations Insights on external non-container and external pluggable databases in the Database service
+* Support for a GraphStudio URL as a connection URL on databases in the Database service
+* Support for adding customer contacts on autonomous databases in the Database service
+* Support for name annotations on harvested objects in the Data Catalog service
+
+Changed
+-------
+* If retries are enabled, the SDK will now retry on status 409/IncorrectState. It will not retry on status 501.
+
+Breaking
+--------
+* Bumped cryptography version to 3.3.2 to address security vulnerability https://github.com/oracle/oci-python-sdk/pull/322
+
+====================
 2.36.0 - 2020-04-13
 ====================
 

--- a/docs/api/data_catalog.rst
+++ b/docs/api/data_catalog.rst
@@ -133,6 +133,8 @@ Data Catalog
     oci.data_catalog.models.SearchResultCollection
     oci.data_catalog.models.SearchTagSummary
     oci.data_catalog.models.SearchTermSummary
+    oci.data_catalog.models.SuggestListItem
+    oci.data_catalog.models.SuggestResults
     oci.data_catalog.models.Term
     oci.data_catalog.models.TermAssociatedObject
     oci.data_catalog.models.TermCollection

--- a/docs/api/data_catalog/models/oci.data_catalog.models.SuggestListItem.rst
+++ b/docs/api/data_catalog/models/oci.data_catalog.models.SuggestListItem.rst
@@ -1,0 +1,11 @@
+SuggestListItem
+===============
+
+.. currentmodule:: oci.data_catalog.models
+
+.. autoclass:: SuggestListItem
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_catalog/models/oci.data_catalog.models.SuggestResults.rst
+++ b/docs/api/data_catalog/models/oci.data_catalog.models.SuggestResults.rst
@@ -1,0 +1,11 @@
+SuggestResults
+==============
+
+.. currentmodule:: oci.data_catalog.models
+
+.. autoclass:: SuggestResults
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database.rst
+++ b/docs/api/database.rst
@@ -117,6 +117,7 @@ Database
     oci.database.models.CreateRecoveryApplianceBackupDestinationDetails
     oci.database.models.CreateRefreshableAutonomousDatabaseCloneDetails
     oci.database.models.CreateVmClusterDetails
+    oci.database.models.CustomerContact
     oci.database.models.DataGuardAssociation
     oci.database.models.DataGuardAssociationSummary
     oci.database.models.Database
@@ -151,8 +152,11 @@ Database
     oci.database.models.DeregisterAutonomousDatabaseDataSafeDetails
     oci.database.models.EnableExternalContainerDatabaseDatabaseManagementDetails
     oci.database.models.EnableExternalDatabaseManagementDetailsBase
+    oci.database.models.EnableExternalDatabaseOperationsInsightsDetailsBase
     oci.database.models.EnableExternalNonContainerDatabaseDatabaseManagementDetails
+    oci.database.models.EnableExternalNonContainerDatabaseOperationsInsightsDetails
     oci.database.models.EnableExternalPluggableDatabaseDatabaseManagementDetails
+    oci.database.models.EnableExternalPluggableDatabaseOperationsInsightsDetails
     oci.database.models.ExadataDbSystemMigration
     oci.database.models.ExadataDbSystemMigrationSummary
     oci.database.models.ExadataInfrastructure
@@ -198,6 +202,7 @@ Database
     oci.database.models.MountTypeDetails
     oci.database.models.NodeDetails
     oci.database.models.OCPUs
+    oci.database.models.OperationsInsightsConfig
     oci.database.models.Patch
     oci.database.models.PatchDetails
     oci.database.models.PatchHistoryEntry

--- a/docs/api/database/models/oci.database.models.CustomerContact.rst
+++ b/docs/api/database/models/oci.database.models.CustomerContact.rst
@@ -1,0 +1,11 @@
+CustomerContact
+===============
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: CustomerContact
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.EnableExternalDatabaseOperationsInsightsDetailsBase.rst
+++ b/docs/api/database/models/oci.database.models.EnableExternalDatabaseOperationsInsightsDetailsBase.rst
@@ -1,0 +1,11 @@
+EnableExternalDatabaseOperationsInsightsDetailsBase
+===================================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: EnableExternalDatabaseOperationsInsightsDetailsBase
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.EnableExternalNonContainerDatabaseOperationsInsightsDetails.rst
+++ b/docs/api/database/models/oci.database.models.EnableExternalNonContainerDatabaseOperationsInsightsDetails.rst
@@ -1,0 +1,11 @@
+EnableExternalNonContainerDatabaseOperationsInsightsDetails
+===========================================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: EnableExternalNonContainerDatabaseOperationsInsightsDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.EnableExternalPluggableDatabaseOperationsInsightsDetails.rst
+++ b/docs/api/database/models/oci.database.models.EnableExternalPluggableDatabaseOperationsInsightsDetails.rst
@@ -1,0 +1,11 @@
+EnableExternalPluggableDatabaseOperationsInsightsDetails
+========================================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: EnableExternalPluggableDatabaseOperationsInsightsDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.OperationsInsightsConfig.rst
+++ b/docs/api/database/models/oci.database.models.OperationsInsightsConfig.rst
@@ -1,0 +1,11 @@
+OperationsInsightsConfig
+========================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: OperationsInsightsConfig
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/sdk_behaviors/retries.rst
+++ b/docs/sdk_behaviors/retries.rst
@@ -40,5 +40,6 @@ The default retry strategy vended by the SDK has the following attributes:
 * Retries on the following exception types:
 
     * Timeouts and connection errors
+    * HTTP 409 (IncorrectState)
     * HTTP 429s (throttles)
-    * HTTP 5xx (server errors)
+    * HTTP 5xx (server errors), except 501

--- a/examples/showoci/CHANGELOG.rst
+++ b/examples/showoci/CHANGELOG.rst
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 
 =====================
+21.04.20 - 21.04.20
+=====================
+* Remove ipv6 from vcn (Breaking)
+* Added peername to LPG
+
+=====================
 21.03.30 - 21.03.30
 =====================
 * Added Network load Balancer

--- a/examples/showoci/showoci.py
+++ b/examples/showoci/showoci.py
@@ -93,7 +93,7 @@ import sys
 import argparse
 import datetime
 
-version = "21.03.23"
+version = "21.04.20"
 
 ##########################################################################
 # check OCI version

--- a/examples/showoci/showoci_data.py
+++ b/examples/showoci/showoci_data.py
@@ -552,6 +552,8 @@ class ShowOCIData(object):
                          'route_table': routestr,
                          'vcn_id': lpg['vcn_id'],
                          'peering_status': lpg['peering_status'],
+                         'peer_id': lpg['peer_id'],
+                         'peer_name': self.__get_core_network_local_peering(lpg['peer_id']),
                          'peer_advertised_cidr': lpg['peer_advertised_cidr'],
                          'peer_advertised_cidr_details': lpg['peer_advertised_cidr_details'],
                          'is_cross_tenancy_peering': lpg['is_cross_tenancy_peering']
@@ -932,8 +934,6 @@ class ShowOCIData(object):
                                  'display_name': vcn['display_name'],
                                  'cidr_block': vcn['cidr_block'],
                                  'cidr_blocks': vcn['cidr_blocks'],
-                                 'ipv6_cidr_block': vcn['ipv6_cidr_block'],
-                                 'ipv6_public_cidr_block': vcn['ipv6_public_cidr_block'],
                                  'compartment_name': str(compartment['name']),
                                  'compartment_id': str(compartment['id']),
                                  'data': val})

--- a/examples/showoci/showoci_output.py
+++ b/examples/showoci/showoci_output.py
@@ -393,7 +393,7 @@ class ShowOCIOutput(object):
         return val
 
     ##########################################################################
-    # Print Network VCN Local Peering
+    # Print Network VCN subnets
     ##########################################################################
 
     def __print_core_network_vcn_subnet(self, subnets, vcn_compartment):
@@ -542,7 +542,7 @@ class ShowOCIOutput(object):
 
                 if 'local_peering' in vcn['data']:
                     for lpeer in vcn['data']['local_peering']:
-                        print(self.tabs + "Local Peer  : " + lpeer['name'] + self.__print_core_network_vcn_compartment(vcn_compartment, lpeer['compartment_name']))
+                        print(self.tabs + "Local Peer  : " + lpeer['name'] + " ---> " + lpeer['peer_name'] + self.__print_core_network_vcn_compartment(vcn_compartment, lpeer['compartment_name']))
 
                 if 'subnets' in vcn['data']:
                     self.__print_core_network_vcn_subnet(vcn['data']['subnets'], vcn_compartment)

--- a/examples/showoci/showoci_service.py
+++ b/examples/showoci/showoci_service.py
@@ -134,7 +134,7 @@ class ShowOCIFlags(object):
 # class ShowOCIService
 ##########################################################################
 class ShowOCIService(object):
-    oci_compatible_version = "2.34.0"
+    oci_compatible_version = "2.36.0"
 
     ##########################################################################
     # Global Constants
@@ -1953,8 +1953,6 @@ class ShowOCIService(object):
                            'display_name': str(vcn.display_name),
                            'cidr_block': str(vcn.cidr_block),
                            'cidr_blocks': vcn.cidr_blocks,
-                           'ipv6_cidr_block': str(vcn.ipv6_cidr_block),
-                           'ipv6_public_cidr_block': str(vcn.ipv6_public_cidr_block),
                            'time_created': str(vcn.time_created),
                            'vcn_domain_name': str(vcn.vcn_domain_name),
                            'compartment_name': str(compartment['name']),
@@ -2151,6 +2149,8 @@ class ShowOCIService(object):
                            'is_cross_tenancy_peering': str(lpg.is_cross_tenancy_peering),
                            'peer_advertised_cidr_details': lpg.peer_advertised_cidr_details,
                            'route_table_id': str(lpg.route_table_id),
+                           'peer_id': str(lpg.peer_id),
+                           'peering_status_details': str(lpg.peering_status_details),
                            'compartment_name': str(compartment['name']),
                            'compartment_id': str(compartment['id']),
                            'defined_tags': [] if lpg.defined_tags is None else lpg.defined_tags,

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ autodocsumm==0.1.11
 certifi
 configparser==4.0.2
 coverage==4.5.2
-cryptography==3.2.1
+cryptography==3.3.2
 flake8==3.6.0
 mock==2.0.0
 pyOpenSSL==19.1.0

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ with open_relative("README.rst") as f:
 requires = [
     "certifi",
     "configparser==4.0.2",
-    "cryptography==3.2.1",
+    "cryptography==3.3.2",
     "pyOpenSSL>=17.5.0,<=19.1.0",
     "python-dateutil>=2.5.3,<3.0.0",
     "pytz>=2016.10",

--- a/src/oci/base_client.py
+++ b/src/oci/base_client.py
@@ -320,7 +320,10 @@ class BaseClient(object):
             #   Simple: "stuff":"things"
             #   List: "collectionFormat": ["val1", "val2", "val3"]
             #   Dict: "definedTags": { "tag1": ["val1", "val2", "val3"], "tag2": ["val1"] }, "definedTagsExists": { "tag3": True, "tag4": True }
-            if not isinstance(v, dict) and not isinstance(v, list):
+            if isinstance(v, bool):
+                # Python capitalizes boolean values in the query parameters.
+                processed_query_params[k] = 'true' if v else 'false'
+            elif not isinstance(v, dict) and not isinstance(v, list):
                 processed_query_params[k] = self.to_path_value(v)
             elif isinstance(v, list):
                 # The requests library supports lists to represent multivalued params natively

--- a/src/oci/core/models/instance_availability_config.py
+++ b/src/oci/core/models/instance_availability_config.py
@@ -26,6 +26,10 @@ class InstanceAvailabilityConfig(object):
         Initializes a new InstanceAvailabilityConfig object with values from keyword arguments.
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
+        :param is_live_migration_preferred:
+            The value to assign to the is_live_migration_preferred property of this InstanceAvailabilityConfig.
+        :type is_live_migration_preferred: bool
+
         :param recovery_action:
             The value to assign to the recovery_action property of this InstanceAvailabilityConfig.
             Allowed values for this property are: "RESTORE_INSTANCE", "STOP_INSTANCE", 'UNKNOWN_ENUM_VALUE'.
@@ -34,14 +38,45 @@ class InstanceAvailabilityConfig(object):
 
         """
         self.swagger_types = {
+            'is_live_migration_preferred': 'bool',
             'recovery_action': 'str'
         }
 
         self.attribute_map = {
+            'is_live_migration_preferred': 'isLiveMigrationPreferred',
             'recovery_action': 'recoveryAction'
         }
 
+        self._is_live_migration_preferred = None
         self._recovery_action = None
+
+    @property
+    def is_live_migration_preferred(self):
+        """
+        Gets the is_live_migration_preferred of this InstanceAvailabilityConfig.
+        Whether to live migrate supported VM instances to a healthy physical VM host without
+        disrupting running instances during infrastructure maintenance events. If null, Oracle
+        chooses the best option for migrating the VM during infrastructure maintenance events.
+
+
+        :return: The is_live_migration_preferred of this InstanceAvailabilityConfig.
+        :rtype: bool
+        """
+        return self._is_live_migration_preferred
+
+    @is_live_migration_preferred.setter
+    def is_live_migration_preferred(self, is_live_migration_preferred):
+        """
+        Sets the is_live_migration_preferred of this InstanceAvailabilityConfig.
+        Whether to live migrate supported VM instances to a healthy physical VM host without
+        disrupting running instances during infrastructure maintenance events. If null, Oracle
+        chooses the best option for migrating the VM during infrastructure maintenance events.
+
+
+        :param is_live_migration_preferred: The is_live_migration_preferred of this InstanceAvailabilityConfig.
+        :type: bool
+        """
+        self._is_live_migration_preferred = is_live_migration_preferred
 
     @property
     def recovery_action(self):

--- a/src/oci/core/models/launch_instance_availability_config_details.py
+++ b/src/oci/core/models/launch_instance_availability_config_details.py
@@ -10,7 +10,8 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class LaunchInstanceAvailabilityConfigDetails(object):
     """
-    Options for defining the availability of a VM instance after a maintenance event that impacts the underlying hardware.
+    Options for defining the availability of a VM instance after a maintenance event that impacts the underlying
+    hardware, including whether to live migrate supported VM instances when possible.
     """
 
     #: A constant which can be used with the recovery_action property of a LaunchInstanceAvailabilityConfigDetails.
@@ -26,6 +27,10 @@ class LaunchInstanceAvailabilityConfigDetails(object):
         Initializes a new LaunchInstanceAvailabilityConfigDetails object with values from keyword arguments.
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
+        :param is_live_migration_preferred:
+            The value to assign to the is_live_migration_preferred property of this LaunchInstanceAvailabilityConfigDetails.
+        :type is_live_migration_preferred: bool
+
         :param recovery_action:
             The value to assign to the recovery_action property of this LaunchInstanceAvailabilityConfigDetails.
             Allowed values for this property are: "RESTORE_INSTANCE", "STOP_INSTANCE"
@@ -33,14 +38,45 @@ class LaunchInstanceAvailabilityConfigDetails(object):
 
         """
         self.swagger_types = {
+            'is_live_migration_preferred': 'bool',
             'recovery_action': 'str'
         }
 
         self.attribute_map = {
+            'is_live_migration_preferred': 'isLiveMigrationPreferred',
             'recovery_action': 'recoveryAction'
         }
 
+        self._is_live_migration_preferred = None
         self._recovery_action = None
+
+    @property
+    def is_live_migration_preferred(self):
+        """
+        Gets the is_live_migration_preferred of this LaunchInstanceAvailabilityConfigDetails.
+        Whether to live migrate supported VM instances to a healthy physical VM host without
+        disrupting running instances during infrastructure maintenance events. If null, Oracle
+        chooses the best option for migrating the VM during infrastructure maintenance events.
+
+
+        :return: The is_live_migration_preferred of this LaunchInstanceAvailabilityConfigDetails.
+        :rtype: bool
+        """
+        return self._is_live_migration_preferred
+
+    @is_live_migration_preferred.setter
+    def is_live_migration_preferred(self, is_live_migration_preferred):
+        """
+        Sets the is_live_migration_preferred of this LaunchInstanceAvailabilityConfigDetails.
+        Whether to live migrate supported VM instances to a healthy physical VM host without
+        disrupting running instances during infrastructure maintenance events. If null, Oracle
+        chooses the best option for migrating the VM during infrastructure maintenance events.
+
+
+        :param is_live_migration_preferred: The is_live_migration_preferred of this LaunchInstanceAvailabilityConfigDetails.
+        :type: bool
+        """
+        self._is_live_migration_preferred = is_live_migration_preferred
 
     @property
     def recovery_action(self):

--- a/src/oci/core/models/shape.py
+++ b/src/oci/core/models/shape.py
@@ -89,6 +89,10 @@ class Shape(object):
             The value to assign to the local_disk_description property of this Shape.
         :type local_disk_description: str
 
+        :param is_live_migration_supported:
+            The value to assign to the is_live_migration_supported property of this Shape.
+        :type is_live_migration_supported: bool
+
         :param ocpu_options:
             The value to assign to the ocpu_options property of this Shape.
         :type ocpu_options: oci.core.models.ShapeOcpuOptions
@@ -120,6 +124,7 @@ class Shape(object):
             'local_disks': 'int',
             'local_disks_total_size_in_gbs': 'float',
             'local_disk_description': 'str',
+            'is_live_migration_supported': 'bool',
             'ocpu_options': 'ShapeOcpuOptions',
             'memory_options': 'ShapeMemoryOptions',
             'networking_bandwidth_options': 'ShapeNetworkingBandwidthOptions',
@@ -140,6 +145,7 @@ class Shape(object):
             'local_disks': 'localDisks',
             'local_disks_total_size_in_gbs': 'localDisksTotalSizeInGBs',
             'local_disk_description': 'localDiskDescription',
+            'is_live_migration_supported': 'isLiveMigrationSupported',
             'ocpu_options': 'ocpuOptions',
             'memory_options': 'memoryOptions',
             'networking_bandwidth_options': 'networkingBandwidthOptions',
@@ -159,6 +165,7 @@ class Shape(object):
         self._local_disks = None
         self._local_disks_total_size_in_gbs = None
         self._local_disk_description = None
+        self._is_live_migration_supported = None
         self._ocpu_options = None
         self._memory_options = None
         self._networking_bandwidth_options = None
@@ -497,6 +504,30 @@ class Shape(object):
         :type: str
         """
         self._local_disk_description = local_disk_description
+
+    @property
+    def is_live_migration_supported(self):
+        """
+        Gets the is_live_migration_supported of this Shape.
+        Whether live migration is supported for this shape.
+
+
+        :return: The is_live_migration_supported of this Shape.
+        :rtype: bool
+        """
+        return self._is_live_migration_supported
+
+    @is_live_migration_supported.setter
+    def is_live_migration_supported(self, is_live_migration_supported):
+        """
+        Sets the is_live_migration_supported of this Shape.
+        Whether live migration is supported for this shape.
+
+
+        :param is_live_migration_supported: The is_live_migration_supported of this Shape.
+        :type: bool
+        """
+        self._is_live_migration_supported = is_live_migration_supported
 
     @property
     def ocpu_options(self):

--- a/src/oci/core/models/update_instance_availability_config_details.py
+++ b/src/oci/core/models/update_instance_availability_config_details.py
@@ -10,7 +10,8 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class UpdateInstanceAvailabilityConfigDetails(object):
     """
-    Options for defining the availability of a VM instance after a maintenance event that impacts the underlying hardware.
+    Options for defining the availability of a VM instance after a maintenance event that impacts the underlying
+    hardware, including whether to live migrate supported VM instances when possible.
     """
 
     #: A constant which can be used with the recovery_action property of a UpdateInstanceAvailabilityConfigDetails.
@@ -26,6 +27,10 @@ class UpdateInstanceAvailabilityConfigDetails(object):
         Initializes a new UpdateInstanceAvailabilityConfigDetails object with values from keyword arguments.
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
+        :param is_live_migration_preferred:
+            The value to assign to the is_live_migration_preferred property of this UpdateInstanceAvailabilityConfigDetails.
+        :type is_live_migration_preferred: bool
+
         :param recovery_action:
             The value to assign to the recovery_action property of this UpdateInstanceAvailabilityConfigDetails.
             Allowed values for this property are: "RESTORE_INSTANCE", "STOP_INSTANCE"
@@ -33,14 +38,45 @@ class UpdateInstanceAvailabilityConfigDetails(object):
 
         """
         self.swagger_types = {
+            'is_live_migration_preferred': 'bool',
             'recovery_action': 'str'
         }
 
         self.attribute_map = {
+            'is_live_migration_preferred': 'isLiveMigrationPreferred',
             'recovery_action': 'recoveryAction'
         }
 
+        self._is_live_migration_preferred = None
         self._recovery_action = None
+
+    @property
+    def is_live_migration_preferred(self):
+        """
+        Gets the is_live_migration_preferred of this UpdateInstanceAvailabilityConfigDetails.
+        Whether to live migrate supported VM instances to a healthy physical VM host without
+        disrupting running instances during infrastructure maintenance events. If null, Oracle
+        chooses the best option for migrating the VM during infrastructure maintenance events.
+
+
+        :return: The is_live_migration_preferred of this UpdateInstanceAvailabilityConfigDetails.
+        :rtype: bool
+        """
+        return self._is_live_migration_preferred
+
+    @is_live_migration_preferred.setter
+    def is_live_migration_preferred(self, is_live_migration_preferred):
+        """
+        Sets the is_live_migration_preferred of this UpdateInstanceAvailabilityConfigDetails.
+        Whether to live migrate supported VM instances to a healthy physical VM host without
+        disrupting running instances during infrastructure maintenance events. If null, Oracle
+        chooses the best option for migrating the VM during infrastructure maintenance events.
+
+
+        :param is_live_migration_preferred: The is_live_migration_preferred of this UpdateInstanceAvailabilityConfigDetails.
+        :type: bool
+        """
+        self._is_live_migration_preferred = is_live_migration_preferred
 
     @property
     def recovery_action(self):

--- a/src/oci/data_catalog/data_catalog_client.py
+++ b/src/oci/data_catalog/data_catalog_client.py
@@ -7474,6 +7474,14 @@ class DataCatalogClient(object):
         :param str display_name: (optional)
             A filter to return only resources that match the entire display name given. The match is not case sensitive.
 
+        :param str business_name: (optional)
+            A filter to return only resources that match the entire business name given. The match is not case sensitive.
+
+        :param str display_or_business_name_contains: (optional)
+            A filter to return only resources that match display name or business name pattern given. The match is not case sensitive.
+            For Example : /folders?displayOrBusinessNameContains=Cu.*
+            The above would match all folders with display name or business name that starts with \"Cu\".
+
         :param str display_name_contains: (optional)
             A filter to return only resources that match display name pattern given. The match is not case sensitive.
             For Example : /folders?displayNameContains=Cu.*
@@ -7572,6 +7580,8 @@ class DataCatalogClient(object):
         expected_kwargs = [
             "retry_strategy",
             "display_name",
+            "business_name",
+            "display_or_business_name_contains",
             "display_name_contains",
             "lifecycle_state",
             "time_created",
@@ -7642,6 +7652,8 @@ class DataCatalogClient(object):
 
         query_params = {
             "displayName": kwargs.get("display_name", missing),
+            "businessName": kwargs.get("business_name", missing),
+            "displayOrBusinessNameContains": kwargs.get("display_or_business_name_contains", missing),
             "displayNameContains": kwargs.get("display_name_contains", missing),
             "lifecycleState": kwargs.get("lifecycle_state", missing),
             "timeCreated": kwargs.get("time_created", missing),
@@ -8908,6 +8920,17 @@ class DataCatalogClient(object):
         :param str display_name: (optional)
             A filter to return only resources that match the entire display name given. The match is not case sensitive.
 
+        :param str business_name: (optional)
+            A filter to return only resources that match the entire business name given. The match is not case sensitive.
+
+        :param str display_or_business_name_contains: (optional)
+            A filter to return only resources that match display name or business name pattern given. The match is not case sensitive.
+            For Example : /folders?displayOrBusinessNameContains=Cu.*
+            The above would match all folders with display name or business name that starts with \"Cu\".
+
+        :param str type_key: (optional)
+            The key of the object type.
+
         :param str display_name_contains: (optional)
             A filter to return only resources that match display name pattern given. The match is not case sensitive.
             For Example : /folders?displayNameContains=Cu.*
@@ -9013,6 +9036,9 @@ class DataCatalogClient(object):
         expected_kwargs = [
             "retry_strategy",
             "display_name",
+            "business_name",
+            "display_or_business_name_contains",
+            "type_key",
             "display_name_contains",
             "lifecycle_state",
             "time_created",
@@ -9090,6 +9116,9 @@ class DataCatalogClient(object):
 
         query_params = {
             "displayName": kwargs.get("display_name", missing),
+            "businessName": kwargs.get("business_name", missing),
+            "displayOrBusinessNameContains": kwargs.get("display_or_business_name_contains", missing),
+            "typeKey": kwargs.get("type_key", missing),
             "displayNameContains": kwargs.get("display_name_contains", missing),
             "lifecycleState": kwargs.get("lifecycle_state", missing),
             "timeCreated": kwargs.get("time_created", missing),
@@ -9523,6 +9552,14 @@ class DataCatalogClient(object):
         :param str display_name: (optional)
             A filter to return only resources that match the entire display name given. The match is not case sensitive.
 
+        :param str business_name: (optional)
+            A filter to return only resources that match the entire business name given. The match is not case sensitive.
+
+        :param str display_or_business_name_contains: (optional)
+            A filter to return only resources that match display name or business name pattern given. The match is not case sensitive.
+            For Example : /folders?displayOrBusinessNameContains=Cu.*
+            The above would match all folders with display name or business name that starts with \"Cu\".
+
         :param str display_name_contains: (optional)
             A filter to return only resources that match display name pattern given. The match is not case sensitive.
             For Example : /folders?displayNameContains=Cu.*
@@ -9611,6 +9648,8 @@ class DataCatalogClient(object):
         expected_kwargs = [
             "retry_strategy",
             "display_name",
+            "business_name",
+            "display_or_business_name_contains",
             "display_name_contains",
             "lifecycle_state",
             "parent_folder_key",
@@ -9683,6 +9722,8 @@ class DataCatalogClient(object):
 
         query_params = {
             "displayName": kwargs.get("display_name", missing),
+            "businessName": kwargs.get("business_name", missing),
+            "displayOrBusinessNameContains": kwargs.get("display_or_business_name_contains", missing),
             "displayNameContains": kwargs.get("display_name_contains", missing),
             "lifecycleState": kwargs.get("lifecycle_state", missing),
             "parentFolderKey": kwargs.get("parent_folder_key", missing),
@@ -10834,6 +10875,9 @@ class DataCatalogClient(object):
         :param str job_definition_key: (optional)
             Unique job definition key.
 
+        :param str data_asset_key: (optional)
+            Unique data asset key.
+
         :param str schedule_cron_expression: (optional)
             Schedule specified in the cron expression format that has seven fields for second, minute, hour, day-of-month, month, day-of-week, year.
             It can also include special characters like * for all and ? for any. There are also pre-defined schedules that can be specified using
@@ -10919,6 +10963,7 @@ class DataCatalogClient(object):
             "updated_by_id",
             "job_type",
             "job_definition_key",
+            "data_asset_key",
             "schedule_cron_expression",
             "time_schedule_begin",
             "time_schedule_end",
@@ -11001,6 +11046,7 @@ class DataCatalogClient(object):
             "updatedById": kwargs.get("updated_by_id", missing),
             "jobType": kwargs.get("job_type", missing),
             "jobDefinitionKey": kwargs.get("job_definition_key", missing),
+            "dataAssetKey": kwargs.get("data_asset_key", missing),
             "scheduleCronExpression": kwargs.get("schedule_cron_expression", missing),
             "timeScheduleBegin": kwargs.get("time_schedule_begin", missing),
             "timeScheduleEnd": kwargs.get("time_schedule_end", missing),
@@ -13355,6 +13401,103 @@ class DataCatalogClient(object):
                 header_params=header_params,
                 body=kwargs.get('search_criteria_details'),
                 response_type="SearchResultCollection")
+
+    def suggest_matches(self, catalog_id, input_text, **kwargs):
+        """
+        Returns a list of potential string matches for a given input string.
+
+
+        :param str catalog_id: (required)
+            Unique catalog identifier.
+
+        :param str input_text: (required)
+            Text input string used for computing potential matching suggestions.
+
+        :param str timeout: (optional)
+            A search timeout string (for example, timeout=4000ms), bounding the search request to be executed within the
+            specified time value and bail with the hits accumulated up to that point when expired.
+            Defaults to no timeout.
+
+        :param int limit: (optional)
+            Limit for the list of potential matches returned from the Suggest API. If not specified, will default to 10.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.data_catalog.models.SuggestResults`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/datacatalog/suggest_matches.py.html>`__ to see an example of how to use suggest_matches API.
+        """
+        resource_path = "/catalogs/{catalogId}/actions/suggest"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "timeout",
+            "limit",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "suggest_matches got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "catalogId": catalog_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        query_params = {
+            "timeout": kwargs.get("timeout", missing),
+            "inputText": input_text,
+            "limit": kwargs.get("limit", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="SuggestResults")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="SuggestResults")
 
     def test_connection(self, catalog_id, data_asset_key, connection_key, **kwargs):
         """

--- a/src/oci/data_catalog/models/__init__.py
+++ b/src/oci/data_catalog/models/__init__.py
@@ -119,6 +119,8 @@ from .search_result import SearchResult
 from .search_result_collection import SearchResultCollection
 from .search_tag_summary import SearchTagSummary
 from .search_term_summary import SearchTermSummary
+from .suggest_list_item import SuggestListItem
+from .suggest_results import SuggestResults
 from .term import Term
 from .term_associated_object import TermAssociatedObject
 from .term_collection import TermCollection
@@ -272,6 +274,8 @@ data_catalog_type_mapping = {
     "SearchResultCollection": SearchResultCollection,
     "SearchTagSummary": SearchTagSummary,
     "SearchTermSummary": SearchTermSummary,
+    "SuggestListItem": SuggestListItem,
+    "SuggestResults": SuggestResults,
     "Term": Term,
     "TermAssociatedObject": TermAssociatedObject,
     "TermCollection": TermCollection,

--- a/src/oci/data_catalog/models/attribute.py
+++ b/src/oci/data_catalog/models/attribute.py
@@ -71,6 +71,10 @@ class Attribute(object):
             The value to assign to the display_name property of this Attribute.
         :type display_name: str
 
+        :param business_name:
+            The value to assign to the business_name property of this Attribute.
+        :type business_name: str
+
         :param description:
             The value to assign to the description property of this Attribute.
         :type description: str
@@ -187,6 +191,7 @@ class Attribute(object):
         self.swagger_types = {
             'key': 'str',
             'display_name': 'str',
+            'business_name': 'str',
             'description': 'str',
             'entity_key': 'str',
             'lifecycle_state': 'str',
@@ -219,6 +224,7 @@ class Attribute(object):
         self.attribute_map = {
             'key': 'key',
             'display_name': 'displayName',
+            'business_name': 'businessName',
             'description': 'description',
             'entity_key': 'entityKey',
             'lifecycle_state': 'lifecycleState',
@@ -250,6 +256,7 @@ class Attribute(object):
 
         self._key = None
         self._display_name = None
+        self._business_name = None
         self._description = None
         self._entity_key = None
         self._lifecycle_state = None
@@ -327,6 +334,30 @@ class Attribute(object):
         :type: str
         """
         self._display_name = display_name
+
+    @property
+    def business_name(self):
+        """
+        Gets the business_name of this Attribute.
+        Optional user friendly business name of the attribute. If set, this supplements the harvested display name of the object.
+
+
+        :return: The business_name of this Attribute.
+        :rtype: str
+        """
+        return self._business_name
+
+    @business_name.setter
+    def business_name(self, business_name):
+        """
+        Sets the business_name of this Attribute.
+        Optional user friendly business name of the attribute. If set, this supplements the harvested display name of the object.
+
+
+        :param business_name: The business_name of this Attribute.
+        :type: str
+        """
+        self._business_name = business_name
 
     @property
     def description(self):

--- a/src/oci/data_catalog/models/attribute_summary.py
+++ b/src/oci/data_catalog/models/attribute_summary.py
@@ -70,6 +70,10 @@ class AttributeSummary(object):
             The value to assign to the display_name property of this AttributeSummary.
         :type display_name: str
 
+        :param business_name:
+            The value to assign to the business_name property of this AttributeSummary.
+        :type business_name: str
+
         :param description:
             The value to assign to the description property of this AttributeSummary.
         :type description: str
@@ -144,6 +148,10 @@ class AttributeSummary(object):
             The value to assign to the path property of this AttributeSummary.
         :type path: str
 
+        :param custom_property_members:
+            The value to assign to the custom_property_members property of this AttributeSummary.
+        :type custom_property_members: list[oci.data_catalog.models.CustomPropertyGetUsage]
+
         :param associated_rule_types:
             The value to assign to the associated_rule_types property of this AttributeSummary.
             Allowed values for items in this list are: "PRIMARYKEY", "FOREIGNKEY", "UNIQUEKEY", 'UNKNOWN_ENUM_VALUE'.
@@ -154,6 +162,7 @@ class AttributeSummary(object):
         self.swagger_types = {
             'key': 'str',
             'display_name': 'str',
+            'business_name': 'str',
             'description': 'str',
             'entity_key': 'str',
             'external_key': 'str',
@@ -172,12 +181,14 @@ class AttributeSummary(object):
             'parent_attribute_key': 'str',
             'external_parent_attribute_key': 'str',
             'path': 'str',
+            'custom_property_members': 'list[CustomPropertyGetUsage]',
             'associated_rule_types': 'list[str]'
         }
 
         self.attribute_map = {
             'key': 'key',
             'display_name': 'displayName',
+            'business_name': 'businessName',
             'description': 'description',
             'entity_key': 'entityKey',
             'external_key': 'externalKey',
@@ -196,11 +207,13 @@ class AttributeSummary(object):
             'parent_attribute_key': 'parentAttributeKey',
             'external_parent_attribute_key': 'externalParentAttributeKey',
             'path': 'path',
+            'custom_property_members': 'customPropertyMembers',
             'associated_rule_types': 'associatedRuleTypes'
         }
 
         self._key = None
         self._display_name = None
+        self._business_name = None
         self._description = None
         self._entity_key = None
         self._external_key = None
@@ -219,6 +232,7 @@ class AttributeSummary(object):
         self._parent_attribute_key = None
         self._external_parent_attribute_key = None
         self._path = None
+        self._custom_property_members = None
         self._associated_rule_types = None
 
     @property
@@ -270,6 +284,30 @@ class AttributeSummary(object):
         :type: str
         """
         self._display_name = display_name
+
+    @property
+    def business_name(self):
+        """
+        Gets the business_name of this AttributeSummary.
+        Optional user friendly business name of the attribute. If set, this supplements the harvested display name of the object.
+
+
+        :return: The business_name of this AttributeSummary.
+        :rtype: str
+        """
+        return self._business_name
+
+    @business_name.setter
+    def business_name(self, business_name):
+        """
+        Sets the business_name of this AttributeSummary.
+        Optional user friendly business name of the attribute. If set, this supplements the harvested display name of the object.
+
+
+        :param business_name: The business_name of this AttributeSummary.
+        :type: str
+        """
+        self._business_name = business_name
 
     @property
     def description(self):
@@ -718,6 +756,30 @@ class AttributeSummary(object):
         :type: str
         """
         self._path = path
+
+    @property
+    def custom_property_members(self):
+        """
+        Gets the custom_property_members of this AttributeSummary.
+        The list of customized properties along with the values for this object
+
+
+        :return: The custom_property_members of this AttributeSummary.
+        :rtype: list[oci.data_catalog.models.CustomPropertyGetUsage]
+        """
+        return self._custom_property_members
+
+    @custom_property_members.setter
+    def custom_property_members(self, custom_property_members):
+        """
+        Sets the custom_property_members of this AttributeSummary.
+        The list of customized properties along with the values for this object
+
+
+        :param custom_property_members: The custom_property_members of this AttributeSummary.
+        :type: list[oci.data_catalog.models.CustomPropertyGetUsage]
+        """
+        self._custom_property_members = custom_property_members
 
     @property
     def associated_rule_types(self):

--- a/src/oci/data_catalog/models/create_attribute_details.py
+++ b/src/oci/data_catalog/models/create_attribute_details.py
@@ -22,6 +22,10 @@ class CreateAttributeDetails(object):
             The value to assign to the display_name property of this CreateAttributeDetails.
         :type display_name: str
 
+        :param business_name:
+            The value to assign to the business_name property of this CreateAttributeDetails.
+        :type business_name: str
+
         :param description:
             The value to assign to the description property of this CreateAttributeDetails.
         :type description: str
@@ -85,6 +89,7 @@ class CreateAttributeDetails(object):
         """
         self.swagger_types = {
             'display_name': 'str',
+            'business_name': 'str',
             'description': 'str',
             'external_data_type': 'str',
             'is_incremental_data': 'bool',
@@ -104,6 +109,7 @@ class CreateAttributeDetails(object):
 
         self.attribute_map = {
             'display_name': 'displayName',
+            'business_name': 'businessName',
             'description': 'description',
             'external_data_type': 'externalDataType',
             'is_incremental_data': 'isIncrementalData',
@@ -122,6 +128,7 @@ class CreateAttributeDetails(object):
         }
 
         self._display_name = None
+        self._business_name = None
         self._description = None
         self._external_data_type = None
         self._is_incremental_data = None
@@ -163,6 +170,30 @@ class CreateAttributeDetails(object):
         :type: str
         """
         self._display_name = display_name
+
+    @property
+    def business_name(self):
+        """
+        Gets the business_name of this CreateAttributeDetails.
+        Optional user friendly business name of the attribute. If set, this supplements the harvested display name of the object.
+
+
+        :return: The business_name of this CreateAttributeDetails.
+        :rtype: str
+        """
+        return self._business_name
+
+    @business_name.setter
+    def business_name(self, business_name):
+        """
+        Sets the business_name of this CreateAttributeDetails.
+        Optional user friendly business name of the attribute. If set, this supplements the harvested display name of the object.
+
+
+        :param business_name: The business_name of this CreateAttributeDetails.
+        :type: str
+        """
+        self._business_name = business_name
 
     @property
     def description(self):

--- a/src/oci/data_catalog/models/create_connection_details.py
+++ b/src/oci/data_catalog/models/create_connection_details.py
@@ -222,7 +222,7 @@ class CreateConnectionDetails(object):
         To determine the set of optional and required properties for a connection type, a query can be done
         on '/types?type=connection' that returns a collection of all connection types. The appropriate connection
         type, which will include definitions of all of it's properties, can be identified from this collection.
-        Example: `{\"encProperties\": { \"default\": { \"password\": \"pwd\"}}}`
+        Example: `{\"encProperties\": { \"default\": { \"password\": \"example-password\"}}}`
 
 
         :return: The enc_properties of this CreateConnectionDetails.
@@ -241,7 +241,7 @@ class CreateConnectionDetails(object):
         To determine the set of optional and required properties for a connection type, a query can be done
         on '/types?type=connection' that returns a collection of all connection types. The appropriate connection
         type, which will include definitions of all of it's properties, can be identified from this collection.
-        Example: `{\"encProperties\": { \"default\": { \"password\": \"pwd\"}}}`
+        Example: `{\"encProperties\": { \"default\": { \"password\": \"example-password\"}}}`
 
 
         :param enc_properties: The enc_properties of this CreateConnectionDetails.

--- a/src/oci/data_catalog/models/create_custom_property_details.py
+++ b/src/oci/data_catalog/models/create_custom_property_details.py
@@ -71,6 +71,10 @@ class CreateCustomPropertyDetails(object):
             The value to assign to the is_editable property of this CreateCustomPropertyDetails.
         :type is_editable: bool
 
+        :param is_shown_in_list:
+            The value to assign to the is_shown_in_list property of this CreateCustomPropertyDetails.
+        :type is_shown_in_list: bool
+
         :param is_hidden_in_search:
             The value to assign to the is_hidden_in_search property of this CreateCustomPropertyDetails.
         :type is_hidden_in_search: bool
@@ -93,6 +97,7 @@ class CreateCustomPropertyDetails(object):
             'is_multi_valued': 'bool',
             'is_hidden': 'bool',
             'is_editable': 'bool',
+            'is_shown_in_list': 'bool',
             'is_hidden_in_search': 'bool',
             'allowed_values': 'list[str]',
             'properties': 'dict(str, dict(str, str))'
@@ -107,6 +112,7 @@ class CreateCustomPropertyDetails(object):
             'is_multi_valued': 'isMultiValued',
             'is_hidden': 'isHidden',
             'is_editable': 'isEditable',
+            'is_shown_in_list': 'isShownInList',
             'is_hidden_in_search': 'isHiddenInSearch',
             'allowed_values': 'allowedValues',
             'properties': 'properties'
@@ -120,6 +126,7 @@ class CreateCustomPropertyDetails(object):
         self._is_multi_valued = None
         self._is_hidden = None
         self._is_editable = None
+        self._is_shown_in_list = None
         self._is_hidden_in_search = None
         self._allowed_values = None
         self._properties = None
@@ -325,6 +332,30 @@ class CreateCustomPropertyDetails(object):
         :type: bool
         """
         self._is_editable = is_editable
+
+    @property
+    def is_shown_in_list(self):
+        """
+        Gets the is_shown_in_list of this CreateCustomPropertyDetails.
+        If this field is displayed in a list view of applicable objects.
+
+
+        :return: The is_shown_in_list of this CreateCustomPropertyDetails.
+        :rtype: bool
+        """
+        return self._is_shown_in_list
+
+    @is_shown_in_list.setter
+    def is_shown_in_list(self, is_shown_in_list):
+        """
+        Sets the is_shown_in_list of this CreateCustomPropertyDetails.
+        If this field is displayed in a list view of applicable objects.
+
+
+        :param is_shown_in_list: The is_shown_in_list of this CreateCustomPropertyDetails.
+        :type: bool
+        """
+        self._is_shown_in_list = is_shown_in_list
 
     @property
     def is_hidden_in_search(self):

--- a/src/oci/data_catalog/models/create_entity_details.py
+++ b/src/oci/data_catalog/models/create_entity_details.py
@@ -38,6 +38,10 @@ class CreateEntityDetails(object):
             The value to assign to the display_name property of this CreateEntityDetails.
         :type display_name: str
 
+        :param business_name:
+            The value to assign to the business_name property of this CreateEntityDetails.
+        :type business_name: str
+
         :param description:
             The value to assign to the description property of this CreateEntityDetails.
         :type description: str
@@ -86,6 +90,7 @@ class CreateEntityDetails(object):
         """
         self.swagger_types = {
             'display_name': 'str',
+            'business_name': 'str',
             'description': 'str',
             'time_external': 'datetime',
             'is_logical': 'bool',
@@ -101,6 +106,7 @@ class CreateEntityDetails(object):
 
         self.attribute_map = {
             'display_name': 'displayName',
+            'business_name': 'businessName',
             'description': 'description',
             'time_external': 'timeExternal',
             'is_logical': 'isLogical',
@@ -115,6 +121,7 @@ class CreateEntityDetails(object):
         }
 
         self._display_name = None
+        self._business_name = None
         self._description = None
         self._time_external = None
         self._is_logical = None
@@ -152,6 +159,30 @@ class CreateEntityDetails(object):
         :type: str
         """
         self._display_name = display_name
+
+    @property
+    def business_name(self):
+        """
+        Gets the business_name of this CreateEntityDetails.
+        Optional user friendly business name of the data entity. If set, this supplements the harvested display name of the object.
+
+
+        :return: The business_name of this CreateEntityDetails.
+        :rtype: str
+        """
+        return self._business_name
+
+    @business_name.setter
+    def business_name(self, business_name):
+        """
+        Sets the business_name of this CreateEntityDetails.
+        Optional user friendly business name of the data entity. If set, this supplements the harvested display name of the object.
+
+
+        :param business_name: The business_name of this CreateEntityDetails.
+        :type: str
+        """
+        self._business_name = business_name
 
     @property
     def description(self):

--- a/src/oci/data_catalog/models/create_folder_details.py
+++ b/src/oci/data_catalog/models/create_folder_details.py
@@ -38,6 +38,10 @@ class CreateFolderDetails(object):
             The value to assign to the display_name property of this CreateFolderDetails.
         :type display_name: str
 
+        :param business_name:
+            The value to assign to the business_name property of this CreateFolderDetails.
+        :type business_name: str
+
         :param description:
             The value to assign to the description property of this CreateFolderDetails.
         :type description: str
@@ -70,6 +74,7 @@ class CreateFolderDetails(object):
         """
         self.swagger_types = {
             'display_name': 'str',
+            'business_name': 'str',
             'description': 'str',
             'custom_property_members': 'list[CustomPropertySetUsage]',
             'properties': 'dict(str, dict(str, str))',
@@ -81,6 +86,7 @@ class CreateFolderDetails(object):
 
         self.attribute_map = {
             'display_name': 'displayName',
+            'business_name': 'businessName',
             'description': 'description',
             'custom_property_members': 'customPropertyMembers',
             'properties': 'properties',
@@ -91,6 +97,7 @@ class CreateFolderDetails(object):
         }
 
         self._display_name = None
+        self._business_name = None
         self._description = None
         self._custom_property_members = None
         self._properties = None
@@ -124,6 +131,30 @@ class CreateFolderDetails(object):
         :type: str
         """
         self._display_name = display_name
+
+    @property
+    def business_name(self):
+        """
+        Gets the business_name of this CreateFolderDetails.
+        Optional user friendly business name of the folder. If set, this supplements the harvested display name of the object.
+
+
+        :return: The business_name of this CreateFolderDetails.
+        :rtype: str
+        """
+        return self._business_name
+
+    @business_name.setter
+    def business_name(self, business_name):
+        """
+        Sets the business_name of this CreateFolderDetails.
+        Optional user friendly business name of the folder. If set, this supplements the harvested display name of the object.
+
+
+        :param business_name: The business_name of this CreateFolderDetails.
+        :type: str
+        """
+        self._business_name = business_name
 
     @property
     def description(self):

--- a/src/oci/data_catalog/models/custom_property.py
+++ b/src/oci/data_catalog/models/custom_property.py
@@ -116,6 +116,10 @@ class CustomProperty(object):
             The value to assign to the is_editable property of this CustomProperty.
         :type is_editable: bool
 
+        :param is_shown_in_list:
+            The value to assign to the is_shown_in_list property of this CustomProperty.
+        :type is_shown_in_list: bool
+
         :param is_service_defined:
             The value to assign to the is_service_defined property of this CustomProperty.
         :type is_service_defined: bool
@@ -175,6 +179,7 @@ class CustomProperty(object):
             'is_multi_valued': 'bool',
             'is_hidden': 'bool',
             'is_editable': 'bool',
+            'is_shown_in_list': 'bool',
             'is_service_defined': 'bool',
             'is_hidden_in_search': 'bool',
             'lifecycle_state': 'str',
@@ -200,6 +205,7 @@ class CustomProperty(object):
             'is_multi_valued': 'isMultiValued',
             'is_hidden': 'isHidden',
             'is_editable': 'isEditable',
+            'is_shown_in_list': 'isShownInList',
             'is_service_defined': 'isServiceDefined',
             'is_hidden_in_search': 'isHiddenInSearch',
             'lifecycle_state': 'lifecycleState',
@@ -224,6 +230,7 @@ class CustomProperty(object):
         self._is_multi_valued = None
         self._is_hidden = None
         self._is_editable = None
+        self._is_shown_in_list = None
         self._is_service_defined = None
         self._is_hidden_in_search = None
         self._lifecycle_state = None
@@ -505,6 +512,30 @@ class CustomProperty(object):
         :type: bool
         """
         self._is_editable = is_editable
+
+    @property
+    def is_shown_in_list(self):
+        """
+        Gets the is_shown_in_list of this CustomProperty.
+        If this field is displayed in a list view of applicable objects.
+
+
+        :return: The is_shown_in_list of this CustomProperty.
+        :rtype: bool
+        """
+        return self._is_shown_in_list
+
+    @is_shown_in_list.setter
+    def is_shown_in_list(self, is_shown_in_list):
+        """
+        Sets the is_shown_in_list of this CustomProperty.
+        If this field is displayed in a list view of applicable objects.
+
+
+        :param is_shown_in_list: The is_shown_in_list of this CustomProperty.
+        :type: bool
+        """
+        self._is_shown_in_list = is_shown_in_list
 
     @property
     def is_service_defined(self):

--- a/src/oci/data_catalog/models/custom_property_get_usage.py
+++ b/src/oci/data_catalog/models/custom_property_get_usage.py
@@ -80,6 +80,10 @@ class CustomPropertyGetUsage(object):
             The value to assign to the is_editable property of this CustomPropertyGetUsage.
         :type is_editable: bool
 
+        :param is_shown_in_list:
+            The value to assign to the is_shown_in_list property of this CustomPropertyGetUsage.
+        :type is_shown_in_list: bool
+
         :param is_list_type:
             The value to assign to the is_list_type property of this CustomPropertyGetUsage.
         :type is_list_type: bool
@@ -100,6 +104,7 @@ class CustomPropertyGetUsage(object):
             'is_multi_valued': 'bool',
             'is_hidden': 'bool',
             'is_editable': 'bool',
+            'is_shown_in_list': 'bool',
             'is_list_type': 'bool',
             'allowed_values': 'list[str]'
         }
@@ -115,6 +120,7 @@ class CustomPropertyGetUsage(object):
             'is_multi_valued': 'isMultiValued',
             'is_hidden': 'isHidden',
             'is_editable': 'isEditable',
+            'is_shown_in_list': 'isShownInList',
             'is_list_type': 'isListType',
             'allowed_values': 'allowedValues'
         }
@@ -129,6 +135,7 @@ class CustomPropertyGetUsage(object):
         self._is_multi_valued = None
         self._is_hidden = None
         self._is_editable = None
+        self._is_shown_in_list = None
         self._is_list_type = None
         self._allowed_values = None
 
@@ -377,6 +384,30 @@ class CustomPropertyGetUsage(object):
         :type: bool
         """
         self._is_editable = is_editable
+
+    @property
+    def is_shown_in_list(self):
+        """
+        Gets the is_shown_in_list of this CustomPropertyGetUsage.
+        If this field is displayed in a list view of applicable objects.
+
+
+        :return: The is_shown_in_list of this CustomPropertyGetUsage.
+        :rtype: bool
+        """
+        return self._is_shown_in_list
+
+    @is_shown_in_list.setter
+    def is_shown_in_list(self, is_shown_in_list):
+        """
+        Sets the is_shown_in_list of this CustomPropertyGetUsage.
+        If this field is displayed in a list view of applicable objects.
+
+
+        :param is_shown_in_list: The is_shown_in_list of this CustomPropertyGetUsage.
+        :type: bool
+        """
+        self._is_shown_in_list = is_shown_in_list
 
     @property
     def is_list_type(self):

--- a/src/oci/data_catalog/models/custom_property_summary.py
+++ b/src/oci/data_catalog/models/custom_property_summary.py
@@ -112,6 +112,10 @@ class CustomPropertySummary(object):
             The value to assign to the is_editable property of this CustomPropertySummary.
         :type is_editable: bool
 
+        :param is_shown_in_list:
+            The value to assign to the is_shown_in_list property of this CustomPropertySummary.
+        :type is_shown_in_list: bool
+
         :param is_service_defined:
             The value to assign to the is_service_defined property of this CustomPropertySummary.
         :type is_service_defined: bool
@@ -154,6 +158,7 @@ class CustomPropertySummary(object):
             'is_multi_valued': 'bool',
             'is_hidden': 'bool',
             'is_editable': 'bool',
+            'is_shown_in_list': 'bool',
             'is_service_defined': 'bool',
             'is_hidden_in_search': 'bool',
             'time_created': 'datetime',
@@ -174,6 +179,7 @@ class CustomPropertySummary(object):
             'is_multi_valued': 'isMultiValued',
             'is_hidden': 'isHidden',
             'is_editable': 'isEditable',
+            'is_shown_in_list': 'isShownInList',
             'is_service_defined': 'isServiceDefined',
             'is_hidden_in_search': 'isHiddenInSearch',
             'time_created': 'timeCreated',
@@ -193,6 +199,7 @@ class CustomPropertySummary(object):
         self._is_multi_valued = None
         self._is_hidden = None
         self._is_editable = None
+        self._is_shown_in_list = None
         self._is_service_defined = None
         self._is_hidden_in_search = None
         self._time_created = None
@@ -446,6 +453,30 @@ class CustomPropertySummary(object):
         :type: bool
         """
         self._is_editable = is_editable
+
+    @property
+    def is_shown_in_list(self):
+        """
+        Gets the is_shown_in_list of this CustomPropertySummary.
+        If this field is displayed in a list view of applicable objects.
+
+
+        :return: The is_shown_in_list of this CustomPropertySummary.
+        :rtype: bool
+        """
+        return self._is_shown_in_list
+
+    @is_shown_in_list.setter
+    def is_shown_in_list(self, is_shown_in_list):
+        """
+        Sets the is_shown_in_list of this CustomPropertySummary.
+        If this field is displayed in a list view of applicable objects.
+
+
+        :param is_shown_in_list: The is_shown_in_list of this CustomPropertySummary.
+        :type: bool
+        """
+        self._is_shown_in_list = is_shown_in_list
 
     @property
     def is_service_defined(self):

--- a/src/oci/data_catalog/models/entity.py
+++ b/src/oci/data_catalog/models/entity.py
@@ -76,6 +76,10 @@ class Entity(object):
             The value to assign to the display_name property of this Entity.
         :type display_name: str
 
+        :param business_name:
+            The value to assign to the business_name property of this Entity.
+        :type business_name: str
+
         :param description:
             The value to assign to the description property of this Entity.
         :type description: str
@@ -176,6 +180,7 @@ class Entity(object):
         self.swagger_types = {
             'key': 'str',
             'display_name': 'str',
+            'business_name': 'str',
             'description': 'str',
             'time_created': 'datetime',
             'time_updated': 'datetime',
@@ -204,6 +209,7 @@ class Entity(object):
         self.attribute_map = {
             'key': 'key',
             'display_name': 'displayName',
+            'business_name': 'businessName',
             'description': 'description',
             'time_created': 'timeCreated',
             'time_updated': 'timeUpdated',
@@ -231,6 +237,7 @@ class Entity(object):
 
         self._key = None
         self._display_name = None
+        self._business_name = None
         self._description = None
         self._time_created = None
         self._time_updated = None
@@ -304,6 +311,30 @@ class Entity(object):
         :type: str
         """
         self._display_name = display_name
+
+    @property
+    def business_name(self):
+        """
+        Gets the business_name of this Entity.
+        Optional user friendly business name of the data entity. If set, this supplements the harvested display name of the object.
+
+
+        :return: The business_name of this Entity.
+        :rtype: str
+        """
+        return self._business_name
+
+    @business_name.setter
+    def business_name(self, business_name):
+        """
+        Sets the business_name of this Entity.
+        Optional user friendly business name of the data entity. If set, this supplements the harvested display name of the object.
+
+
+        :param business_name: The business_name of this Entity.
+        :type: str
+        """
+        self._business_name = business_name
 
     @property
     def description(self):

--- a/src/oci/data_catalog/models/entity_summary.py
+++ b/src/oci/data_catalog/models/entity_summary.py
@@ -60,6 +60,10 @@ class EntitySummary(object):
             The value to assign to the display_name property of this EntitySummary.
         :type display_name: str
 
+        :param business_name:
+            The value to assign to the business_name property of this EntitySummary.
+        :type business_name: str
+
         :param description:
             The value to assign to the description property of this EntitySummary.
         :type description: str
@@ -83,6 +87,10 @@ class EntitySummary(object):
         :param pattern_key:
             The value to assign to the pattern_key property of this EntitySummary.
         :type pattern_key: str
+
+        :param type_key:
+            The value to assign to the type_key property of this EntitySummary.
+        :type type_key: str
 
         :param realized_expression:
             The value to assign to the realized_expression property of this EntitySummary.
@@ -118,12 +126,14 @@ class EntitySummary(object):
         self.swagger_types = {
             'key': 'str',
             'display_name': 'str',
+            'business_name': 'str',
             'description': 'str',
             'data_asset_key': 'str',
             'folder_key': 'str',
             'folder_name': 'str',
             'external_key': 'str',
             'pattern_key': 'str',
+            'type_key': 'str',
             'realized_expression': 'str',
             'path': 'str',
             'time_created': 'datetime',
@@ -136,12 +146,14 @@ class EntitySummary(object):
         self.attribute_map = {
             'key': 'key',
             'display_name': 'displayName',
+            'business_name': 'businessName',
             'description': 'description',
             'data_asset_key': 'dataAssetKey',
             'folder_key': 'folderKey',
             'folder_name': 'folderName',
             'external_key': 'externalKey',
             'pattern_key': 'patternKey',
+            'type_key': 'typeKey',
             'realized_expression': 'realizedExpression',
             'path': 'path',
             'time_created': 'timeCreated',
@@ -153,12 +165,14 @@ class EntitySummary(object):
 
         self._key = None
         self._display_name = None
+        self._business_name = None
         self._description = None
         self._data_asset_key = None
         self._folder_key = None
         self._folder_name = None
         self._external_key = None
         self._pattern_key = None
+        self._type_key = None
         self._realized_expression = None
         self._path = None
         self._time_created = None
@@ -216,6 +230,30 @@ class EntitySummary(object):
         :type: str
         """
         self._display_name = display_name
+
+    @property
+    def business_name(self):
+        """
+        Gets the business_name of this EntitySummary.
+        Optional user friendly business name of the data entity. If set, this supplements the harvested display name of the object.
+
+
+        :return: The business_name of this EntitySummary.
+        :rtype: str
+        """
+        return self._business_name
+
+    @business_name.setter
+    def business_name(self, business_name):
+        """
+        Sets the business_name of this EntitySummary.
+        Optional user friendly business name of the data entity. If set, this supplements the harvested display name of the object.
+
+
+        :param business_name: The business_name of this EntitySummary.
+        :type: str
+        """
+        self._business_name = business_name
 
     @property
     def description(self):
@@ -360,6 +398,30 @@ class EntitySummary(object):
         :type: str
         """
         self._pattern_key = pattern_key
+
+    @property
+    def type_key(self):
+        """
+        Gets the type_key of this EntitySummary.
+        The type of data entity object. Type keys can be found via the '/types' endpoint.
+
+
+        :return: The type_key of this EntitySummary.
+        :rtype: str
+        """
+        return self._type_key
+
+    @type_key.setter
+    def type_key(self, type_key):
+        """
+        Sets the type_key of this EntitySummary.
+        The type of data entity object. Type keys can be found via the '/types' endpoint.
+
+
+        :param type_key: The type_key of this EntitySummary.
+        :type: str
+        """
+        self._type_key = type_key
 
     @property
     def realized_expression(self):

--- a/src/oci/data_catalog/models/folder.py
+++ b/src/oci/data_catalog/models/folder.py
@@ -77,6 +77,10 @@ class Folder(object):
             The value to assign to the display_name property of this Folder.
         :type display_name: str
 
+        :param business_name:
+            The value to assign to the business_name property of this Folder.
+        :type business_name: str
+
         :param description:
             The value to assign to the description property of this Folder.
         :type description: str
@@ -149,6 +153,7 @@ class Folder(object):
         self.swagger_types = {
             'key': 'str',
             'display_name': 'str',
+            'business_name': 'str',
             'description': 'str',
             'parent_folder_key': 'str',
             'path': 'str',
@@ -170,6 +175,7 @@ class Folder(object):
         self.attribute_map = {
             'key': 'key',
             'display_name': 'displayName',
+            'business_name': 'businessName',
             'description': 'description',
             'parent_folder_key': 'parentFolderKey',
             'path': 'path',
@@ -190,6 +196,7 @@ class Folder(object):
 
         self._key = None
         self._display_name = None
+        self._business_name = None
         self._description = None
         self._parent_folder_key = None
         self._path = None
@@ -256,6 +263,30 @@ class Folder(object):
         :type: str
         """
         self._display_name = display_name
+
+    @property
+    def business_name(self):
+        """
+        Gets the business_name of this Folder.
+        Optional user friendly business name of the folder. If set, this supplements the harvested display name of the object.
+
+
+        :return: The business_name of this Folder.
+        :rtype: str
+        """
+        return self._business_name
+
+    @business_name.setter
+    def business_name(self, business_name):
+        """
+        Sets the business_name of this Folder.
+        Optional user friendly business name of the folder. If set, this supplements the harvested display name of the object.
+
+
+        :param business_name: The business_name of this Folder.
+        :type: str
+        """
+        self._business_name = business_name
 
     @property
     def description(self):

--- a/src/oci/data_catalog/models/folder_summary.py
+++ b/src/oci/data_catalog/models/folder_summary.py
@@ -62,6 +62,10 @@ class FolderSummary(object):
             The value to assign to the display_name property of this FolderSummary.
         :type display_name: str
 
+        :param business_name:
+            The value to assign to the business_name property of this FolderSummary.
+        :type business_name: str
+
         :param description:
             The value to assign to the description property of this FolderSummary.
         :type description: str
@@ -104,6 +108,7 @@ class FolderSummary(object):
         self.swagger_types = {
             'key': 'str',
             'display_name': 'str',
+            'business_name': 'str',
             'description': 'str',
             'data_asset_key': 'str',
             'parent_folder_key': 'str',
@@ -118,6 +123,7 @@ class FolderSummary(object):
         self.attribute_map = {
             'key': 'key',
             'display_name': 'displayName',
+            'business_name': 'businessName',
             'description': 'description',
             'data_asset_key': 'dataAssetKey',
             'parent_folder_key': 'parentFolderKey',
@@ -131,6 +137,7 @@ class FolderSummary(object):
 
         self._key = None
         self._display_name = None
+        self._business_name = None
         self._description = None
         self._data_asset_key = None
         self._parent_folder_key = None
@@ -190,6 +197,30 @@ class FolderSummary(object):
         :type: str
         """
         self._display_name = display_name
+
+    @property
+    def business_name(self):
+        """
+        Gets the business_name of this FolderSummary.
+        Optional user friendly business name of the folder. If set, this supplements the harvested display name of the object.
+
+
+        :return: The business_name of this FolderSummary.
+        :rtype: str
+        """
+        return self._business_name
+
+    @business_name.setter
+    def business_name(self, business_name):
+        """
+        Sets the business_name of this FolderSummary.
+        Optional user friendly business name of the folder. If set, this supplements the harvested display name of the object.
+
+
+        :param business_name: The business_name of this FolderSummary.
+        :type: str
+        """
+        self._business_name = business_name
 
     @property
     def description(self):

--- a/src/oci/data_catalog/models/job.py
+++ b/src/oci/data_catalog/models/job.py
@@ -188,6 +188,10 @@ class Job(object):
             The value to assign to the job_definition_name property of this Job.
         :type job_definition_name: str
 
+        :param data_asset_key:
+            The value to assign to the data_asset_key property of this Job.
+        :type data_asset_key: str
+
         :param error_code:
             The value to assign to the error_code property of this Job.
         :type error_code: str
@@ -222,6 +226,7 @@ class Job(object):
             'created_by_id': 'str',
             'updated_by_id': 'str',
             'job_definition_name': 'str',
+            'data_asset_key': 'str',
             'error_code': 'str',
             'error_message': 'str',
             'uri': 'str'
@@ -248,6 +253,7 @@ class Job(object):
             'created_by_id': 'createdById',
             'updated_by_id': 'updatedById',
             'job_definition_name': 'jobDefinitionName',
+            'data_asset_key': 'dataAssetKey',
             'error_code': 'errorCode',
             'error_message': 'errorMessage',
             'uri': 'uri'
@@ -273,6 +279,7 @@ class Job(object):
         self._created_by_id = None
         self._updated_by_id = None
         self._job_definition_name = None
+        self._data_asset_key = None
         self._error_code = None
         self._error_message = None
         self._uri = None
@@ -806,6 +813,30 @@ class Job(object):
         :type: str
         """
         self._job_definition_name = job_definition_name
+
+    @property
+    def data_asset_key(self):
+        """
+        Gets the data_asset_key of this Job.
+        Unique key of the data asset to which this job applies, if the job involves a data asset.
+
+
+        :return: The data_asset_key of this Job.
+        :rtype: str
+        """
+        return self._data_asset_key
+
+    @data_asset_key.setter
+    def data_asset_key(self, data_asset_key):
+        """
+        Sets the data_asset_key of this Job.
+        Unique key of the data asset to which this job applies, if the job involves a data asset.
+
+
+        :param data_asset_key: The data_asset_key of this Job.
+        :type: str
+        """
+        self._data_asset_key = data_asset_key
 
     @property
     def error_code(self):

--- a/src/oci/data_catalog/models/job_definition_summary.py
+++ b/src/oci/data_catalog/models/job_definition_summary.py
@@ -216,6 +216,10 @@ class JobDefinitionSummary(object):
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type schedule_type: str
 
+        :param data_asset_key:
+            The value to assign to the data_asset_key property of this JobDefinitionSummary.
+        :type data_asset_key: str
+
         """
         self.swagger_types = {
             'key': 'str',
@@ -231,7 +235,8 @@ class JobDefinitionSummary(object):
             'time_latest_execution_started': 'datetime',
             'time_latest_execution_ended': 'datetime',
             'job_execution_state': 'str',
-            'schedule_type': 'str'
+            'schedule_type': 'str',
+            'data_asset_key': 'str'
         }
 
         self.attribute_map = {
@@ -248,7 +253,8 @@ class JobDefinitionSummary(object):
             'time_latest_execution_started': 'timeLatestExecutionStarted',
             'time_latest_execution_ended': 'timeLatestExecutionEnded',
             'job_execution_state': 'jobExecutionState',
-            'schedule_type': 'scheduleType'
+            'schedule_type': 'scheduleType',
+            'data_asset_key': 'dataAssetKey'
         }
 
         self._key = None
@@ -265,6 +271,7 @@ class JobDefinitionSummary(object):
         self._time_latest_execution_ended = None
         self._job_execution_state = None
         self._schedule_type = None
+        self._data_asset_key = None
 
     @property
     def key(self):
@@ -643,6 +650,30 @@ class JobDefinitionSummary(object):
         if not value_allowed_none_or_none_sentinel(schedule_type, allowed_values):
             schedule_type = 'UNKNOWN_ENUM_VALUE'
         self._schedule_type = schedule_type
+
+    @property
+    def data_asset_key(self):
+        """
+        Gets the data_asset_key of this JobDefinitionSummary.
+        Unique key of the data asset to which this job applies, if the job involves a data asset.
+
+
+        :return: The data_asset_key of this JobDefinitionSummary.
+        :rtype: str
+        """
+        return self._data_asset_key
+
+    @data_asset_key.setter
+    def data_asset_key(self, data_asset_key):
+        """
+        Sets the data_asset_key of this JobDefinitionSummary.
+        Unique key of the data asset to which this job applies, if the job involves a data asset.
+
+
+        :param data_asset_key: The data_asset_key of this JobDefinitionSummary.
+        :type: str
+        """
+        self._data_asset_key = data_asset_key
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/data_catalog/models/job_summary.py
+++ b/src/oci/data_catalog/models/job_summary.py
@@ -170,6 +170,10 @@ class JobSummary(object):
             The value to assign to the job_definition_name property of this JobSummary.
         :type job_definition_name: str
 
+        :param data_asset_key:
+            The value to assign to the data_asset_key property of this JobSummary.
+        :type data_asset_key: str
+
         :param error_code:
             The value to assign to the error_code property of this JobSummary.
         :type error_code: str
@@ -202,6 +206,7 @@ class JobSummary(object):
             'execution_count': 'int',
             'time_of_latest_execution': 'datetime',
             'job_definition_name': 'str',
+            'data_asset_key': 'str',
             'error_code': 'str',
             'error_message': 'str',
             'executions': 'list[JobExecutionSummary]'
@@ -226,6 +231,7 @@ class JobSummary(object):
             'execution_count': 'executionCount',
             'time_of_latest_execution': 'timeOfLatestExecution',
             'job_definition_name': 'jobDefinitionName',
+            'data_asset_key': 'dataAssetKey',
             'error_code': 'errorCode',
             'error_message': 'errorMessage',
             'executions': 'executions'
@@ -249,6 +255,7 @@ class JobSummary(object):
         self._execution_count = None
         self._time_of_latest_execution = None
         self._job_definition_name = None
+        self._data_asset_key = None
         self._error_code = None
         self._error_message = None
         self._executions = None
@@ -722,6 +729,30 @@ class JobSummary(object):
         :type: str
         """
         self._job_definition_name = job_definition_name
+
+    @property
+    def data_asset_key(self):
+        """
+        Gets the data_asset_key of this JobSummary.
+        Unique key of the data asset to which this job applies, if the job involves a data asset.
+
+
+        :return: The data_asset_key of this JobSummary.
+        :rtype: str
+        """
+        return self._data_asset_key
+
+    @data_asset_key.setter
+    def data_asset_key(self, data_asset_key):
+        """
+        Sets the data_asset_key of this JobSummary.
+        Unique key of the data asset to which this job applies, if the job involves a data asset.
+
+
+        :param data_asset_key: The data_asset_key of this JobSummary.
+        :type: str
+        """
+        self._data_asset_key = data_asset_key
 
     @property
     def error_code(self):

--- a/src/oci/data_catalog/models/search_result.py
+++ b/src/oci/data_catalog/models/search_result.py
@@ -15,6 +15,38 @@ class SearchResult(object):
     for each object along with other contextual information like the data asset root, folder, or entity parents.
     """
 
+    #: A constant which can be used with the lifecycle_state property of a SearchResult.
+    #: This constant has a value of "CREATING"
+    LIFECYCLE_STATE_CREATING = "CREATING"
+
+    #: A constant which can be used with the lifecycle_state property of a SearchResult.
+    #: This constant has a value of "ACTIVE"
+    LIFECYCLE_STATE_ACTIVE = "ACTIVE"
+
+    #: A constant which can be used with the lifecycle_state property of a SearchResult.
+    #: This constant has a value of "INACTIVE"
+    LIFECYCLE_STATE_INACTIVE = "INACTIVE"
+
+    #: A constant which can be used with the lifecycle_state property of a SearchResult.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a SearchResult.
+    #: This constant has a value of "DELETING"
+    LIFECYCLE_STATE_DELETING = "DELETING"
+
+    #: A constant which can be used with the lifecycle_state property of a SearchResult.
+    #: This constant has a value of "DELETED"
+    LIFECYCLE_STATE_DELETED = "DELETED"
+
+    #: A constant which can be used with the lifecycle_state property of a SearchResult.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    #: A constant which can be used with the lifecycle_state property of a SearchResult.
+    #: This constant has a value of "MOVING"
+    LIFECYCLE_STATE_MOVING = "MOVING"
+
     def __init__(self, **kwargs):
         """
         Initializes a new SearchResult object with values from keyword arguments.
@@ -124,6 +156,16 @@ class SearchResult(object):
             The value to assign to the path property of this SearchResult.
         :type path: str
 
+        :param business_name:
+            The value to assign to the business_name property of this SearchResult.
+        :type business_name: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this SearchResult.
+            Allowed values for this property are: "CREATING", "ACTIVE", "INACTIVE", "UPDATING", "DELETING", "DELETED", "FAILED", "MOVING", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
         :param expression:
             The value to assign to the expression property of this SearchResult.
         :type expression: str
@@ -160,6 +202,8 @@ class SearchResult(object):
             'created_by_id': 'str',
             'updated_by_id': 'str',
             'path': 'str',
+            'business_name': 'str',
+            'lifecycle_state': 'str',
             'expression': 'str',
             'custom_properties': 'list[FacetedSearchCustomProperty]'
         }
@@ -191,6 +235,8 @@ class SearchResult(object):
             'created_by_id': 'createdById',
             'updated_by_id': 'updatedById',
             'path': 'path',
+            'business_name': 'businessName',
+            'lifecycle_state': 'lifecycleState',
             'expression': 'expression',
             'custom_properties': 'customProperties'
         }
@@ -221,6 +267,8 @@ class SearchResult(object):
         self._created_by_id = None
         self._updated_by_id = None
         self._path = None
+        self._business_name = None
+        self._lifecycle_state = None
         self._expression = None
         self._custom_properties = None
 
@@ -859,6 +907,60 @@ class SearchResult(object):
         :type: str
         """
         self._path = path
+
+    @property
+    def business_name(self):
+        """
+        Gets the business_name of this SearchResult.
+        Optional user friendly business name of the data object. If set, this supplements the harvested display name of the object.
+
+
+        :return: The business_name of this SearchResult.
+        :rtype: str
+        """
+        return self._business_name
+
+    @business_name.setter
+    def business_name(self, business_name):
+        """
+        Sets the business_name of this SearchResult.
+        Optional user friendly business name of the data object. If set, this supplements the harvested display name of the object.
+
+
+        :param business_name: The business_name of this SearchResult.
+        :type: str
+        """
+        self._business_name = business_name
+
+    @property
+    def lifecycle_state(self):
+        """
+        Gets the lifecycle_state of this SearchResult.
+        The current state of the data object.
+
+        Allowed values for this property are: "CREATING", "ACTIVE", "INACTIVE", "UPDATING", "DELETING", "DELETED", "FAILED", "MOVING", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this SearchResult.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this SearchResult.
+        The current state of the data object.
+
+
+        :param lifecycle_state: The lifecycle_state of this SearchResult.
+        :type: str
+        """
+        allowed_values = ["CREATING", "ACTIVE", "INACTIVE", "UPDATING", "DELETING", "DELETED", "FAILED", "MOVING"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
 
     @property
     def expression(self):

--- a/src/oci/data_catalog/models/suggest_list_item.py
+++ b/src/oci/data_catalog/models/suggest_list_item.py
@@ -1,0 +1,102 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class SuggestListItem(object):
+    """
+    Details of a potential match returned from the suggest operation for the given input text.
+    by the limit parameter.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new SuggestListItem object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param suggestion:
+            The value to assign to the suggestion property of this SuggestListItem.
+        :type suggestion: str
+
+        :param object_count:
+            The value to assign to the object_count property of this SuggestListItem.
+        :type object_count: int
+
+        """
+        self.swagger_types = {
+            'suggestion': 'str',
+            'object_count': 'int'
+        }
+
+        self.attribute_map = {
+            'suggestion': 'suggestion',
+            'object_count': 'objectCount'
+        }
+
+        self._suggestion = None
+        self._object_count = None
+
+    @property
+    def suggestion(self):
+        """
+        Gets the suggestion of this SuggestListItem.
+        Potential string match. Matching is based on the frequency of usage within the catalog.
+
+
+        :return: The suggestion of this SuggestListItem.
+        :rtype: str
+        """
+        return self._suggestion
+
+    @suggestion.setter
+    def suggestion(self, suggestion):
+        """
+        Sets the suggestion of this SuggestListItem.
+        Potential string match. Matching is based on the frequency of usage within the catalog.
+
+
+        :param suggestion: The suggestion of this SuggestListItem.
+        :type: str
+        """
+        self._suggestion = suggestion
+
+    @property
+    def object_count(self):
+        """
+        Gets the object_count of this SuggestListItem.
+        The number of objects which contain this suggestion.
+
+
+        :return: The object_count of this SuggestListItem.
+        :rtype: int
+        """
+        return self._object_count
+
+    @object_count.setter
+    def object_count(self, object_count):
+        """
+        Sets the object_count of this SuggestListItem.
+        The number of objects which contain this suggestion.
+
+
+        :param object_count: The object_count of this SuggestListItem.
+        :type: int
+        """
+        self._object_count = object_count
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_catalog/models/suggest_results.py
+++ b/src/oci/data_catalog/models/suggest_results.py
@@ -1,0 +1,164 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class SuggestResults(object):
+    """
+    The list of potential matches returned from the suggest operation for the given input text. The size of the list will be determined
+    by the limit parameter.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new SuggestResults object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param total_count:
+            The value to assign to the total_count property of this SuggestResults.
+        :type total_count: int
+
+        :param search_latency_in_ms:
+            The value to assign to the search_latency_in_ms property of this SuggestResults.
+        :type search_latency_in_ms: int
+
+        :param input_text:
+            The value to assign to the input_text property of this SuggestResults.
+        :type input_text: str
+
+        :param items:
+            The value to assign to the items property of this SuggestResults.
+        :type items: list[oci.data_catalog.models.SuggestListItem]
+
+        """
+        self.swagger_types = {
+            'total_count': 'int',
+            'search_latency_in_ms': 'int',
+            'input_text': 'str',
+            'items': 'list[SuggestListItem]'
+        }
+
+        self.attribute_map = {
+            'total_count': 'totalCount',
+            'search_latency_in_ms': 'searchLatencyInMs',
+            'input_text': 'inputText',
+            'items': 'items'
+        }
+
+        self._total_count = None
+        self._search_latency_in_ms = None
+        self._input_text = None
+        self._items = None
+
+    @property
+    def total_count(self):
+        """
+        **[Required]** Gets the total_count of this SuggestResults.
+        Total number of items returned.
+
+
+        :return: The total_count of this SuggestResults.
+        :rtype: int
+        """
+        return self._total_count
+
+    @total_count.setter
+    def total_count(self, total_count):
+        """
+        Sets the total_count of this SuggestResults.
+        Total number of items returned.
+
+
+        :param total_count: The total_count of this SuggestResults.
+        :type: int
+        """
+        self._total_count = total_count
+
+    @property
+    def search_latency_in_ms(self):
+        """
+        Gets the search_latency_in_ms of this SuggestResults.
+        Time taken to compute the result, in milliseconds.
+
+
+        :return: The search_latency_in_ms of this SuggestResults.
+        :rtype: int
+        """
+        return self._search_latency_in_ms
+
+    @search_latency_in_ms.setter
+    def search_latency_in_ms(self, search_latency_in_ms):
+        """
+        Sets the search_latency_in_ms of this SuggestResults.
+        Time taken to compute the result, in milliseconds.
+
+
+        :param search_latency_in_ms: The search_latency_in_ms of this SuggestResults.
+        :type: int
+        """
+        self._search_latency_in_ms = search_latency_in_ms
+
+    @property
+    def input_text(self):
+        """
+        **[Required]** Gets the input_text of this SuggestResults.
+        Input string for which the potential matches are computed.
+
+
+        :return: The input_text of this SuggestResults.
+        :rtype: str
+        """
+        return self._input_text
+
+    @input_text.setter
+    def input_text(self, input_text):
+        """
+        Sets the input_text of this SuggestResults.
+        Input string for which the potential matches are computed.
+
+
+        :param input_text: The input_text of this SuggestResults.
+        :type: str
+        """
+        self._input_text = input_text
+
+    @property
+    def items(self):
+        """
+        Gets the items of this SuggestResults.
+        List of suggestions.
+
+
+        :return: The items of this SuggestResults.
+        :rtype: list[oci.data_catalog.models.SuggestListItem]
+        """
+        return self._items
+
+    @items.setter
+    def items(self, items):
+        """
+        Sets the items of this SuggestResults.
+        List of suggestions.
+
+
+        :param items: The items of this SuggestResults.
+        :type: list[oci.data_catalog.models.SuggestListItem]
+        """
+        self._items = items
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_catalog/models/update_attribute_details.py
+++ b/src/oci/data_catalog/models/update_attribute_details.py
@@ -22,6 +22,10 @@ class UpdateAttributeDetails(object):
             The value to assign to the display_name property of this UpdateAttributeDetails.
         :type display_name: str
 
+        :param business_name:
+            The value to assign to the business_name property of this UpdateAttributeDetails.
+        :type business_name: str
+
         :param description:
             The value to assign to the description property of this UpdateAttributeDetails.
         :type description: str
@@ -85,6 +89,7 @@ class UpdateAttributeDetails(object):
         """
         self.swagger_types = {
             'display_name': 'str',
+            'business_name': 'str',
             'description': 'str',
             'external_data_type': 'str',
             'is_incremental_data': 'bool',
@@ -104,6 +109,7 @@ class UpdateAttributeDetails(object):
 
         self.attribute_map = {
             'display_name': 'displayName',
+            'business_name': 'businessName',
             'description': 'description',
             'external_data_type': 'externalDataType',
             'is_incremental_data': 'isIncrementalData',
@@ -122,6 +128,7 @@ class UpdateAttributeDetails(object):
         }
 
         self._display_name = None
+        self._business_name = None
         self._description = None
         self._external_data_type = None
         self._is_incremental_data = None
@@ -163,6 +170,30 @@ class UpdateAttributeDetails(object):
         :type: str
         """
         self._display_name = display_name
+
+    @property
+    def business_name(self):
+        """
+        Gets the business_name of this UpdateAttributeDetails.
+        Optional user friendly business name of the attribute. If set, this supplements the harvested display name of the object.
+
+
+        :return: The business_name of this UpdateAttributeDetails.
+        :rtype: str
+        """
+        return self._business_name
+
+    @business_name.setter
+    def business_name(self, business_name):
+        """
+        Sets the business_name of this UpdateAttributeDetails.
+        Optional user friendly business name of the attribute. If set, this supplements the harvested display name of the object.
+
+
+        :param business_name: The business_name of this UpdateAttributeDetails.
+        :type: str
+        """
+        self._business_name = business_name
 
     @property
     def description(self):

--- a/src/oci/data_catalog/models/update_connection_details.py
+++ b/src/oci/data_catalog/models/update_connection_details.py
@@ -191,7 +191,7 @@ class UpdateConnectionDetails(object):
         To determine the set of optional and required properties for a connection type, a query can be done
         on '/types?type=connection' that returns a collection of all connection types. The appropriate connection
         type, which will include definitions of all of it's properties, can be identified from this collection.
-        Example: `{\"encProperties\": { \"default\": { \"password\": \"pwd\"}}}`
+        Example: `{\"encProperties\": { \"default\": { \"password\": \"example-password\"}}}`
 
 
         :return: The enc_properties of this UpdateConnectionDetails.
@@ -210,7 +210,7 @@ class UpdateConnectionDetails(object):
         To determine the set of optional and required properties for a connection type, a query can be done
         on '/types?type=connection' that returns a collection of all connection types. The appropriate connection
         type, which will include definitions of all of it's properties, can be identified from this collection.
-        Example: `{\"encProperties\": { \"default\": { \"password\": \"pwd\"}}}`
+        Example: `{\"encProperties\": { \"default\": { \"password\": \"example-password\"}}}`
 
 
         :param enc_properties: The enc_properties of this UpdateConnectionDetails.

--- a/src/oci/data_catalog/models/update_custom_property_details.py
+++ b/src/oci/data_catalog/models/update_custom_property_details.py
@@ -46,6 +46,10 @@ class UpdateCustomPropertyDetails(object):
             The value to assign to the is_editable property of this UpdateCustomPropertyDetails.
         :type is_editable: bool
 
+        :param is_shown_in_list:
+            The value to assign to the is_shown_in_list property of this UpdateCustomPropertyDetails.
+        :type is_shown_in_list: bool
+
         :param is_hidden_in_search:
             The value to assign to the is_hidden_in_search property of this UpdateCustomPropertyDetails.
         :type is_hidden_in_search: bool
@@ -67,6 +71,7 @@ class UpdateCustomPropertyDetails(object):
             'is_multi_valued': 'bool',
             'is_hidden': 'bool',
             'is_editable': 'bool',
+            'is_shown_in_list': 'bool',
             'is_hidden_in_search': 'bool',
             'allowed_values': 'list[str]',
             'properties': 'dict(str, dict(str, str))'
@@ -80,6 +85,7 @@ class UpdateCustomPropertyDetails(object):
             'is_multi_valued': 'isMultiValued',
             'is_hidden': 'isHidden',
             'is_editable': 'isEditable',
+            'is_shown_in_list': 'isShownInList',
             'is_hidden_in_search': 'isHiddenInSearch',
             'allowed_values': 'allowedValues',
             'properties': 'properties'
@@ -92,6 +98,7 @@ class UpdateCustomPropertyDetails(object):
         self._is_multi_valued = None
         self._is_hidden = None
         self._is_editable = None
+        self._is_shown_in_list = None
         self._is_hidden_in_search = None
         self._allowed_values = None
         self._properties = None
@@ -265,6 +272,30 @@ class UpdateCustomPropertyDetails(object):
         :type: bool
         """
         self._is_editable = is_editable
+
+    @property
+    def is_shown_in_list(self):
+        """
+        Gets the is_shown_in_list of this UpdateCustomPropertyDetails.
+        If this field is displayed in a list view of applicable objects.
+
+
+        :return: The is_shown_in_list of this UpdateCustomPropertyDetails.
+        :rtype: bool
+        """
+        return self._is_shown_in_list
+
+    @is_shown_in_list.setter
+    def is_shown_in_list(self, is_shown_in_list):
+        """
+        Sets the is_shown_in_list of this UpdateCustomPropertyDetails.
+        If this field is displayed in a list view of applicable objects.
+
+
+        :param is_shown_in_list: The is_shown_in_list of this UpdateCustomPropertyDetails.
+        :type: bool
+        """
+        self._is_shown_in_list = is_shown_in_list
 
     @property
     def is_hidden_in_search(self):

--- a/src/oci/data_catalog/models/update_entity_details.py
+++ b/src/oci/data_catalog/models/update_entity_details.py
@@ -38,6 +38,10 @@ class UpdateEntityDetails(object):
             The value to assign to the display_name property of this UpdateEntityDetails.
         :type display_name: str
 
+        :param business_name:
+            The value to assign to the business_name property of this UpdateEntityDetails.
+        :type business_name: str
+
         :param description:
             The value to assign to the description property of this UpdateEntityDetails.
         :type description: str
@@ -86,6 +90,7 @@ class UpdateEntityDetails(object):
         """
         self.swagger_types = {
             'display_name': 'str',
+            'business_name': 'str',
             'description': 'str',
             'time_external': 'datetime',
             'is_logical': 'bool',
@@ -101,6 +106,7 @@ class UpdateEntityDetails(object):
 
         self.attribute_map = {
             'display_name': 'displayName',
+            'business_name': 'businessName',
             'description': 'description',
             'time_external': 'timeExternal',
             'is_logical': 'isLogical',
@@ -115,6 +121,7 @@ class UpdateEntityDetails(object):
         }
 
         self._display_name = None
+        self._business_name = None
         self._description = None
         self._time_external = None
         self._is_logical = None
@@ -152,6 +159,30 @@ class UpdateEntityDetails(object):
         :type: str
         """
         self._display_name = display_name
+
+    @property
+    def business_name(self):
+        """
+        Gets the business_name of this UpdateEntityDetails.
+        Optional user friendly business name of the data entity. If set, this supplements the harvested display name of the object.
+
+
+        :return: The business_name of this UpdateEntityDetails.
+        :rtype: str
+        """
+        return self._business_name
+
+    @business_name.setter
+    def business_name(self, business_name):
+        """
+        Sets the business_name of this UpdateEntityDetails.
+        Optional user friendly business name of the data entity. If set, this supplements the harvested display name of the object.
+
+
+        :param business_name: The business_name of this UpdateEntityDetails.
+        :type: str
+        """
+        self._business_name = business_name
 
     @property
     def description(self):

--- a/src/oci/data_catalog/models/update_folder_details.py
+++ b/src/oci/data_catalog/models/update_folder_details.py
@@ -38,6 +38,10 @@ class UpdateFolderDetails(object):
             The value to assign to the display_name property of this UpdateFolderDetails.
         :type display_name: str
 
+        :param business_name:
+            The value to assign to the business_name property of this UpdateFolderDetails.
+        :type business_name: str
+
         :param description:
             The value to assign to the description property of this UpdateFolderDetails.
         :type description: str
@@ -70,6 +74,7 @@ class UpdateFolderDetails(object):
         """
         self.swagger_types = {
             'display_name': 'str',
+            'business_name': 'str',
             'description': 'str',
             'parent_folder_key': 'str',
             'custom_property_members': 'list[CustomPropertySetUsage]',
@@ -81,6 +86,7 @@ class UpdateFolderDetails(object):
 
         self.attribute_map = {
             'display_name': 'displayName',
+            'business_name': 'businessName',
             'description': 'description',
             'parent_folder_key': 'parentFolderKey',
             'custom_property_members': 'customPropertyMembers',
@@ -91,6 +97,7 @@ class UpdateFolderDetails(object):
         }
 
         self._display_name = None
+        self._business_name = None
         self._description = None
         self._parent_folder_key = None
         self._custom_property_members = None
@@ -124,6 +131,30 @@ class UpdateFolderDetails(object):
         :type: str
         """
         self._display_name = display_name
+
+    @property
+    def business_name(self):
+        """
+        Gets the business_name of this UpdateFolderDetails.
+        Optional user friendly business name of the folder. If set, this supplements the harvested display name of the object.
+
+
+        :return: The business_name of this UpdateFolderDetails.
+        :rtype: str
+        """
+        return self._business_name
+
+    @business_name.setter
+    def business_name(self, business_name):
+        """
+        Sets the business_name of this UpdateFolderDetails.
+        Optional user friendly business name of the folder. If set, this supplements the harvested display name of the object.
+
+
+        :param business_name: The business_name of this UpdateFolderDetails.
+        :type: str
+        """
+        self._business_name = business_name
 
     @property
     def description(self):

--- a/src/oci/database/database_client.py
+++ b/src/oci/database/database_client.py
@@ -5692,6 +5692,99 @@ class DatabaseClient(object):
                 path_params=path_params,
                 header_params=header_params)
 
+    def disable_external_non_container_database_operations_insights(self, external_non_container_database_id, **kwargs):
+        """
+        Disable Operations Insights for the external non-container database.
+
+
+        :param str external_non_container_database_id: (required)
+            The external non-container database `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/database/disable_external_non_container_database_operations_insights.py.html>`__ to see an example of how to use disable_external_non_container_database_operations_insights API.
+        """
+        resource_path = "/externalnoncontainerdatabases/{externalNonContainerDatabaseId}/actions/disableOperationsInsights"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "opc_request_id",
+            "if_match"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "disable_external_non_container_database_operations_insights got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "externalNonContainerDatabaseId": external_non_container_database_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
     def disable_external_pluggable_database_database_management(self, external_pluggable_database_id, **kwargs):
         """
         Disable Database Management Service for the external pluggable database.
@@ -5749,6 +5842,99 @@ class DatabaseClient(object):
         if extra_kwargs:
             raise ValueError(
                 "disable_external_pluggable_database_database_management got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "externalPluggableDatabaseId": external_pluggable_database_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+
+    def disable_external_pluggable_database_operations_insights(self, external_pluggable_database_id, **kwargs):
+        """
+        Disable Operations Insights for the external pluggable database.
+
+
+        :param str external_pluggable_database_id: (required)
+            The ExternalPluggableDatabaseId `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/database/disable_external_pluggable_database_operations_insights.py.html>`__ to see an example of how to use disable_external_pluggable_database_operations_insights API.
+        """
+        resource_path = "/externalpluggabledatabases/{externalPluggableDatabaseId}/actions/disableOperationsInsights"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "opc_request_id",
+            "if_match"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "disable_external_pluggable_database_operations_insights got unknown kwargs: {!r}".format(extra_kwargs))
 
         path_params = {
             "externalPluggableDatabaseId": external_pluggable_database_id
@@ -6250,6 +6436,104 @@ class DatabaseClient(object):
                 header_params=header_params,
                 body=enable_external_non_container_database_database_management_details)
 
+    def enable_external_non_container_database_operations_insights(self, external_non_container_database_id, enable_external_non_container_database_operations_insights_details, **kwargs):
+        """
+        Enable Operations Insights for the external non-container database.
+
+
+        :param str external_non_container_database_id: (required)
+            The external non-container database `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param oci.database.models.EnableExternalNonContainerDatabaseOperationsInsightsDetails enable_external_non_container_database_operations_insights_details: (required)
+            Details to enable Operations Insights on the external non-container database
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/database/enable_external_non_container_database_operations_insights.py.html>`__ to see an example of how to use enable_external_non_container_database_operations_insights API.
+        """
+        resource_path = "/externalnoncontainerdatabases/{externalNonContainerDatabaseId}/actions/enableOperationsInsights"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "opc_request_id",
+            "if_match"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "enable_external_non_container_database_operations_insights got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "externalNonContainerDatabaseId": external_non_container_database_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=enable_external_non_container_database_operations_insights_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=enable_external_non_container_database_operations_insights_details)
+
     def enable_external_pluggable_database_database_management(self, external_pluggable_database_id, enable_external_pluggable_database_database_management_details, **kwargs):
         """
         Enable Database Management Service for the external pluggable database.
@@ -6351,6 +6635,104 @@ class DatabaseClient(object):
                 path_params=path_params,
                 header_params=header_params,
                 body=enable_external_pluggable_database_database_management_details)
+
+    def enable_external_pluggable_database_operations_insights(self, external_pluggable_database_id, enable_external_pluggable_database_operations_insights_details, **kwargs):
+        """
+        Enable Operations Insights for the external pluggable database.
+
+
+        :param str external_pluggable_database_id: (required)
+            The ExternalPluggableDatabaseId `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param oci.database.models.EnableExternalPluggableDatabaseOperationsInsightsDetails enable_external_pluggable_database_operations_insights_details: (required)
+            Details to enable Operations Insights on the external pluggable database
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/database/enable_external_pluggable_database_operations_insights.py.html>`__ to see an example of how to use enable_external_pluggable_database_operations_insights API.
+        """
+        resource_path = "/externalpluggabledatabases/{externalPluggableDatabaseId}/actions/enableOperationsInsights"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "opc_request_id",
+            "if_match"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "enable_external_pluggable_database_operations_insights got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "externalPluggableDatabaseId": external_pluggable_database_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "if-match": kwargs.get("if_match", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=enable_external_pluggable_database_operations_insights_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=enable_external_pluggable_database_operations_insights_details)
 
     def fail_over_autonomous_database(self, autonomous_database_id, **kwargs):
         """

--- a/src/oci/database/database_client_composite_operations.py
+++ b/src/oci/database/database_client_composite_operations.py
@@ -3272,6 +3272,43 @@ class DatabaseClientCompositeOperations(object):
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
+    def disable_external_non_container_database_operations_insights_and_wait_for_work_request(self, external_non_container_database_id, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.disable_external_non_container_database_operations_insights` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str external_non_container_database_id: (required)
+            The external non-container database `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.disable_external_non_container_database_operations_insights`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.disable_external_non_container_database_operations_insights(external_non_container_database_id, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def disable_external_pluggable_database_database_management_and_wait_for_work_request(self, external_pluggable_database_id, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.database.DatabaseClient.disable_external_pluggable_database_database_management` and waits for the oci.work_requests.models.WorkRequest
@@ -3294,6 +3331,43 @@ class DatabaseClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         operation_result = self.client.disable_external_pluggable_database_database_management(external_pluggable_database_id, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def disable_external_pluggable_database_operations_insights_and_wait_for_work_request(self, external_pluggable_database_id, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.disable_external_pluggable_database_operations_insights` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str external_pluggable_database_id: (required)
+            The ExternalPluggableDatabaseId `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.disable_external_pluggable_database_operations_insights`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.disable_external_pluggable_database_operations_insights(external_pluggable_database_id, **operation_kwargs)
         work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
         lowered_work_request_states = [w.lower() for w in work_request_states]
         work_request_id = operation_result.headers['opc-work-request-id']
@@ -3426,6 +3500,46 @@ class DatabaseClientCompositeOperations(object):
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
+    def enable_external_non_container_database_operations_insights_and_wait_for_work_request(self, external_non_container_database_id, enable_external_non_container_database_operations_insights_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.enable_external_non_container_database_operations_insights` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str external_non_container_database_id: (required)
+            The external non-container database `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param oci.database.models.EnableExternalNonContainerDatabaseOperationsInsightsDetails enable_external_non_container_database_operations_insights_details: (required)
+            Details to enable Operations Insights on the external non-container database
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.enable_external_non_container_database_operations_insights`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.enable_external_non_container_database_operations_insights(external_non_container_database_id, enable_external_non_container_database_operations_insights_details, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def enable_external_pluggable_database_database_management_and_wait_for_work_request(self, external_pluggable_database_id, enable_external_pluggable_database_database_management_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.database.DatabaseClient.enable_external_pluggable_database_database_management` and waits for the oci.work_requests.models.WorkRequest
@@ -3451,6 +3565,46 @@ class DatabaseClientCompositeOperations(object):
             as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
         """
         operation_result = self.client.enable_external_pluggable_database_database_management(external_pluggable_database_id, enable_external_pluggable_database_database_management_details, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def enable_external_pluggable_database_operations_insights_and_wait_for_work_request(self, external_pluggable_database_id, enable_external_pluggable_database_operations_insights_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.enable_external_pluggable_database_operations_insights` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str external_pluggable_database_id: (required)
+            The ExternalPluggableDatabaseId `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param oci.database.models.EnableExternalPluggableDatabaseOperationsInsightsDetails enable_external_pluggable_database_operations_insights_details: (required)
+            Details to enable Operations Insights on the external pluggable database
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.enable_external_pluggable_database_operations_insights`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.enable_external_pluggable_database_operations_insights(external_pluggable_database_id, enable_external_pluggable_database_operations_insights_details, **operation_kwargs)
         work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
         lowered_work_request_states = [w.lower() for w in work_request_states]
         work_request_id = operation_result.headers['opc-work-request-id']

--- a/src/oci/database/models/__init__.py
+++ b/src/oci/database/models/__init__.py
@@ -103,6 +103,7 @@ from .create_new_database_details import CreateNewDatabaseDetails
 from .create_recovery_appliance_backup_destination_details import CreateRecoveryApplianceBackupDestinationDetails
 from .create_refreshable_autonomous_database_clone_details import CreateRefreshableAutonomousDatabaseCloneDetails
 from .create_vm_cluster_details import CreateVmClusterDetails
+from .customer_contact import CustomerContact
 from .data_guard_association import DataGuardAssociation
 from .data_guard_association_summary import DataGuardAssociationSummary
 from .database import Database
@@ -137,8 +138,11 @@ from .db_version_summary import DbVersionSummary
 from .deregister_autonomous_database_data_safe_details import DeregisterAutonomousDatabaseDataSafeDetails
 from .enable_external_container_database_database_management_details import EnableExternalContainerDatabaseDatabaseManagementDetails
 from .enable_external_database_management_details_base import EnableExternalDatabaseManagementDetailsBase
+from .enable_external_database_operations_insights_details_base import EnableExternalDatabaseOperationsInsightsDetailsBase
 from .enable_external_non_container_database_database_management_details import EnableExternalNonContainerDatabaseDatabaseManagementDetails
+from .enable_external_non_container_database_operations_insights_details import EnableExternalNonContainerDatabaseOperationsInsightsDetails
 from .enable_external_pluggable_database_database_management_details import EnableExternalPluggableDatabaseDatabaseManagementDetails
+from .enable_external_pluggable_database_operations_insights_details import EnableExternalPluggableDatabaseOperationsInsightsDetails
 from .exadata_db_system_migration import ExadataDbSystemMigration
 from .exadata_db_system_migration_summary import ExadataDbSystemMigrationSummary
 from .exadata_infrastructure import ExadataInfrastructure
@@ -184,6 +188,7 @@ from .month import Month
 from .mount_type_details import MountTypeDetails
 from .node_details import NodeDetails
 from .ocp_us import OCPUs
+from .operations_insights_config import OperationsInsightsConfig
 from .patch import Patch
 from .patch_details import PatchDetails
 from .patch_history_entry import PatchHistoryEntry
@@ -335,6 +340,7 @@ database_type_mapping = {
     "CreateRecoveryApplianceBackupDestinationDetails": CreateRecoveryApplianceBackupDestinationDetails,
     "CreateRefreshableAutonomousDatabaseCloneDetails": CreateRefreshableAutonomousDatabaseCloneDetails,
     "CreateVmClusterDetails": CreateVmClusterDetails,
+    "CustomerContact": CustomerContact,
     "DataGuardAssociation": DataGuardAssociation,
     "DataGuardAssociationSummary": DataGuardAssociationSummary,
     "Database": Database,
@@ -369,8 +375,11 @@ database_type_mapping = {
     "DeregisterAutonomousDatabaseDataSafeDetails": DeregisterAutonomousDatabaseDataSafeDetails,
     "EnableExternalContainerDatabaseDatabaseManagementDetails": EnableExternalContainerDatabaseDatabaseManagementDetails,
     "EnableExternalDatabaseManagementDetailsBase": EnableExternalDatabaseManagementDetailsBase,
+    "EnableExternalDatabaseOperationsInsightsDetailsBase": EnableExternalDatabaseOperationsInsightsDetailsBase,
     "EnableExternalNonContainerDatabaseDatabaseManagementDetails": EnableExternalNonContainerDatabaseDatabaseManagementDetails,
+    "EnableExternalNonContainerDatabaseOperationsInsightsDetails": EnableExternalNonContainerDatabaseOperationsInsightsDetails,
     "EnableExternalPluggableDatabaseDatabaseManagementDetails": EnableExternalPluggableDatabaseDatabaseManagementDetails,
+    "EnableExternalPluggableDatabaseOperationsInsightsDetails": EnableExternalPluggableDatabaseOperationsInsightsDetails,
     "ExadataDbSystemMigration": ExadataDbSystemMigration,
     "ExadataDbSystemMigrationSummary": ExadataDbSystemMigrationSummary,
     "ExadataInfrastructure": ExadataInfrastructure,
@@ -416,6 +425,7 @@ database_type_mapping = {
     "MountTypeDetails": MountTypeDetails,
     "NodeDetails": NodeDetails,
     "OCPUs": OCPUs,
+    "OperationsInsightsConfig": OperationsInsightsConfig,
     "Patch": Patch,
     "PatchDetails": PatchDetails,
     "PatchHistoryEntry": PatchHistoryEntry,

--- a/src/oci/database/models/autonomous_container_database_dataguard_association.py
+++ b/src/oci/database/models/autonomous_container_database_dataguard_association.py
@@ -292,7 +292,7 @@ class AutonomousContainerDatabaseDataguardAssociation(object):
     def role(self):
         """
         **[Required]** Gets the role of this AutonomousContainerDatabaseDataguardAssociation.
-        The role of the Autonomous Data Guard-enabled Autonomous Container Database.
+        The Data Guard role of the Autonomous Container Database, if Autonomous Data Guard is enabled.
 
         Allowed values for this property are: "PRIMARY", "STANDBY", "DISABLED_STANDBY", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -307,7 +307,7 @@ class AutonomousContainerDatabaseDataguardAssociation(object):
     def role(self, role):
         """
         Sets the role of this AutonomousContainerDatabaseDataguardAssociation.
-        The role of the Autonomous Data Guard-enabled Autonomous Container Database.
+        The Data Guard role of the Autonomous Container Database, if Autonomous Data Guard is enabled.
 
 
         :param role: The role of this AutonomousContainerDatabaseDataguardAssociation.
@@ -428,7 +428,7 @@ class AutonomousContainerDatabaseDataguardAssociation(object):
     def peer_role(self):
         """
         **[Required]** Gets the peer_role of this AutonomousContainerDatabaseDataguardAssociation.
-        The role of the Autonomous Data Guard-enabled Autonomous Container Database.
+        The Data Guard role of the Autonomous Container Database, if Autonomous Data Guard is enabled.
 
         Allowed values for this property are: "PRIMARY", "STANDBY", "DISABLED_STANDBY", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -443,7 +443,7 @@ class AutonomousContainerDatabaseDataguardAssociation(object):
     def peer_role(self, peer_role):
         """
         Sets the peer_role of this AutonomousContainerDatabaseDataguardAssociation.
-        The role of the Autonomous Data Guard-enabled Autonomous Container Database.
+        The Data Guard role of the Autonomous Container Database, if Autonomous Data Guard is enabled.
 
 
         :param peer_role: The peer_role of this AutonomousContainerDatabaseDataguardAssociation.

--- a/src/oci/database/models/autonomous_database.py
+++ b/src/oci/database/models/autonomous_database.py
@@ -480,6 +480,10 @@ class AutonomousDatabase(object):
             The value to assign to the key_store_wallet_name property of this AutonomousDatabase.
         :type key_store_wallet_name: str
 
+        :param customer_contacts:
+            The value to assign to the customer_contacts property of this AutonomousDatabase.
+        :type customer_contacts: list[oci.database.models.CustomerContact]
+
         """
         self.swagger_types = {
             'id': 'str',
@@ -542,7 +546,8 @@ class AutonomousDatabase(object):
             'role': 'str',
             'available_upgrade_versions': 'list[str]',
             'key_store_id': 'str',
-            'key_store_wallet_name': 'str'
+            'key_store_wallet_name': 'str',
+            'customer_contacts': 'list[CustomerContact]'
         }
 
         self.attribute_map = {
@@ -606,7 +611,8 @@ class AutonomousDatabase(object):
             'role': 'role',
             'available_upgrade_versions': 'availableUpgradeVersions',
             'key_store_id': 'keyStoreId',
-            'key_store_wallet_name': 'keyStoreWalletName'
+            'key_store_wallet_name': 'keyStoreWalletName',
+            'customer_contacts': 'customerContacts'
         }
 
         self._id = None
@@ -670,6 +676,7 @@ class AutonomousDatabase(object):
         self._available_upgrade_versions = None
         self._key_store_id = None
         self._key_store_wallet_name = None
+        self._customer_contacts = None
 
     @property
     def id(self):
@@ -2247,7 +2254,7 @@ class AutonomousDatabase(object):
     def role(self):
         """
         Gets the role of this AutonomousDatabase.
-        The role of the Autonomous Data Guard-enabled Autonomous Container Database.
+        The Data Guard role of the Autonomous Container Database, if Autonomous Data Guard is enabled.
 
         Allowed values for this property are: "PRIMARY", "STANDBY", "DISABLED_STANDBY", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -2262,7 +2269,7 @@ class AutonomousDatabase(object):
     def role(self, role):
         """
         Sets the role of this AutonomousDatabase.
-        The role of the Autonomous Data Guard-enabled Autonomous Container Database.
+        The Data Guard role of the Autonomous Container Database, if Autonomous Data Guard is enabled.
 
 
         :param role: The role of this AutonomousDatabase.
@@ -2348,6 +2355,30 @@ class AutonomousDatabase(object):
         :type: str
         """
         self._key_store_wallet_name = key_store_wallet_name
+
+    @property
+    def customer_contacts(self):
+        """
+        Gets the customer_contacts of this AutonomousDatabase.
+        Customer Contacts.
+
+
+        :return: The customer_contacts of this AutonomousDatabase.
+        :rtype: list[oci.database.models.CustomerContact]
+        """
+        return self._customer_contacts
+
+    @customer_contacts.setter
+    def customer_contacts(self, customer_contacts):
+        """
+        Sets the customer_contacts of this AutonomousDatabase.
+        Customer Contacts.
+
+
+        :param customer_contacts: The customer_contacts of this AutonomousDatabase.
+        :type: list[oci.database.models.CustomerContact]
+        """
+        self._customer_contacts = customer_contacts
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/database/models/autonomous_database_connection_urls.py
+++ b/src/oci/database/models/autonomous_database_connection_urls.py
@@ -34,22 +34,29 @@ class AutonomousDatabaseConnectionUrls(object):
             The value to assign to the machine_learning_user_management_url property of this AutonomousDatabaseConnectionUrls.
         :type machine_learning_user_management_url: str
 
+        :param graph_studio_url:
+            The value to assign to the graph_studio_url property of this AutonomousDatabaseConnectionUrls.
+        :type graph_studio_url: str
+
         """
         self.swagger_types = {
             'sql_dev_web_url': 'str',
             'apex_url': 'str',
-            'machine_learning_user_management_url': 'str'
+            'machine_learning_user_management_url': 'str',
+            'graph_studio_url': 'str'
         }
 
         self.attribute_map = {
             'sql_dev_web_url': 'sqlDevWebUrl',
             'apex_url': 'apexUrl',
-            'machine_learning_user_management_url': 'machineLearningUserManagementUrl'
+            'machine_learning_user_management_url': 'machineLearningUserManagementUrl',
+            'graph_studio_url': 'graphStudioUrl'
         }
 
         self._sql_dev_web_url = None
         self._apex_url = None
         self._machine_learning_user_management_url = None
+        self._graph_studio_url = None
 
     @property
     def sql_dev_web_url(self):
@@ -122,6 +129,30 @@ class AutonomousDatabaseConnectionUrls(object):
         :type: str
         """
         self._machine_learning_user_management_url = machine_learning_user_management_url
+
+    @property
+    def graph_studio_url(self):
+        """
+        Gets the graph_studio_url of this AutonomousDatabaseConnectionUrls.
+        The URL of the Graph Studio for the Autonomous Database.
+
+
+        :return: The graph_studio_url of this AutonomousDatabaseConnectionUrls.
+        :rtype: str
+        """
+        return self._graph_studio_url
+
+    @graph_studio_url.setter
+    def graph_studio_url(self, graph_studio_url):
+        """
+        Sets the graph_studio_url of this AutonomousDatabaseConnectionUrls.
+        The URL of the Graph Studio for the Autonomous Database.
+
+
+        :param graph_studio_url: The graph_studio_url of this AutonomousDatabaseConnectionUrls.
+        :type: str
+        """
+        self._graph_studio_url = graph_studio_url
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/database/models/autonomous_database_dataguard_association.py
+++ b/src/oci/database/models/autonomous_database_dataguard_association.py
@@ -287,7 +287,7 @@ class AutonomousDatabaseDataguardAssociation(object):
     def role(self):
         """
         **[Required]** Gets the role of this AutonomousDatabaseDataguardAssociation.
-        The role of the Autonomous Data Guard-enabled Autonomous Container Database.
+        The Data Guard role of the Autonomous Container Database, if Autonomous Data Guard is enabled.
 
         Allowed values for this property are: "PRIMARY", "STANDBY", "DISABLED_STANDBY", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -302,7 +302,7 @@ class AutonomousDatabaseDataguardAssociation(object):
     def role(self, role):
         """
         Sets the role of this AutonomousDatabaseDataguardAssociation.
-        The role of the Autonomous Data Guard-enabled Autonomous Container Database.
+        The Data Guard role of the Autonomous Container Database, if Autonomous Data Guard is enabled.
 
 
         :param role: The role of this AutonomousDatabaseDataguardAssociation.
@@ -371,7 +371,7 @@ class AutonomousDatabaseDataguardAssociation(object):
     def peer_role(self):
         """
         **[Required]** Gets the peer_role of this AutonomousDatabaseDataguardAssociation.
-        The role of the Autonomous Data Guard-enabled Autonomous Container Database.
+        The Data Guard role of the Autonomous Container Database, if Autonomous Data Guard is enabled.
 
         Allowed values for this property are: "PRIMARY", "STANDBY", "DISABLED_STANDBY", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -386,7 +386,7 @@ class AutonomousDatabaseDataguardAssociation(object):
     def peer_role(self, peer_role):
         """
         Sets the peer_role of this AutonomousDatabaseDataguardAssociation.
-        The role of the Autonomous Data Guard-enabled Autonomous Container Database.
+        The Data Guard role of the Autonomous Container Database, if Autonomous Data Guard is enabled.
 
 
         :param peer_role: The peer_role of this AutonomousDatabaseDataguardAssociation.

--- a/src/oci/database/models/autonomous_database_summary.py
+++ b/src/oci/database/models/autonomous_database_summary.py
@@ -482,6 +482,10 @@ class AutonomousDatabaseSummary(object):
             The value to assign to the key_store_wallet_name property of this AutonomousDatabaseSummary.
         :type key_store_wallet_name: str
 
+        :param customer_contacts:
+            The value to assign to the customer_contacts property of this AutonomousDatabaseSummary.
+        :type customer_contacts: list[oci.database.models.CustomerContact]
+
         """
         self.swagger_types = {
             'id': 'str',
@@ -544,7 +548,8 @@ class AutonomousDatabaseSummary(object):
             'role': 'str',
             'available_upgrade_versions': 'list[str]',
             'key_store_id': 'str',
-            'key_store_wallet_name': 'str'
+            'key_store_wallet_name': 'str',
+            'customer_contacts': 'list[CustomerContact]'
         }
 
         self.attribute_map = {
@@ -608,7 +613,8 @@ class AutonomousDatabaseSummary(object):
             'role': 'role',
             'available_upgrade_versions': 'availableUpgradeVersions',
             'key_store_id': 'keyStoreId',
-            'key_store_wallet_name': 'keyStoreWalletName'
+            'key_store_wallet_name': 'keyStoreWalletName',
+            'customer_contacts': 'customerContacts'
         }
 
         self._id = None
@@ -672,6 +678,7 @@ class AutonomousDatabaseSummary(object):
         self._available_upgrade_versions = None
         self._key_store_id = None
         self._key_store_wallet_name = None
+        self._customer_contacts = None
 
     @property
     def id(self):
@@ -2249,7 +2256,7 @@ class AutonomousDatabaseSummary(object):
     def role(self):
         """
         Gets the role of this AutonomousDatabaseSummary.
-        The role of the Autonomous Data Guard-enabled Autonomous Container Database.
+        The Data Guard role of the Autonomous Container Database, if Autonomous Data Guard is enabled.
 
         Allowed values for this property are: "PRIMARY", "STANDBY", "DISABLED_STANDBY", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -2264,7 +2271,7 @@ class AutonomousDatabaseSummary(object):
     def role(self, role):
         """
         Sets the role of this AutonomousDatabaseSummary.
-        The role of the Autonomous Data Guard-enabled Autonomous Container Database.
+        The Data Guard role of the Autonomous Container Database, if Autonomous Data Guard is enabled.
 
 
         :param role: The role of this AutonomousDatabaseSummary.
@@ -2350,6 +2357,30 @@ class AutonomousDatabaseSummary(object):
         :type: str
         """
         self._key_store_wallet_name = key_store_wallet_name
+
+    @property
+    def customer_contacts(self):
+        """
+        Gets the customer_contacts of this AutonomousDatabaseSummary.
+        Customer Contacts.
+
+
+        :return: The customer_contacts of this AutonomousDatabaseSummary.
+        :rtype: list[oci.database.models.CustomerContact]
+        """
+        return self._customer_contacts
+
+    @customer_contacts.setter
+    def customer_contacts(self, customer_contacts):
+        """
+        Sets the customer_contacts of this AutonomousDatabaseSummary.
+        Customer Contacts.
+
+
+        :param customer_contacts: The customer_contacts of this AutonomousDatabaseSummary.
+        :type: list[oci.database.models.CustomerContact]
+        """
+        self._customer_contacts = customer_contacts
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/database/models/create_autonomous_database_base.py
+++ b/src/oci/database/models/create_autonomous_database_base.py
@@ -175,6 +175,10 @@ class CreateAutonomousDatabaseBase(object):
             Allowed values for this property are: "NONE", "DATABASE", "BACKUP_FROM_ID", "BACKUP_FROM_TIMESTAMP", "CLONE_TO_REFRESHABLE"
         :type source: str
 
+        :param customer_contacts:
+            The value to assign to the customer_contacts property of this CreateAutonomousDatabaseBase.
+        :type customer_contacts: list[oci.database.models.CustomerContact]
+
         """
         self.swagger_types = {
             'compartment_id': 'str',
@@ -201,7 +205,8 @@ class CreateAutonomousDatabaseBase(object):
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
             'db_version': 'str',
-            'source': 'str'
+            'source': 'str',
+            'customer_contacts': 'list[CustomerContact]'
         }
 
         self.attribute_map = {
@@ -229,7 +234,8 @@ class CreateAutonomousDatabaseBase(object):
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
             'db_version': 'dbVersion',
-            'source': 'source'
+            'source': 'source',
+            'customer_contacts': 'customerContacts'
         }
 
         self._compartment_id = None
@@ -257,6 +263,7 @@ class CreateAutonomousDatabaseBase(object):
         self._defined_tags = None
         self._db_version = None
         self._source = None
+        self._customer_contacts = None
 
     @staticmethod
     def get_subtype(object_dictionary):
@@ -1062,6 +1069,30 @@ class CreateAutonomousDatabaseBase(object):
                 .format(allowed_values)
             )
         self._source = source
+
+    @property
+    def customer_contacts(self):
+        """
+        Gets the customer_contacts of this CreateAutonomousDatabaseBase.
+        Customer Contacts.
+
+
+        :return: The customer_contacts of this CreateAutonomousDatabaseBase.
+        :rtype: list[oci.database.models.CustomerContact]
+        """
+        return self._customer_contacts
+
+    @customer_contacts.setter
+    def customer_contacts(self, customer_contacts):
+        """
+        Sets the customer_contacts of this CreateAutonomousDatabaseBase.
+        Customer Contacts.
+
+
+        :param customer_contacts: The customer_contacts of this CreateAutonomousDatabaseBase.
+        :type: list[oci.database.models.CustomerContact]
+        """
+        self._customer_contacts = customer_contacts
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/database/models/create_autonomous_database_clone_details.py
+++ b/src/oci/database/models/create_autonomous_database_clone_details.py
@@ -130,6 +130,10 @@ class CreateAutonomousDatabaseCloneDetails(CreateAutonomousDatabaseBase):
             Allowed values for this property are: "NONE", "DATABASE", "BACKUP_FROM_ID", "BACKUP_FROM_TIMESTAMP", "CLONE_TO_REFRESHABLE"
         :type source: str
 
+        :param customer_contacts:
+            The value to assign to the customer_contacts property of this CreateAutonomousDatabaseCloneDetails.
+        :type customer_contacts: list[oci.database.models.CustomerContact]
+
         :param source_id:
             The value to assign to the source_id property of this CreateAutonomousDatabaseCloneDetails.
         :type source_id: str
@@ -166,6 +170,7 @@ class CreateAutonomousDatabaseCloneDetails(CreateAutonomousDatabaseBase):
             'defined_tags': 'dict(str, dict(str, object))',
             'db_version': 'str',
             'source': 'str',
+            'customer_contacts': 'list[CustomerContact]',
             'source_id': 'str',
             'clone_type': 'str'
         }
@@ -196,6 +201,7 @@ class CreateAutonomousDatabaseCloneDetails(CreateAutonomousDatabaseBase):
             'defined_tags': 'definedTags',
             'db_version': 'dbVersion',
             'source': 'source',
+            'customer_contacts': 'customerContacts',
             'source_id': 'sourceId',
             'clone_type': 'cloneType'
         }
@@ -225,6 +231,7 @@ class CreateAutonomousDatabaseCloneDetails(CreateAutonomousDatabaseBase):
         self._defined_tags = None
         self._db_version = None
         self._source = None
+        self._customer_contacts = None
         self._source_id = None
         self._clone_type = None
         self._source = 'DATABASE'

--- a/src/oci/database/models/create_autonomous_database_details.py
+++ b/src/oci/database/models/create_autonomous_database_details.py
@@ -122,6 +122,10 @@ class CreateAutonomousDatabaseDetails(CreateAutonomousDatabaseBase):
             Allowed values for this property are: "NONE", "DATABASE", "BACKUP_FROM_ID", "BACKUP_FROM_TIMESTAMP", "CLONE_TO_REFRESHABLE"
         :type source: str
 
+        :param customer_contacts:
+            The value to assign to the customer_contacts property of this CreateAutonomousDatabaseDetails.
+        :type customer_contacts: list[oci.database.models.CustomerContact]
+
         """
         self.swagger_types = {
             'compartment_id': 'str',
@@ -148,7 +152,8 @@ class CreateAutonomousDatabaseDetails(CreateAutonomousDatabaseBase):
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
             'db_version': 'str',
-            'source': 'str'
+            'source': 'str',
+            'customer_contacts': 'list[CustomerContact]'
         }
 
         self.attribute_map = {
@@ -176,7 +181,8 @@ class CreateAutonomousDatabaseDetails(CreateAutonomousDatabaseBase):
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
             'db_version': 'dbVersion',
-            'source': 'source'
+            'source': 'source',
+            'customer_contacts': 'customerContacts'
         }
 
         self._compartment_id = None
@@ -204,6 +210,7 @@ class CreateAutonomousDatabaseDetails(CreateAutonomousDatabaseBase):
         self._defined_tags = None
         self._db_version = None
         self._source = None
+        self._customer_contacts = None
         self._source = 'NONE'
 
     def __repr__(self):

--- a/src/oci/database/models/create_autonomous_database_from_backup_details.py
+++ b/src/oci/database/models/create_autonomous_database_from_backup_details.py
@@ -130,6 +130,10 @@ class CreateAutonomousDatabaseFromBackupDetails(CreateAutonomousDatabaseBase):
             Allowed values for this property are: "NONE", "DATABASE", "BACKUP_FROM_ID", "BACKUP_FROM_TIMESTAMP", "CLONE_TO_REFRESHABLE"
         :type source: str
 
+        :param customer_contacts:
+            The value to assign to the customer_contacts property of this CreateAutonomousDatabaseFromBackupDetails.
+        :type customer_contacts: list[oci.database.models.CustomerContact]
+
         :param autonomous_database_backup_id:
             The value to assign to the autonomous_database_backup_id property of this CreateAutonomousDatabaseFromBackupDetails.
         :type autonomous_database_backup_id: str
@@ -166,6 +170,7 @@ class CreateAutonomousDatabaseFromBackupDetails(CreateAutonomousDatabaseBase):
             'defined_tags': 'dict(str, dict(str, object))',
             'db_version': 'str',
             'source': 'str',
+            'customer_contacts': 'list[CustomerContact]',
             'autonomous_database_backup_id': 'str',
             'clone_type': 'str'
         }
@@ -196,6 +201,7 @@ class CreateAutonomousDatabaseFromBackupDetails(CreateAutonomousDatabaseBase):
             'defined_tags': 'definedTags',
             'db_version': 'dbVersion',
             'source': 'source',
+            'customer_contacts': 'customerContacts',
             'autonomous_database_backup_id': 'autonomousDatabaseBackupId',
             'clone_type': 'cloneType'
         }
@@ -225,6 +231,7 @@ class CreateAutonomousDatabaseFromBackupDetails(CreateAutonomousDatabaseBase):
         self._defined_tags = None
         self._db_version = None
         self._source = None
+        self._customer_contacts = None
         self._autonomous_database_backup_id = None
         self._clone_type = None
         self._source = 'BACKUP_FROM_ID'

--- a/src/oci/database/models/create_autonomous_database_from_backup_timestamp_details.py
+++ b/src/oci/database/models/create_autonomous_database_from_backup_timestamp_details.py
@@ -130,6 +130,10 @@ class CreateAutonomousDatabaseFromBackupTimestampDetails(CreateAutonomousDatabas
             Allowed values for this property are: "NONE", "DATABASE", "BACKUP_FROM_ID", "BACKUP_FROM_TIMESTAMP", "CLONE_TO_REFRESHABLE"
         :type source: str
 
+        :param customer_contacts:
+            The value to assign to the customer_contacts property of this CreateAutonomousDatabaseFromBackupTimestampDetails.
+        :type customer_contacts: list[oci.database.models.CustomerContact]
+
         :param autonomous_database_id:
             The value to assign to the autonomous_database_id property of this CreateAutonomousDatabaseFromBackupTimestampDetails.
         :type autonomous_database_id: str
@@ -170,6 +174,7 @@ class CreateAutonomousDatabaseFromBackupTimestampDetails(CreateAutonomousDatabas
             'defined_tags': 'dict(str, dict(str, object))',
             'db_version': 'str',
             'source': 'str',
+            'customer_contacts': 'list[CustomerContact]',
             'autonomous_database_id': 'str',
             'timestamp': 'datetime',
             'clone_type': 'str'
@@ -201,6 +206,7 @@ class CreateAutonomousDatabaseFromBackupTimestampDetails(CreateAutonomousDatabas
             'defined_tags': 'definedTags',
             'db_version': 'dbVersion',
             'source': 'source',
+            'customer_contacts': 'customerContacts',
             'autonomous_database_id': 'autonomousDatabaseId',
             'timestamp': 'timestamp',
             'clone_type': 'cloneType'
@@ -231,6 +237,7 @@ class CreateAutonomousDatabaseFromBackupTimestampDetails(CreateAutonomousDatabas
         self._defined_tags = None
         self._db_version = None
         self._source = None
+        self._customer_contacts = None
         self._autonomous_database_id = None
         self._timestamp = None
         self._clone_type = None

--- a/src/oci/database/models/create_database_details.py
+++ b/src/oci/database/models/create_database_details.py
@@ -201,7 +201,7 @@ class CreateDatabaseDetails(object):
     def pdb_name(self):
         """
         Gets the pdb_name of this CreateDatabaseDetails.
-        The name of the pluggable database. The name must begin with an alphabetic character and can contain a maximum of eight alphanumeric characters. Special characters are not permitted. Pluggable database should not be same as database name.
+        The name of the pluggable database. The name must begin with an alphabetic character and can contain a maximum of thirty alphanumeric characters. Special characters are not permitted. Pluggable database should not be same as database name.
 
 
         :return: The pdb_name of this CreateDatabaseDetails.
@@ -213,7 +213,7 @@ class CreateDatabaseDetails(object):
     def pdb_name(self, pdb_name):
         """
         Sets the pdb_name of this CreateDatabaseDetails.
-        The name of the pluggable database. The name must begin with an alphabetic character and can contain a maximum of eight alphanumeric characters. Special characters are not permitted. Pluggable database should not be same as database name.
+        The name of the pluggable database. The name must begin with an alphabetic character and can contain a maximum of thirty alphanumeric characters. Special characters are not permitted. Pluggable database should not be same as database name.
 
 
         :param pdb_name: The pdb_name of this CreateDatabaseDetails.

--- a/src/oci/database/models/create_database_software_image_details.py
+++ b/src/oci/database/models/create_database_software_image_details.py
@@ -151,7 +151,7 @@ class CreateDatabaseSoftwareImageDetails(object):
     @property
     def database_version(self):
         """
-        **[Required]** Gets the database_version of this CreateDatabaseSoftwareImageDetails.
+        Gets the database_version of this CreateDatabaseSoftwareImageDetails.
         The database version with which the database software image is to be built.
 
 
@@ -263,7 +263,7 @@ class CreateDatabaseSoftwareImageDetails(object):
     @property
     def patch_set(self):
         """
-        **[Required]** Gets the patch_set of this CreateDatabaseSoftwareImageDetails.
+        Gets the patch_set of this CreateDatabaseSoftwareImageDetails.
         The PSU or PBP or Release Updates. To get a list of supported versions, use the :func:`list_db_versions` operation.
 
 

--- a/src/oci/database/models/create_refreshable_autonomous_database_clone_details.py
+++ b/src/oci/database/models/create_refreshable_autonomous_database_clone_details.py
@@ -130,6 +130,10 @@ class CreateRefreshableAutonomousDatabaseCloneDetails(CreateAutonomousDatabaseBa
             Allowed values for this property are: "NONE", "DATABASE", "BACKUP_FROM_ID", "BACKUP_FROM_TIMESTAMP", "CLONE_TO_REFRESHABLE"
         :type source: str
 
+        :param customer_contacts:
+            The value to assign to the customer_contacts property of this CreateRefreshableAutonomousDatabaseCloneDetails.
+        :type customer_contacts: list[oci.database.models.CustomerContact]
+
         :param source_id:
             The value to assign to the source_id property of this CreateRefreshableAutonomousDatabaseCloneDetails.
         :type source_id: str
@@ -166,6 +170,7 @@ class CreateRefreshableAutonomousDatabaseCloneDetails(CreateAutonomousDatabaseBa
             'defined_tags': 'dict(str, dict(str, object))',
             'db_version': 'str',
             'source': 'str',
+            'customer_contacts': 'list[CustomerContact]',
             'source_id': 'str',
             'refreshable_mode': 'str'
         }
@@ -196,6 +201,7 @@ class CreateRefreshableAutonomousDatabaseCloneDetails(CreateAutonomousDatabaseBa
             'defined_tags': 'definedTags',
             'db_version': 'dbVersion',
             'source': 'source',
+            'customer_contacts': 'customerContacts',
             'source_id': 'sourceId',
             'refreshable_mode': 'refreshableMode'
         }
@@ -225,6 +231,7 @@ class CreateRefreshableAutonomousDatabaseCloneDetails(CreateAutonomousDatabaseBa
         self._defined_tags = None
         self._db_version = None
         self._source = None
+        self._customer_contacts = None
         self._source_id = None
         self._refreshable_mode = None
         self._source = 'CLONE_TO_REFRESHABLE'

--- a/src/oci/database/models/customer_contact.py
+++ b/src/oci/database/models/customer_contact.py
@@ -1,0 +1,70 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CustomerContact(object):
+    """
+    The object holds customer email contact for Oracle Autonomous Databases.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CustomerContact object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param email:
+            The value to assign to the email property of this CustomerContact.
+        :type email: str
+
+        """
+        self.swagger_types = {
+            'email': 'str'
+        }
+
+        self.attribute_map = {
+            'email': 'email'
+        }
+
+        self._email = None
+
+    @property
+    def email(self):
+        """
+        Gets the email of this CustomerContact.
+        The email address of an Oracle Autonomous Database contact.
+
+
+        :return: The email of this CustomerContact.
+        :rtype: str
+        """
+        return self._email
+
+    @email.setter
+    def email(self, email):
+        """
+        Sets the email of this CustomerContact.
+        The email address of an Oracle Autonomous Database contact.
+
+
+        :param email: The email of this CustomerContact.
+        :type: str
+        """
+        self._email = email
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/database.py
+++ b/src/oci/database/models/database.py
@@ -434,7 +434,7 @@ class Database(object):
     def pdb_name(self):
         """
         Gets the pdb_name of this Database.
-        The name of the pluggable database. The name must begin with an alphabetic character and can contain a maximum of eight alphanumeric characters. Special characters are not permitted. Pluggable database should not be same as database name.
+        The name of the pluggable database. The name must begin with an alphabetic character and can contain a maximum of thirty alphanumeric characters. Special characters are not permitted. Pluggable database should not be same as database name.
 
 
         :return: The pdb_name of this Database.
@@ -446,7 +446,7 @@ class Database(object):
     def pdb_name(self, pdb_name):
         """
         Sets the pdb_name of this Database.
-        The name of the pluggable database. The name must begin with an alphabetic character and can contain a maximum of eight alphanumeric characters. Special characters are not permitted. Pluggable database should not be same as database name.
+        The name of the pluggable database. The name must begin with an alphabetic character and can contain a maximum of thirty alphanumeric characters. Special characters are not permitted. Pluggable database should not be same as database name.
 
 
         :param pdb_name: The pdb_name of this Database.

--- a/src/oci/database/models/database_summary.py
+++ b/src/oci/database/models/database_summary.py
@@ -441,7 +441,7 @@ class DatabaseSummary(object):
     def pdb_name(self):
         """
         Gets the pdb_name of this DatabaseSummary.
-        The name of the pluggable database. The name must begin with an alphabetic character and can contain a maximum of eight alphanumeric characters. Special characters are not permitted. Pluggable database should not be same as database name.
+        The name of the pluggable database. The name must begin with an alphabetic character and can contain a maximum of thirty alphanumeric characters. Special characters are not permitted. Pluggable database should not be same as database name.
 
 
         :return: The pdb_name of this DatabaseSummary.
@@ -453,7 +453,7 @@ class DatabaseSummary(object):
     def pdb_name(self, pdb_name):
         """
         Sets the pdb_name of this DatabaseSummary.
-        The name of the pluggable database. The name must begin with an alphabetic character and can contain a maximum of eight alphanumeric characters. Special characters are not permitted. Pluggable database should not be same as database name.
+        The name of the pluggable database. The name must begin with an alphabetic character and can contain a maximum of thirty alphanumeric characters. Special characters are not permitted. Pluggable database should not be same as database name.
 
 
         :param pdb_name: The pdb_name of this DatabaseSummary.

--- a/src/oci/database/models/enable_external_database_operations_insights_details_base.py
+++ b/src/oci/database/models/enable_external_database_operations_insights_details_base.py
@@ -1,0 +1,76 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class EnableExternalDatabaseOperationsInsightsDetailsBase(object):
+    """
+    Details to enable Operations Insights on the external database.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new EnableExternalDatabaseOperationsInsightsDetailsBase object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param external_database_connector_id:
+            The value to assign to the external_database_connector_id property of this EnableExternalDatabaseOperationsInsightsDetailsBase.
+        :type external_database_connector_id: str
+
+        """
+        self.swagger_types = {
+            'external_database_connector_id': 'str'
+        }
+
+        self.attribute_map = {
+            'external_database_connector_id': 'externalDatabaseConnectorId'
+        }
+
+        self._external_database_connector_id = None
+
+    @property
+    def external_database_connector_id(self):
+        """
+        **[Required]** Gets the external_database_connector_id of this EnableExternalDatabaseOperationsInsightsDetailsBase.
+        The `OCID`__ of the
+        :func:`create_external_database_connector_details`.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The external_database_connector_id of this EnableExternalDatabaseOperationsInsightsDetailsBase.
+        :rtype: str
+        """
+        return self._external_database_connector_id
+
+    @external_database_connector_id.setter
+    def external_database_connector_id(self, external_database_connector_id):
+        """
+        Sets the external_database_connector_id of this EnableExternalDatabaseOperationsInsightsDetailsBase.
+        The `OCID`__ of the
+        :func:`create_external_database_connector_details`.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param external_database_connector_id: The external_database_connector_id of this EnableExternalDatabaseOperationsInsightsDetailsBase.
+        :type: str
+        """
+        self._external_database_connector_id = external_database_connector_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/enable_external_non_container_database_operations_insights_details.py
+++ b/src/oci/database/models/enable_external_non_container_database_operations_insights_details.py
@@ -1,0 +1,76 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class EnableExternalNonContainerDatabaseOperationsInsightsDetails(object):
+    """
+    Details to enable Operations Insights on the external non-container database
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new EnableExternalNonContainerDatabaseOperationsInsightsDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param external_database_connector_id:
+            The value to assign to the external_database_connector_id property of this EnableExternalNonContainerDatabaseOperationsInsightsDetails.
+        :type external_database_connector_id: str
+
+        """
+        self.swagger_types = {
+            'external_database_connector_id': 'str'
+        }
+
+        self.attribute_map = {
+            'external_database_connector_id': 'externalDatabaseConnectorId'
+        }
+
+        self._external_database_connector_id = None
+
+    @property
+    def external_database_connector_id(self):
+        """
+        **[Required]** Gets the external_database_connector_id of this EnableExternalNonContainerDatabaseOperationsInsightsDetails.
+        The `OCID`__ of the
+        :func:`create_external_database_connector_details`.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The external_database_connector_id of this EnableExternalNonContainerDatabaseOperationsInsightsDetails.
+        :rtype: str
+        """
+        return self._external_database_connector_id
+
+    @external_database_connector_id.setter
+    def external_database_connector_id(self, external_database_connector_id):
+        """
+        Sets the external_database_connector_id of this EnableExternalNonContainerDatabaseOperationsInsightsDetails.
+        The `OCID`__ of the
+        :func:`create_external_database_connector_details`.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param external_database_connector_id: The external_database_connector_id of this EnableExternalNonContainerDatabaseOperationsInsightsDetails.
+        :type: str
+        """
+        self._external_database_connector_id = external_database_connector_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/enable_external_pluggable_database_operations_insights_details.py
+++ b/src/oci/database/models/enable_external_pluggable_database_operations_insights_details.py
@@ -1,0 +1,76 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class EnableExternalPluggableDatabaseOperationsInsightsDetails(object):
+    """
+    Details to enable Operations Insights on the external pluggable database
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new EnableExternalPluggableDatabaseOperationsInsightsDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param external_database_connector_id:
+            The value to assign to the external_database_connector_id property of this EnableExternalPluggableDatabaseOperationsInsightsDetails.
+        :type external_database_connector_id: str
+
+        """
+        self.swagger_types = {
+            'external_database_connector_id': 'str'
+        }
+
+        self.attribute_map = {
+            'external_database_connector_id': 'externalDatabaseConnectorId'
+        }
+
+        self._external_database_connector_id = None
+
+    @property
+    def external_database_connector_id(self):
+        """
+        **[Required]** Gets the external_database_connector_id of this EnableExternalPluggableDatabaseOperationsInsightsDetails.
+        The `OCID`__ of the
+        :func:`create_external_database_connector_details`.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The external_database_connector_id of this EnableExternalPluggableDatabaseOperationsInsightsDetails.
+        :rtype: str
+        """
+        return self._external_database_connector_id
+
+    @external_database_connector_id.setter
+    def external_database_connector_id(self, external_database_connector_id):
+        """
+        Sets the external_database_connector_id of this EnableExternalPluggableDatabaseOperationsInsightsDetails.
+        The `OCID`__ of the
+        :func:`create_external_database_connector_details`.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param external_database_connector_id: The external_database_connector_id of this EnableExternalPluggableDatabaseOperationsInsightsDetails.
+        :type: str
+        """
+        self._external_database_connector_id = external_database_connector_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/external_non_container_database.py
+++ b/src/oci/database/models/external_non_container_database.py
@@ -62,6 +62,10 @@ class ExternalNonContainerDatabase(object):
         Initializes a new ExternalNonContainerDatabase object with values from keyword arguments.
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
+        :param operations_insights_config:
+            The value to assign to the operations_insights_config property of this ExternalNonContainerDatabase.
+        :type operations_insights_config: oci.database.models.OperationsInsightsConfig
+
         :param compartment_id:
             The value to assign to the compartment_id property of this ExternalNonContainerDatabase.
         :type compartment_id: str
@@ -136,6 +140,7 @@ class ExternalNonContainerDatabase(object):
 
         """
         self.swagger_types = {
+            'operations_insights_config': 'OperationsInsightsConfig',
             'compartment_id': 'str',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
@@ -156,6 +161,7 @@ class ExternalNonContainerDatabase(object):
         }
 
         self.attribute_map = {
+            'operations_insights_config': 'operationsInsightsConfig',
             'compartment_id': 'compartmentId',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
@@ -175,6 +181,7 @@ class ExternalNonContainerDatabase(object):
             'database_management_config': 'databaseManagementConfig'
         }
 
+        self._operations_insights_config = None
         self._compartment_id = None
         self._freeform_tags = None
         self._defined_tags = None
@@ -192,6 +199,26 @@ class ExternalNonContainerDatabase(object):
         self._ncharacter_set = None
         self._db_packs = None
         self._database_management_config = None
+
+    @property
+    def operations_insights_config(self):
+        """
+        Gets the operations_insights_config of this ExternalNonContainerDatabase.
+
+        :return: The operations_insights_config of this ExternalNonContainerDatabase.
+        :rtype: oci.database.models.OperationsInsightsConfig
+        """
+        return self._operations_insights_config
+
+    @operations_insights_config.setter
+    def operations_insights_config(self, operations_insights_config):
+        """
+        Sets the operations_insights_config of this ExternalNonContainerDatabase.
+
+        :param operations_insights_config: The operations_insights_config of this ExternalNonContainerDatabase.
+        :type: oci.database.models.OperationsInsightsConfig
+        """
+        self._operations_insights_config = operations_insights_config
 
     @property
     def compartment_id(self):

--- a/src/oci/database/models/external_non_container_database_summary.py
+++ b/src/oci/database/models/external_non_container_database_summary.py
@@ -63,6 +63,10 @@ class ExternalNonContainerDatabaseSummary(object):
         Initializes a new ExternalNonContainerDatabaseSummary object with values from keyword arguments.
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
+        :param operations_insights_config:
+            The value to assign to the operations_insights_config property of this ExternalNonContainerDatabaseSummary.
+        :type operations_insights_config: oci.database.models.OperationsInsightsConfig
+
         :param compartment_id:
             The value to assign to the compartment_id property of this ExternalNonContainerDatabaseSummary.
         :type compartment_id: str
@@ -137,6 +141,7 @@ class ExternalNonContainerDatabaseSummary(object):
 
         """
         self.swagger_types = {
+            'operations_insights_config': 'OperationsInsightsConfig',
             'compartment_id': 'str',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
@@ -157,6 +162,7 @@ class ExternalNonContainerDatabaseSummary(object):
         }
 
         self.attribute_map = {
+            'operations_insights_config': 'operationsInsightsConfig',
             'compartment_id': 'compartmentId',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
@@ -176,6 +182,7 @@ class ExternalNonContainerDatabaseSummary(object):
             'database_management_config': 'databaseManagementConfig'
         }
 
+        self._operations_insights_config = None
         self._compartment_id = None
         self._freeform_tags = None
         self._defined_tags = None
@@ -193,6 +200,26 @@ class ExternalNonContainerDatabaseSummary(object):
         self._ncharacter_set = None
         self._db_packs = None
         self._database_management_config = None
+
+    @property
+    def operations_insights_config(self):
+        """
+        Gets the operations_insights_config of this ExternalNonContainerDatabaseSummary.
+
+        :return: The operations_insights_config of this ExternalNonContainerDatabaseSummary.
+        :rtype: oci.database.models.OperationsInsightsConfig
+        """
+        return self._operations_insights_config
+
+    @operations_insights_config.setter
+    def operations_insights_config(self, operations_insights_config):
+        """
+        Sets the operations_insights_config of this ExternalNonContainerDatabaseSummary.
+
+        :param operations_insights_config: The operations_insights_config of this ExternalNonContainerDatabaseSummary.
+        :type: oci.database.models.OperationsInsightsConfig
+        """
+        self._operations_insights_config = operations_insights_config
 
     @property
     def compartment_id(self):

--- a/src/oci/database/models/external_pluggable_database.py
+++ b/src/oci/database/models/external_pluggable_database.py
@@ -70,6 +70,10 @@ class ExternalPluggableDatabase(object):
             The value to assign to the external_container_database_id property of this ExternalPluggableDatabase.
         :type external_container_database_id: str
 
+        :param operations_insights_config:
+            The value to assign to the operations_insights_config property of this ExternalPluggableDatabase.
+        :type operations_insights_config: oci.database.models.OperationsInsightsConfig
+
         :param compartment_id:
             The value to assign to the compartment_id property of this ExternalPluggableDatabase.
         :type compartment_id: str
@@ -146,6 +150,7 @@ class ExternalPluggableDatabase(object):
         self.swagger_types = {
             'source_id': 'str',
             'external_container_database_id': 'str',
+            'operations_insights_config': 'OperationsInsightsConfig',
             'compartment_id': 'str',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
@@ -168,6 +173,7 @@ class ExternalPluggableDatabase(object):
         self.attribute_map = {
             'source_id': 'sourceId',
             'external_container_database_id': 'externalContainerDatabaseId',
+            'operations_insights_config': 'operationsInsightsConfig',
             'compartment_id': 'compartmentId',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
@@ -189,6 +195,7 @@ class ExternalPluggableDatabase(object):
 
         self._source_id = None
         self._external_container_database_id = None
+        self._operations_insights_config = None
         self._compartment_id = None
         self._freeform_tags = None
         self._defined_tags = None
@@ -268,6 +275,26 @@ class ExternalPluggableDatabase(object):
         :type: str
         """
         self._external_container_database_id = external_container_database_id
+
+    @property
+    def operations_insights_config(self):
+        """
+        Gets the operations_insights_config of this ExternalPluggableDatabase.
+
+        :return: The operations_insights_config of this ExternalPluggableDatabase.
+        :rtype: oci.database.models.OperationsInsightsConfig
+        """
+        return self._operations_insights_config
+
+    @operations_insights_config.setter
+    def operations_insights_config(self, operations_insights_config):
+        """
+        Sets the operations_insights_config of this ExternalPluggableDatabase.
+
+        :param operations_insights_config: The operations_insights_config of this ExternalPluggableDatabase.
+        :type: oci.database.models.OperationsInsightsConfig
+        """
+        self._operations_insights_config = operations_insights_config
 
     @property
     def compartment_id(self):

--- a/src/oci/database/models/external_pluggable_database_summary.py
+++ b/src/oci/database/models/external_pluggable_database_summary.py
@@ -70,6 +70,10 @@ class ExternalPluggableDatabaseSummary(object):
             The value to assign to the external_container_database_id property of this ExternalPluggableDatabaseSummary.
         :type external_container_database_id: str
 
+        :param operations_insights_config:
+            The value to assign to the operations_insights_config property of this ExternalPluggableDatabaseSummary.
+        :type operations_insights_config: oci.database.models.OperationsInsightsConfig
+
         :param compartment_id:
             The value to assign to the compartment_id property of this ExternalPluggableDatabaseSummary.
         :type compartment_id: str
@@ -146,6 +150,7 @@ class ExternalPluggableDatabaseSummary(object):
         self.swagger_types = {
             'source_id': 'str',
             'external_container_database_id': 'str',
+            'operations_insights_config': 'OperationsInsightsConfig',
             'compartment_id': 'str',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
@@ -168,6 +173,7 @@ class ExternalPluggableDatabaseSummary(object):
         self.attribute_map = {
             'source_id': 'sourceId',
             'external_container_database_id': 'externalContainerDatabaseId',
+            'operations_insights_config': 'operationsInsightsConfig',
             'compartment_id': 'compartmentId',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
@@ -189,6 +195,7 @@ class ExternalPluggableDatabaseSummary(object):
 
         self._source_id = None
         self._external_container_database_id = None
+        self._operations_insights_config = None
         self._compartment_id = None
         self._freeform_tags = None
         self._defined_tags = None
@@ -268,6 +275,26 @@ class ExternalPluggableDatabaseSummary(object):
         :type: str
         """
         self._external_container_database_id = external_container_database_id
+
+    @property
+    def operations_insights_config(self):
+        """
+        Gets the operations_insights_config of this ExternalPluggableDatabaseSummary.
+
+        :return: The operations_insights_config of this ExternalPluggableDatabaseSummary.
+        :rtype: oci.database.models.OperationsInsightsConfig
+        """
+        return self._operations_insights_config
+
+    @operations_insights_config.setter
+    def operations_insights_config(self, operations_insights_config):
+        """
+        Sets the operations_insights_config of this ExternalPluggableDatabaseSummary.
+
+        :param operations_insights_config: The operations_insights_config of this ExternalPluggableDatabaseSummary.
+        :type: oci.database.models.OperationsInsightsConfig
+        """
+        self._operations_insights_config = operations_insights_config
 
     @property
     def compartment_id(self):

--- a/src/oci/database/models/operations_insights_config.py
+++ b/src/oci/database/models/operations_insights_config.py
@@ -1,0 +1,139 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class OperationsInsightsConfig(object):
+    """
+    The configuration of Operations Insights for the external database
+    """
+
+    #: A constant which can be used with the operations_insights_status property of a OperationsInsightsConfig.
+    #: This constant has a value of "ENABLING"
+    OPERATIONS_INSIGHTS_STATUS_ENABLING = "ENABLING"
+
+    #: A constant which can be used with the operations_insights_status property of a OperationsInsightsConfig.
+    #: This constant has a value of "ENABLED"
+    OPERATIONS_INSIGHTS_STATUS_ENABLED = "ENABLED"
+
+    #: A constant which can be used with the operations_insights_status property of a OperationsInsightsConfig.
+    #: This constant has a value of "DISABLING"
+    OPERATIONS_INSIGHTS_STATUS_DISABLING = "DISABLING"
+
+    #: A constant which can be used with the operations_insights_status property of a OperationsInsightsConfig.
+    #: This constant has a value of "NOT_ENABLED"
+    OPERATIONS_INSIGHTS_STATUS_NOT_ENABLED = "NOT_ENABLED"
+
+    #: A constant which can be used with the operations_insights_status property of a OperationsInsightsConfig.
+    #: This constant has a value of "FAILED_ENABLING"
+    OPERATIONS_INSIGHTS_STATUS_FAILED_ENABLING = "FAILED_ENABLING"
+
+    #: A constant which can be used with the operations_insights_status property of a OperationsInsightsConfig.
+    #: This constant has a value of "FAILED_DISABLING"
+    OPERATIONS_INSIGHTS_STATUS_FAILED_DISABLING = "FAILED_DISABLING"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new OperationsInsightsConfig object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param operations_insights_status:
+            The value to assign to the operations_insights_status property of this OperationsInsightsConfig.
+            Allowed values for this property are: "ENABLING", "ENABLED", "DISABLING", "NOT_ENABLED", "FAILED_ENABLING", "FAILED_DISABLING", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type operations_insights_status: str
+
+        :param operations_insights_connector_id:
+            The value to assign to the operations_insights_connector_id property of this OperationsInsightsConfig.
+        :type operations_insights_connector_id: str
+
+        """
+        self.swagger_types = {
+            'operations_insights_status': 'str',
+            'operations_insights_connector_id': 'str'
+        }
+
+        self.attribute_map = {
+            'operations_insights_status': 'operationsInsightsStatus',
+            'operations_insights_connector_id': 'operationsInsightsConnectorId'
+        }
+
+        self._operations_insights_status = None
+        self._operations_insights_connector_id = None
+
+    @property
+    def operations_insights_status(self):
+        """
+        **[Required]** Gets the operations_insights_status of this OperationsInsightsConfig.
+        The status of Operations Insights
+
+        Allowed values for this property are: "ENABLING", "ENABLED", "DISABLING", "NOT_ENABLED", "FAILED_ENABLING", "FAILED_DISABLING", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The operations_insights_status of this OperationsInsightsConfig.
+        :rtype: str
+        """
+        return self._operations_insights_status
+
+    @operations_insights_status.setter
+    def operations_insights_status(self, operations_insights_status):
+        """
+        Sets the operations_insights_status of this OperationsInsightsConfig.
+        The status of Operations Insights
+
+
+        :param operations_insights_status: The operations_insights_status of this OperationsInsightsConfig.
+        :type: str
+        """
+        allowed_values = ["ENABLING", "ENABLED", "DISABLING", "NOT_ENABLED", "FAILED_ENABLING", "FAILED_DISABLING"]
+        if not value_allowed_none_or_none_sentinel(operations_insights_status, allowed_values):
+            operations_insights_status = 'UNKNOWN_ENUM_VALUE'
+        self._operations_insights_status = operations_insights_status
+
+    @property
+    def operations_insights_connector_id(self):
+        """
+        Gets the operations_insights_connector_id of this OperationsInsightsConfig.
+        The `OCID`__ of the
+        :func:`create_external_database_connector_details`.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The operations_insights_connector_id of this OperationsInsightsConfig.
+        :rtype: str
+        """
+        return self._operations_insights_connector_id
+
+    @operations_insights_connector_id.setter
+    def operations_insights_connector_id(self, operations_insights_connector_id):
+        """
+        Sets the operations_insights_connector_id of this OperationsInsightsConfig.
+        The `OCID`__ of the
+        :func:`create_external_database_connector_details`.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param operations_insights_connector_id: The operations_insights_connector_id of this OperationsInsightsConfig.
+        :type: str
+        """
+        self._operations_insights_connector_id = operations_insights_connector_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/update_autonomous_database_details.py
+++ b/src/oci/database/models/update_autonomous_database_details.py
@@ -169,6 +169,10 @@ class UpdateAutonomousDatabaseDetails(object):
             The value to assign to the nsg_ids property of this UpdateAutonomousDatabaseDetails.
         :type nsg_ids: list[str]
 
+        :param customer_contacts:
+            The value to assign to the customer_contacts property of this UpdateAutonomousDatabaseDetails.
+        :type customer_contacts: list[oci.database.models.CustomerContact]
+
         """
         self.swagger_types = {
             'cpu_core_count': 'int',
@@ -194,7 +198,8 @@ class UpdateAutonomousDatabaseDetails(object):
             'permission_level': 'str',
             'subnet_id': 'str',
             'private_endpoint_label': 'str',
-            'nsg_ids': 'list[str]'
+            'nsg_ids': 'list[str]',
+            'customer_contacts': 'list[CustomerContact]'
         }
 
         self.attribute_map = {
@@ -221,7 +226,8 @@ class UpdateAutonomousDatabaseDetails(object):
             'permission_level': 'permissionLevel',
             'subnet_id': 'subnetId',
             'private_endpoint_label': 'privateEndpointLabel',
-            'nsg_ids': 'nsgIds'
+            'nsg_ids': 'nsgIds',
+            'customer_contacts': 'customerContacts'
         }
 
         self._cpu_core_count = None
@@ -248,6 +254,7 @@ class UpdateAutonomousDatabaseDetails(object):
         self._subnet_id = None
         self._private_endpoint_label = None
         self._nsg_ids = None
+        self._customer_contacts = None
 
     @property
     def cpu_core_count(self):
@@ -1004,6 +1011,30 @@ class UpdateAutonomousDatabaseDetails(object):
         :type: list[str]
         """
         self._nsg_ids = nsg_ids
+
+    @property
+    def customer_contacts(self):
+        """
+        Gets the customer_contacts of this UpdateAutonomousDatabaseDetails.
+        Customer Contacts. Setting this to an empty list removes all customer contacts of an Oracle Autonomous Database.
+
+
+        :return: The customer_contacts of this UpdateAutonomousDatabaseDetails.
+        :rtype: list[oci.database.models.CustomerContact]
+        """
+        return self._customer_contacts
+
+    @customer_contacts.setter
+    def customer_contacts(self, customer_contacts):
+        """
+        Sets the customer_contacts of this UpdateAutonomousDatabaseDetails.
+        Customer Contacts. Setting this to an empty list removes all customer contacts of an Oracle Autonomous Database.
+
+
+        :param customer_contacts: The customer_contacts of this UpdateAutonomousDatabaseDetails.
+        :type: list[oci.database.models.CustomerContact]
+        """
+        self._customer_contacts = customer_contacts
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/version.py
+++ b/src/oci/version.py
@@ -2,4 +2,4 @@
 # Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
 # This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 
-__version__ = "2.36.0"
+__version__ = "2.37.0"

--- a/tests/autogentest/test_model.py
+++ b/tests/autogentest/test_model.py
@@ -1,0 +1,151 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+import oci
+import oci.util
+import datetime
+import pytest
+
+
+@pytest.fixture
+def new_instance():
+    def _new_instance(**kwargs):
+        instance = oci.core.models.Instance()
+        instance.availability_domain = 'some ad'
+        instance.compartment_id = 'some compartment'
+        instance.display_name = 'some name'
+        instance.id = 'some id'
+        instance.image_id = 'some image'
+        instance.metadata = {'foo': 'bar', 'foo2': 'bar2'}
+        instance.region = 'some region'
+        instance.shape = 'some shape'
+        instance.lifecycle_state = 'RUNNING'
+        instance.time_created = datetime.date(1999, 12, 31)
+        for name, value in kwargs.items():
+            setattr(instance, name, value)
+        return instance
+    return _new_instance
+
+
+@pytest.fixture
+def instance(new_instance):
+    return new_instance()
+
+
+def test_model_values(instance):
+    assert 'some ad' == instance.availability_domain
+    assert 'some compartment' == instance.compartment_id
+    assert 'some name' == instance.display_name
+    assert 'some id' == instance.id
+    assert 'some image' == instance.image_id
+    assert 'bar' == instance.metadata['foo']
+    assert 'some region' == instance.region
+    assert 'some shape' == instance.shape
+    assert 'RUNNING' == instance.lifecycle_state
+    assert datetime.date(1999, 12, 31) == instance.time_created
+
+
+def test_equal(new_instance):
+    assert new_instance() == new_instance()
+
+
+def test_not_equal(new_instance):
+    assert new_instance() != new_instance(shape="some other shape")
+
+
+def test_equal_none(instance):
+    # Explicit variable so we can use ==, != directly
+    none = None
+    assert instance != none
+    assert none != instance
+    assert not (instance == none)
+
+
+def test_to_string(instance):
+    string = str(instance)
+    assert 'some name' in string
+    assert 'foo2' in string
+    assert '1999' in string
+
+
+def test_to_dict(instance):
+    instance_dict = oci.util.to_dict(instance)
+
+    assert 'some ad' == instance_dict['availability_domain']
+    assert 'some compartment' == instance_dict['compartment_id']
+    assert 'some name' == instance_dict['display_name']
+    assert 'some id' == instance_dict['id']
+    assert 'some image' == instance_dict['image_id']
+    assert 'bar' == instance_dict['metadata']['foo']
+    assert 'some region' == instance_dict['region']
+    assert 'some shape' == instance_dict['shape']
+    assert 'RUNNING' == instance_dict['lifecycle_state']
+    assert "1999-12-31" == instance_dict['time_created']
+
+
+def test_subclass():
+    volume_attachment = oci.core.models.IScsiVolumeAttachment()
+    assert 'iscsi' == volume_attachment.attachment_type
+    assert hasattr(volume_attachment, 'chap_username')
+    assert hasattr(volume_attachment, 'availability_domain')
+    assert oci.core.models.VolumeAttachment.get_subtype(
+        {'attachmentType': volume_attachment.attachment_type}) == 'IScsiVolumeAttachment'
+
+    volume_attachment.chap_secret = 'foo'
+    volume_attachment.compartment_id = 'bar'
+
+    assert 'foo' == volume_attachment.chap_secret
+    assert 'bar' == volume_attachment.compartment_id
+
+    attachment_dict = oci.util.to_dict(volume_attachment)
+
+    assert 'foo' == attachment_dict['chap_secret']
+    assert 'bar' == attachment_dict['compartment_id']
+
+
+def test_subclass_for_unknown_subtype_defaults_to_base_type():
+    subtype = oci.core.models.VolumeAttachment.get_subtype({'attachmentType': 'new_subtype'})
+    assert 'VolumeAttachment' == subtype
+
+
+def test_value_allowed_none_or_none_sentinel_val_is_none():
+    assert oci.util.value_allowed_none_or_none_sentinel(None, ['hello', 'world'])
+
+
+def test_value_allowed_none_or_none_sentinel_val_is_none_sentinel():
+    assert oci.util.value_allowed_none_or_none_sentinel(oci.util.NONE_SENTINEL, ['hello', 'world'])
+
+
+def test_value_allowed_none_or_none_sentinel_val_is_allowed():
+    assert oci.util.value_allowed_none_or_none_sentinel('hello', ['hello', 'world'])
+
+
+def test_value_allowed_none_or_none_sentinel_val_is_not_allowed():
+    assert not oci.util.value_allowed_none_or_none_sentinel('bad value', ['hello', 'world'])
+
+
+def test_enum_none_value_ok(instance):
+    instance.lifecycle_state = None
+    assert instance.lifecycle_state is None
+
+
+def test_enum_none_sentinel_value_ok(instance):
+    instance.lifecycle_state = oci.util.NONE_SENTINEL
+    assert instance.lifecycle_state is oci.util.NONE_SENTINEL
+
+
+def test_enum_allowed_value_ok(instance):
+    instance.lifecycle_state = 'PROVISIONING'
+    assert instance.lifecycle_state == 'PROVISIONING'
+
+
+def test_enum_not_allowed_value_translates_to_unknown_value(instance):
+    instance.lifecycle_state = 'superman'
+    assert instance.lifecycle_state == 'UNKNOWN_ENUM_VALUE'
+
+
+def test_enum_not_allowed_value_throws_exception():
+    model = oci.object_storage.models.CreateBucketDetails()
+    with pytest.raises(ValueError):
+        model.public_access_type = 'superman'


### PR DESCRIPTION
## Added

* Support for opting in/out of live migration on instances in the Compute service

* Support for enabling/disabling Operations Insights on external non-container and external pluggable databases in the Database service

* Support for a GraphStudio URL as a connection URL on databases in the Database service

* Support for adding customer contacts on autonomous databases in the Database service

* Support for name annotations on harvested objects in the Data Catalog service



## Changed

* If retries are enabled, the SDK will now retry on status 409/IncorrectState. It will not retry on status 501.



## Breaking

* Bumped cryptography version to 3.3.2 to address security vulnerability https://github.com/oracle/oci-python-sdk/pull/322
