### PR TITLE
Releasing version 2.38.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 ====================
-2.37.0 - 2020-04-20
+2.38.0 - 2021-04-27
+====================
+
+Added
+-----
+* Support for RACs (real application clusters) for external container, non-container, and pluggable databases in the Database service
+* Support for data masking in the Cloud Guard service
+* Support for opting out of DNS records during instance launch, as well as attaching secondary VNICs, in the Compute service
+* Support for mutable sizes on cluster networks in the Autoscaling service
+* Support for auto-tiering on buckets in the Object Storage service
+
+Breaking
+--------
+* VCN id parameters were moved from being required to being optional on all list operations in the Networking service
+
+====================
+2.37.0 - 2021-04-20
 ====================
 
 Added
@@ -24,7 +40,7 @@ Breaking
 * Bumped cryptography version to 3.3.2 to address security vulnerability https://github.com/oracle/oci-python-sdk/pull/322
 
 ====================
-2.36.0 - 2020-04-13
+2.36.0 - 2021-04-13
 ====================
 
 Added
@@ -74,7 +90,7 @@ Breaking changes
 * Value of attribute `model_type` in model `ConnectionDetails` in Data Integration service defaults to UNKNOWN_ENUM_VALUE when it receives an invalid value. In the earlier versions, this raises a ValueError
 
 ====================
-2.35.1 - 2020-04-06
+2.35.1 - 2021-04-06
 ====================
 
 Added
@@ -93,7 +109,7 @@ Added
 * Support for calculating content length of a non-resettable stream for binary uploads. A non-resettable stream will be buffered into memory to calculate the content length. A buffer_limit may be passed into the request to provide a buffer limit. The default buffer limit is 100 MiB. More documentation can be found here: https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/index.html
 
 ====================
-2.35.0 - 2020-03-30
+2.35.0 - 2021-03-30
 ====================
 
 Added
@@ -135,7 +151,7 @@ Breaking
 * Value of Enum attribute `operator` in Usage API service defaults to `UNKNOWN_ENUM_VALUE` when it receives an invalid value. In the earlier versions, this raises a `ValueError`
 
 ====================
-2.33.0 - 2020-03-16
+2.33.0 - 2021-03-16
 ====================
 
 Added
@@ -150,7 +166,7 @@ Breaking
 * Retries are now enabled on all operations performing binary data upload, except upload manager. The SDK used to explicitly override retry configuration on binary upload operations because of potential data corruption issue (https://github.com/oracle/oci-python-sdk/issues/203).
 
 ====================
-2.32.1 - 2020-03-09
+2.32.1 - 2021-03-09
 ====================
 
 Added

--- a/docs/api/cloud_guard.rst
+++ b/docs/api/cloud_guard.rst
@@ -20,6 +20,7 @@ Cloud Guard
 
     oci.cloud_guard.models.ActivityProblemAggregation
     oci.cloud_guard.models.ActivityProblemAggregationCollection
+    oci.cloud_guard.models.AllTargetsSelected
     oci.cloud_guard.models.AttachTargetDetectorRecipeDetails
     oci.cloud_guard.models.AttachTargetResponderRecipeDetails
     oci.cloud_guard.models.CandidateResponderRule
@@ -35,12 +36,16 @@ Cloud Guard
     oci.cloud_guard.models.ConditionOperator
     oci.cloud_guard.models.ConfigValue
     oci.cloud_guard.models.Configuration
+    oci.cloud_guard.models.CreateDataMaskRuleDetails
     oci.cloud_guard.models.CreateDetectorRecipeDetails
     oci.cloud_guard.models.CreateManagedListDetails
     oci.cloud_guard.models.CreateResponderRecipeDetails
     oci.cloud_guard.models.CreateTargetDetails
     oci.cloud_guard.models.CreateTargetDetectorRecipeDetails
     oci.cloud_guard.models.CreateTargetResponderRecipeDetails
+    oci.cloud_guard.models.DataMaskRule
+    oci.cloud_guard.models.DataMaskRuleCollection
+    oci.cloud_guard.models.DataMaskRuleSummary
     oci.cloud_guard.models.Detector
     oci.cloud_guard.models.DetectorCollection
     oci.cloud_guard.models.DetectorConfiguration
@@ -65,6 +70,8 @@ Cloud Guard
     oci.cloud_guard.models.ManagedListTypeCollection
     oci.cloud_guard.models.ManagedListTypeSummary
     oci.cloud_guard.models.OperatorSummary
+    oci.cloud_guard.models.PolicyCollection
+    oci.cloud_guard.models.PolicySummary
     oci.cloud_guard.models.PoliticalLocation
     oci.cloud_guard.models.Problem
     oci.cloud_guard.models.ProblemAggregation
@@ -119,16 +126,20 @@ Cloud Guard
     oci.cloud_guard.models.TargetDetectorRecipeDetectorRuleCollection
     oci.cloud_guard.models.TargetDetectorRecipeDetectorRuleSummary
     oci.cloud_guard.models.TargetDetectorRecipeSummary
+    oci.cloud_guard.models.TargetIdsSelected
+    oci.cloud_guard.models.TargetResourceTypesSelected
     oci.cloud_guard.models.TargetResponderRecipe
     oci.cloud_guard.models.TargetResponderRecipeCollection
     oci.cloud_guard.models.TargetResponderRecipeResponderRule
     oci.cloud_guard.models.TargetResponderRecipeResponderRuleCollection
     oci.cloud_guard.models.TargetResponderRecipeResponderRuleSummary
     oci.cloud_guard.models.TargetResponderRecipeSummary
+    oci.cloud_guard.models.TargetSelected
     oci.cloud_guard.models.TargetSummary
     oci.cloud_guard.models.TriggerResponderDetails
     oci.cloud_guard.models.UpdateBulkProblemStatusDetails
     oci.cloud_guard.models.UpdateConfigurationDetails
+    oci.cloud_guard.models.UpdateDataMaskRuleDetails
     oci.cloud_guard.models.UpdateDetectorRecipeDetails
     oci.cloud_guard.models.UpdateDetectorRecipeDetectorRule
     oci.cloud_guard.models.UpdateDetectorRecipeDetectorRuleDetails

--- a/docs/api/cloud_guard/models/oci.cloud_guard.models.AllTargetsSelected.rst
+++ b/docs/api/cloud_guard/models/oci.cloud_guard.models.AllTargetsSelected.rst
@@ -1,0 +1,11 @@
+AllTargetsSelected
+==================
+
+.. currentmodule:: oci.cloud_guard.models
+
+.. autoclass:: AllTargetsSelected
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/cloud_guard/models/oci.cloud_guard.models.CreateDataMaskRuleDetails.rst
+++ b/docs/api/cloud_guard/models/oci.cloud_guard.models.CreateDataMaskRuleDetails.rst
@@ -1,0 +1,11 @@
+CreateDataMaskRuleDetails
+=========================
+
+.. currentmodule:: oci.cloud_guard.models
+
+.. autoclass:: CreateDataMaskRuleDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/cloud_guard/models/oci.cloud_guard.models.DataMaskRule.rst
+++ b/docs/api/cloud_guard/models/oci.cloud_guard.models.DataMaskRule.rst
@@ -1,0 +1,11 @@
+DataMaskRule
+============
+
+.. currentmodule:: oci.cloud_guard.models
+
+.. autoclass:: DataMaskRule
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/cloud_guard/models/oci.cloud_guard.models.DataMaskRuleCollection.rst
+++ b/docs/api/cloud_guard/models/oci.cloud_guard.models.DataMaskRuleCollection.rst
@@ -1,0 +1,11 @@
+DataMaskRuleCollection
+======================
+
+.. currentmodule:: oci.cloud_guard.models
+
+.. autoclass:: DataMaskRuleCollection
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/cloud_guard/models/oci.cloud_guard.models.DataMaskRuleSummary.rst
+++ b/docs/api/cloud_guard/models/oci.cloud_guard.models.DataMaskRuleSummary.rst
@@ -1,0 +1,11 @@
+DataMaskRuleSummary
+===================
+
+.. currentmodule:: oci.cloud_guard.models
+
+.. autoclass:: DataMaskRuleSummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/cloud_guard/models/oci.cloud_guard.models.PolicyCollection.rst
+++ b/docs/api/cloud_guard/models/oci.cloud_guard.models.PolicyCollection.rst
@@ -1,0 +1,11 @@
+PolicyCollection
+================
+
+.. currentmodule:: oci.cloud_guard.models
+
+.. autoclass:: PolicyCollection
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/cloud_guard/models/oci.cloud_guard.models.PolicySummary.rst
+++ b/docs/api/cloud_guard/models/oci.cloud_guard.models.PolicySummary.rst
@@ -1,0 +1,11 @@
+PolicySummary
+=============
+
+.. currentmodule:: oci.cloud_guard.models
+
+.. autoclass:: PolicySummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/cloud_guard/models/oci.cloud_guard.models.TargetIdsSelected.rst
+++ b/docs/api/cloud_guard/models/oci.cloud_guard.models.TargetIdsSelected.rst
@@ -1,0 +1,11 @@
+TargetIdsSelected
+=================
+
+.. currentmodule:: oci.cloud_guard.models
+
+.. autoclass:: TargetIdsSelected
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/cloud_guard/models/oci.cloud_guard.models.TargetResourceTypesSelected.rst
+++ b/docs/api/cloud_guard/models/oci.cloud_guard.models.TargetResourceTypesSelected.rst
@@ -1,0 +1,11 @@
+TargetResourceTypesSelected
+===========================
+
+.. currentmodule:: oci.cloud_guard.models
+
+.. autoclass:: TargetResourceTypesSelected
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/cloud_guard/models/oci.cloud_guard.models.TargetSelected.rst
+++ b/docs/api/cloud_guard/models/oci.cloud_guard.models.TargetSelected.rst
@@ -1,0 +1,11 @@
+TargetSelected
+==============
+
+.. currentmodule:: oci.cloud_guard.models
+
+.. autoclass:: TargetSelected
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/cloud_guard/models/oci.cloud_guard.models.UpdateDataMaskRuleDetails.rst
+++ b/docs/api/cloud_guard/models/oci.cloud_guard.models.UpdateDataMaskRuleDetails.rst
@@ -1,0 +1,11 @@
+UpdateDataMaskRuleDetails
+=========================
+
+.. currentmodule:: oci.cloud_guard.models
+
+.. autoclass:: UpdateDataMaskRuleDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/core.rst
+++ b/docs/api/core.rst
@@ -365,6 +365,7 @@ Core Services
     oci.core.models.UpdateBootVolumeKmsKeyDetails
     oci.core.models.UpdateByoipRangeDetails
     oci.core.models.UpdateClusterNetworkDetails
+    oci.core.models.UpdateClusterNetworkInstancePoolDetails
     oci.core.models.UpdateComputeCapacityReservationDetails
     oci.core.models.UpdateComputeImageCapabilitySchemaDetails
     oci.core.models.UpdateConsoleHistoryDetails

--- a/docs/api/core/models/oci.core.models.UpdateClusterNetworkInstancePoolDetails.rst
+++ b/docs/api/core/models/oci.core.models.UpdateClusterNetworkInstancePoolDetails.rst
@@ -1,0 +1,11 @@
+UpdateClusterNetworkInstancePoolDetails
+=======================================
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: UpdateClusterNetworkInstancePoolDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/examples/usage_reports_to_adw/CHANGELOG.rst
+++ b/examples/usage_reports_to_adw/CHANGELOG.rst
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 
 =====================
+21.04.27 - 2021-04-27
+=====================
+* Added gather stats crontab weekly with script run_gather_stats.sh
+* Fixed bug calling reference update
+
+=====================
 21.04.04 - 2021-04-04
 =====================
 * Added option to specify one Tag Key to extract the data to TAG_SPECIAL column , use -ts

--- a/examples/usage_reports_to_adw/setup/setup.crontab.txt
+++ b/examples/usage_reports_to_adw/setup/setup.crontab.txt
@@ -1,5 +1,10 @@
 ###############################################################################
-# Crontab to run every 6 hours
+# Crontab to run every 3 hours
 ###############################################################################
-0 */6 * * * timeout 6h /home/opc/usage_reports_to_adw/shell_scripts/run_single_daily_usage2adw.sh > /home/opc/usage_reports_to_adw/run_single_daily_usage2adw_crontab_run.txt 2>&1
+0 */3 * * * timeout 6h /home/opc/usage_reports_to_adw/shell_scripts/run_single_daily_usage2adw.sh > /home/opc/usage_reports_to_adw/run_single_daily_usage2adw_crontab_run.txt 2>&1
+
+###############################################################################
+# Gather stats every weekend
+###############################################################################
+30 0   * * 0 timeout 6h /home/opc/usage_reports_to_adw/shell_scripts/run_gather_stats.sh > /home/opc/usage_reports_to_adw/run_gather_stats_run.txt 2>&1
 

--- a/examples/usage_reports_to_adw/setup/setup_credentials.sh
+++ b/examples/usage_reports_to_adw/setup/setup_credentials.sh
@@ -7,7 +7,7 @@
 # Written by Adi Zohar, October 2020
 # Git Location = https://github.com/oracle/oci-python-sdk/tree/master/examples/usage_reports_to_adw
 #
-# Version 2021-04-04
+# Version 2021-04-27
 #
 #########################################################################################################################
 
@@ -29,7 +29,7 @@ echo "########################################################################" 
 printf "Please Enter Database Name     : "; read DATABASE_NAME
 printf "Please Enter ADB Admin Password: "; read DATABASE_ADMIN
 printf "Please Enter ADB Application Password (Min 12 Chars, One Upper, One Lower, One Digits): "; read DATABASE_PASS
-printf "Please Enter Extract Start Date (Format YYYY-MM i.e. 2020-10): "; read EXTRACT_DATE
+printf "Please Enter Extract Start Date (Format YYYY-MM i.e. 2021-04): "; read EXTRACT_DATE
 printf "Please Enter Tag Key to extract as Special Tag (Oracle-Tags.CreatedBy): "; read TAG_SPECIAL
 
 if [ -z "$TAG_SPECIAL" ]; then

--- a/examples/usage_reports_to_adw/setup/setup_upgrade_usage2adw.sh
+++ b/examples/usage_reports_to_adw/setup/setup_upgrade_usage2adw.sh
@@ -78,12 +78,18 @@ else
    printf "   Please Enter Database Name     : "; read DATABASE_NAME
    printf "   Please Enter ADB Admin Password: "; read DATABASE_ADMIN
    printf "   Please Enter ADB App  Password : "; read DATABASE_PASS
+   printf "   Please Enter Tag Key to extract as Special Tag (Oracle-Tags.CreatedBy): "; read TAG_SPECIAL
+
+   if [ -z "$TAG_SPECIAL" ]; then
+       TAG_SPECIAL="Oracle-Tags.CreatedBy"
+   fi
 
    echo "DATABASE_USER=USAGE" > $CREDFILE   
    echo "DATABASE_NAME=${DATABASE_NAME}_low" >> $CREDFILE
    echo "DATABASE_PASS=${DATABASE_PASS}" >> $CREDFILE 
    echo "DATABASE_ADMIN=${DATABASE_ADMIN}" >> $CREDFILE
-   echo "EXTRACT_DATE=2020-08" >> $CREDFILE
+   echo "EXTRACT_DATE=2021-04" >> $CREDFILE
+   echo "TAG_SPECIAL=${TAG_SPECIAL}" >> $CREDFILE
    echo "File Created." | tee -a $LOG
 fi
 
@@ -163,7 +169,6 @@ echo "##################################################" | tee -a $LOG
 echo "# Upgrade Completed at `date`" | tee -a $LOG
 echo "##################################################" | tee -a $LOG
 echo "Please run the application to upgrade schema:" | tee -a $LOG
-echo "cd $APPDIR" | tee -a $LOG
-echo "python3 usage2adw.py -ip -du USAGE -dp ${db_app_password} -dn ${db_db_name}" | tee -a $LOG
+echo "/home/opc/usage_reports_to_adw/shell_scripts/run_single_daily_usage2adw.sh" | tee -a $LOG
 echo ""
 

--- a/examples/usage_reports_to_adw/setup/setup_usage2adw.sh
+++ b/examples/usage_reports_to_adw/setup/setup_usage2adw.sh
@@ -153,7 +153,7 @@ fi
 # Setup Crontab
 ###########################################
 echo "" | tee -a $LOG
-echo "7. Setup Crontab to run every 6 hours" | tee -a $LOG
+echo "7. Setup Crontab to run every 3 hours and gather stats every week" | tee -a $LOG
 echo "Executed: crontab $APPDIR/setup/setup.crontab.txt" | tee -a $LOG
 crontab $APPDIR/setup/setup.crontab.txt
 

--- a/examples/usage_reports_to_adw/shell_scripts/run_daily_report.sh
+++ b/examples/usage_reports_to_adw/shell_scripts/run_daily_report.sh
@@ -11,12 +11,12 @@
 #############################################################################################################################
 # Env Variables based on yum instant client
 export CLIENT_HOME=/usr/lib/oracle/current/client64
-export LD_LIBRARY_PATH=$CLIENT_HOME/lib
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$CLIENT_HOME/lib
 export PATH=$PATH:$CLIENT_HOME/bin
 
 # App dir
 export TNS_ADMIN=$HOME/ADWCUSG
-export APPDIR=$HOME/oci-python-sdk/examples/usage_reports_to_adw
+export APPDIR=$HOME/usage_reports_to_adw
 export CREDFILE=$APPDIR/config.user
 cd $APPDIR
 
@@ -63,16 +63,16 @@ prompt     <tr><td colspan=16 class=tabheader>Cost Usage Daily Report - $DATE_PR
 select
     '<tr>'||
         '<th width=150 nowrap class=th1>Tenant Name</th>'||
-        '<th width=80  nowrap class=th1>'||to_char(trunc(sysdate-10),'DD-MON-YYYY')||'</th>'||
-        '<th width=80  nowrap class=th1>'||to_char(trunc(sysdate-9),'DD-MON-YYYY')||'</th>'||
-        '<th width=80  nowrap class=th1>'||to_char(trunc(sysdate-8),'DD-MON-YYYY')||'</th>'||
-        '<th width=80  nowrap class=th1>'||to_char(trunc(sysdate-7),'DD-MON-YYYY')||'</th>'||
-        '<th width=80  nowrap class=th1>'||to_char(trunc(sysdate-6),'DD-MON-YYYY')||'</th>'||
-        '<th width=80  nowrap class=th1>'||to_char(trunc(sysdate-5),'DD-MON-YYYY')||'</th>'||
-        '<th width=80  nowrap class=th1>'||to_char(trunc(sysdate-4),'DD-MON-YYYY')||'</th>'||
-        '<th width=80  nowrap class=th1>'||to_char(trunc(sysdate-3),'DD-MON-YYYY')||'</th>'||
-        '<th width=80  nowrap class=th1>'||to_char(trunc(sysdate-2),'DD-MON-YYYY')||'</th>'||
-        '<th width=80  nowrap class=th1>'||to_char(trunc(sysdate-1),'DD-MON-YYYY')||'</th>'||
+        '<th width=80  nowrap class=th1>'||to_char(trunc(sysdate-10),'DD-MON-YYYY DY')||'</th>'||
+        '<th width=80  nowrap class=th1>'||to_char(trunc(sysdate-9),'DD-MON-YYYY DY')||'</th>'||
+        '<th width=80  nowrap class=th1>'||to_char(trunc(sysdate-8),'DD-MON-YYYY DY')||'</th>'||
+        '<th width=80  nowrap class=th1>'||to_char(trunc(sysdate-7),'DD-MON-YYYY DY')||'</th>'||
+        '<th width=80  nowrap class=th1>'||to_char(trunc(sysdate-6),'DD-MON-YYYY DY')||'</th>'||
+        '<th width=80  nowrap class=th1>'||to_char(trunc(sysdate-5),'DD-MON-YYYY DY')||'</th>'||
+        '<th width=80  nowrap class=th1>'||to_char(trunc(sysdate-4),'DD-MON-YYYY DY')||'</th>'||
+        '<th width=80  nowrap class=th1>'||to_char(trunc(sysdate-3),'DD-MON-YYYY DY')||'</th>'||
+        '<th width=80  nowrap class=th1>'||to_char(trunc(sysdate-2),'DD-MON-YYYY DY')||'</th>'||
+        '<th width=80  nowrap class=th1>'||to_char(trunc(sysdate-1),'DD-MON-YYYY DY')||'</th>'||
         '<th width=80  nowrap class=th1>Month 31 Prediction</th>'||
         '<th width=80  nowrap class=th1>Year Prediction</th>'||
         '<th width=80  nowrap class=th1>Sub Tenants</th>'||
@@ -290,4 +290,5 @@ Subject: $MAIL_SUBJECT
 Content-Type: text/html
 `cat $OUTPUT_FILE`
 eomail
+
 

--- a/examples/usage_reports_to_adw/shell_scripts/run_gather_stats.sh
+++ b/examples/usage_reports_to_adw/shell_scripts/run_gather_stats.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+#############################################################################################################################
+# Author - Adi Zohar, Jul 7th 2020
+#
+# run_gather_stats for crontab use weekly run
+#
+# Amend variables below and database connectivity
+#
+# Crontab set:
+# 30 0 * * 0 timeout 6h /home/opc/usage_reports_to_adw/shell_scripts/run_gather_stats.sh > /home/opc/usage_reports_to_adw/run_gather_stats_run.txt 2>&1
+#############################################################################################################################
+# Env Variables based on yum instant client
+export CLIENT_HOME=/usr/lib/oracle/current/client64
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$CLIENT_HOME/lib:$CLIENT_HOME
+export PATH=$PATH:$CLIENT_HOME/bin:$CLIENT_HOME
+
+# App dir
+export TNS_ADMIN=$HOME/ADWCUSG
+export APPDIR=$HOME/usage_reports_to_adw
+export CREDFILE=$APPDIR/config.user
+cd $APPDIR
+
+# Mail Info
+export DATE_PRINT="`date '+%d-%b-%Y'`"
+
+# database info
+export DATABASE_USER=`grep "^DATABASE_USER" $CREDFILE | awk -F= '{ print $2 }'`
+export DATABASE_PASS=`grep "^DATABASE_PASS" $CREDFILE | awk -F= '{ print $2 }'`
+export DATABASE_NAME=`grep "^DATABASE_NAME" $CREDFILE | awk -F= '{ print $2 }'`
+
+# Fixed variables
+export DATE=`date '+%Y%m%d_%H%M'`
+export REPORT_DIR=${APPDIR}/report/daily
+export OUTPUT_FILE=${REPORT_DIR}/gather_stats_${DATE}.txt
+mkdir -p ${REPORT_DIR}
+
+##################################
+# run stats
+##################################
+echo "Running Gather Stats, Log = $OUTPUT_FILE"
+echo "
+set pages 0 head off feed off lines 799 trimsp on echo off verify off
+set define @
+exec dbms_stats.gather_schema_stats(ownname=>'USAGE',DEGREE=>8,estimate_percent=>10,block_sample=>TRUE,stattype=>'DATA',force=>TRUE, method_opt=>'FOR ALL COLUMNS SIZE 1',cascade=>TRUE);
+" | sqlplus -s ${DATABASE_USER}/${DATABASE_PASS}@${DATABASE_NAME} | tee -a $OUTPUT_FILE
+
+# Check for errors
+if (( `grep ORA- $OUTPUT_FILE | wc -l` > 0 ))
+then
+    echo ""
+    echo "!!! Error running gather stats, check logfile $OUTPUT_FILE"
+    echo ""
+    grep ORA- $OUTPUT_FILE
+    exit 1
+fi
+

--- a/examples/usage_reports_to_adw/shell_scripts/run_single_daily_usage2adw.sh
+++ b/examples/usage_reports_to_adw/shell_scripts/run_single_daily_usage2adw.sh
@@ -13,8 +13,8 @@
 
 # Env Variables based on yum instant client
 export CLIENT_HOME=/usr/lib/oracle/current/client64
-export LD_LIBRARY_PATH=$CLIENT_HOME/lib
-export PATH=$PATH:$CLIENT_HOME/bin
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$CLIENT_HOME/lib:$CLIENT_HOME
+export PATH=$PATH:$CLIENT_HOME/bin:$CLIENT_HOME
 
 # App dir
 export TNS_ADMIN=$HOME/ADWCUSG

--- a/examples/usage_reports_to_adw/usage2adw.py
+++ b/examples/usage_reports_to_adw/usage2adw.py
@@ -70,7 +70,7 @@ import requests
 import time
 
 
-version = "21.04.04"
+version = "21.04.27"
 usage_report_namespace = "bling"
 work_report_dir = os.curdir + "/work_report_dir"
 
@@ -265,7 +265,8 @@ def check_database_table_structure_usage(connection):
             sql += "    USG_CONSUMED_UNITS      VARCHAR2(100),"
             sql += "    USG_CONSUMED_MEASURE    VARCHAR2(100),"
             sql += "    IS_CORRECTION           VARCHAR2(10),"
-            sql += "    TAGS_DATA               VARCHAR2(4000)"
+            sql += "    TAGS_DATA               VARCHAR2(4000),"
+            sql += "    TAG_SPECIAL             VARCHAR2(4000)"
             sql += ") COMPRESS"
             cursor.execute(sql)
             print("   Table OCI_USAGE created")
@@ -780,7 +781,7 @@ def update_tenant_id_if_null(connection, tenant_name, short_tenant_id):
 ##########################################################################
 # Check Table Structure Cost
 ##########################################################################
-def check_database_table_structure_cost(connection):
+def check_database_table_structure_cost(connection, tag_special_key, tenant_name):
     try:
         # open cursor
         cursor = connection.cursor()
@@ -820,7 +821,8 @@ def check_database_table_structure_cost(connection):
             sql += "    COST_BILLING_UNIT       VARCHAR2(1000),"
             sql += "    COST_OVERAGE_FLAG       VARCHAR2(10),"
             sql += "    IS_CORRECTION           VARCHAR2(10),"
-            sql += "    TAGS_DATA               VARCHAR2(4000)"
+            sql += "    TAGS_DATA               VARCHAR2(4000),"
+            sql += "    TAG_SPECIAL             VARCHAR2(4000)"
             sql += ") COMPRESS"
             cursor.execute(sql)
             print("   Table OCI_COST created")
@@ -921,7 +923,7 @@ def check_database_table_structure_cost(connection):
             cursor.execute(sql)
             print("   Table OCI_COST_REFERENCE created")
 
-            update_cost_reference(connection)
+            update_cost_reference(connection, tag_special_key, tenant_name)
         else:
             print("   Table OCI_COST_REFERENCE exist")
 
@@ -1556,7 +1558,7 @@ def main_process():
         # Check tables structure
         print("\nChecking Database Structure...")
         check_database_table_structure_usage(connection)
-        check_database_table_structure_cost(connection)
+        check_database_table_structure_cost(connection, cmd.tagspecial, tenancy.name)
         check_database_table_structure_price_list(connection, tenancy.name)
 
         ###############################

--- a/src/oci/cloud_guard/cloud_guard_client.py
+++ b/src/oci/cloud_guard/cloud_guard_client.py
@@ -379,6 +379,82 @@ class CloudGuardClient(object):
                 header_params=header_params,
                 body=change_responder_recipe_compartment_details)
 
+    def create_data_mask_rule(self, create_data_mask_rule_details, **kwargs):
+        """
+        Creates a new Data Mask Rule Definition
+
+
+        :param oci.cloud_guard.models.CreateDataMaskRuleDetails create_data_mask_rule_details: (required)
+            Definition for the new Data Mask Rule.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            might be rejected.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.cloud_guard.models.DataMaskRule`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/cloudguard/create_data_mask_rule.py.html>`__ to see an example of how to use create_data_mask_rule API.
+        """
+        resource_path = "/dataMaskRules"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "create_data_mask_rule got unknown kwargs: {!r}".format(extra_kwargs))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_data_mask_rule_details,
+                response_type="DataMaskRule")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                header_params=header_params,
+                body=create_data_mask_rule_details,
+                response_type="DataMaskRule")
+
     def create_detector_recipe(self, create_detector_recipe_details, **kwargs):
         """
         Creates a DetectorRecipe
@@ -864,6 +940,88 @@ class CloudGuardClient(object):
                 header_params=header_params,
                 body=attach_target_responder_recipe_details,
                 response_type="TargetResponderRecipe")
+
+    def delete_data_mask_rule(self, data_mask_rule_id, **kwargs):
+        """
+        Deletes a DataMaskRule identified by dataMaskRuleId
+
+
+        :param str data_mask_rule_id: (required)
+            OCID of dataMaskRule
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call
+            for a resource, set the `if-match` parameter to the value of the
+            etag from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the etag you
+            provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/cloudguard/delete_data_mask_rule.py.html>`__ to see an example of how to use delete_data_mask_rule API.
+        """
+        resource_path = "/dataMaskRules/{dataMaskRuleId}"
+        method = "DELETE"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "delete_data_mask_rule got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "dataMaskRuleId": data_mask_rule_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params)
 
     def delete_detector_recipe(self, detector_recipe_id, **kwargs):
         """
@@ -1658,6 +1816,81 @@ class CloudGuardClient(object):
                 query_params=query_params,
                 header_params=header_params,
                 response_type="Configuration")
+
+    def get_data_mask_rule(self, data_mask_rule_id, **kwargs):
+        """
+        Returns a DataMaskRule identified by DataMaskRuleId
+
+
+        :param str data_mask_rule_id: (required)
+            OCID of dataMaskRule
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.cloud_guard.models.DataMaskRule`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/cloudguard/get_data_mask_rule.py.html>`__ to see an example of how to use get_data_mask_rule API.
+        """
+        resource_path = "/dataMaskRules/{dataMaskRuleId}"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "get_data_mask_rule got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "dataMaskRuleId": data_mask_rule_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="DataMaskRule")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                response_type="DataMaskRule")
 
     def get_detector(self, detector_id, **kwargs):
         """
@@ -2942,6 +3175,180 @@ class CloudGuardClient(object):
                 header_params=header_params,
                 response_type="ConditionMetadataTypeCollection")
 
+    def list_data_mask_rules(self, compartment_id, **kwargs):
+        """
+        Returns a list of all Data Mask Rules in the root 'compartmentId' passed.
+
+
+        :param str compartment_id: (required)
+            The ID of the compartment in which to list resources.
+
+        :param str display_name: (optional)
+            A filter to return only resources that match the entire display name given.
+
+        :param str lifecycle_state: (optional)
+            The field life cycle state. Only one state can be provided. Default value for state is active. If no value is specified state is active.
+
+            Allowed values are: "CREATING", "UPDATING", "ACTIVE", "INACTIVE", "DELETING", "DELETED", "FAILED"
+
+        :param str access_level: (optional)
+            Valid values are `RESTRICTED` and `ACCESSIBLE`. Default is `RESTRICTED`.
+            Setting this to `ACCESSIBLE` returns only those compartments for which the
+            user has INSPECT permissions directly or indirectly (permissions can be on a
+            resource in a subcompartment).
+            When set to `RESTRICTED` permissions are checked and no partial results are displayed.
+
+            Allowed values are: "RESTRICTED", "ACCESSIBLE"
+
+        :param int limit: (optional)
+            The maximum number of items to return.
+
+        :param str page: (optional)
+            The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+
+        :param str sort_order: (optional)
+            The sort order to use, either 'asc' or 'desc'.
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str sort_by: (optional)
+            The field to sort by. Only one sort order may be provided. Default order for timeCreated is descending. Default order for displayName is ascending. If no value is specified timeCreated is default.
+
+            Allowed values are: "timeCreated", "displayName"
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param str data_mask_rule_status: (optional)
+            The status of the dataMaskRule.
+
+            Allowed values are: "ENABLED", "DISABLED"
+
+        :param str target_id: (optional)
+            OCID of target
+
+        :param str iam_group_id: (optional)
+            OCID of iamGroup
+
+        :param str target_type: (optional)
+            Type of target
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.cloud_guard.models.DataMaskRuleCollection`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/cloudguard/list_data_mask_rules.py.html>`__ to see an example of how to use list_data_mask_rules API.
+        """
+        resource_path = "/dataMaskRules"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "display_name",
+            "lifecycle_state",
+            "access_level",
+            "limit",
+            "page",
+            "sort_order",
+            "sort_by",
+            "opc_request_id",
+            "data_mask_rule_status",
+            "target_id",
+            "iam_group_id",
+            "target_type"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_data_mask_rules got unknown kwargs: {!r}".format(extra_kwargs))
+
+        if 'lifecycle_state' in kwargs:
+            lifecycle_state_allowed_values = ["CREATING", "UPDATING", "ACTIVE", "INACTIVE", "DELETING", "DELETED", "FAILED"]
+            if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
+                raise ValueError(
+                    "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
+                )
+
+        if 'access_level' in kwargs:
+            access_level_allowed_values = ["RESTRICTED", "ACCESSIBLE"]
+            if kwargs['access_level'] not in access_level_allowed_values:
+                raise ValueError(
+                    "Invalid value for `access_level`, must be one of {0}".format(access_level_allowed_values)
+                )
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["timeCreated", "displayName"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        if 'data_mask_rule_status' in kwargs:
+            data_mask_rule_status_allowed_values = ["ENABLED", "DISABLED"]
+            if kwargs['data_mask_rule_status'] not in data_mask_rule_status_allowed_values:
+                raise ValueError(
+                    "Invalid value for `data_mask_rule_status`, must be one of {0}".format(data_mask_rule_status_allowed_values)
+                )
+
+        query_params = {
+            "displayName": kwargs.get("display_name", missing),
+            "compartmentId": compartment_id,
+            "lifecycleState": kwargs.get("lifecycle_state", missing),
+            "accessLevel": kwargs.get("access_level", missing),
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "sortBy": kwargs.get("sort_by", missing),
+            "dataMaskRuleStatus": kwargs.get("data_mask_rule_status", missing),
+            "targetId": kwargs.get("target_id", missing),
+            "iamGroupId": kwargs.get("iam_group_id", missing),
+            "targetType": kwargs.get("target_type", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="DataMaskRuleCollection")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="DataMaskRuleCollection")
+
     def list_detector_recipe_detector_rules(self, detector_recipe_id, compartment_id, **kwargs):
         """
         Returns a list of DetectorRule associated with DetectorRecipe.
@@ -3112,7 +3519,7 @@ class CloudGuardClient(object):
         :param bool resource_metadata_only: (optional)
             Default is false.
             When set to true, the list of all Oracle Managed Resources
-            Metadata supported by Cloud Guard is returned.
+            Metadata supported by Cloud Guard are returned.
 
         :param str lifecycle_state: (optional)
             The field life cycle state. Only one state can be provided. Default value for state is active. If no value is specified state is active.
@@ -3790,7 +4197,7 @@ class CloudGuardClient(object):
         :param bool resource_metadata_only: (optional)
             Default is false.
             When set to true, the list of all Oracle Managed Resources
-            Metadata supported by Cloud Guard is returned.
+            Metadata supported by Cloud Guard are returned.
 
         :param str lifecycle_state: (optional)
             The field life cycle state. Only one state can be provided. Default value for state is active. If no value is specified state is active.
@@ -3800,7 +4207,7 @@ class CloudGuardClient(object):
         :param str list_type: (optional)
             The type of the ManagedList.
 
-            Allowed values are: "CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS"
+            Allowed values are: "CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS", "GENERIC"
 
         :param int limit: (optional)
             The maximum number of items to return.
@@ -3881,7 +4288,7 @@ class CloudGuardClient(object):
                 )
 
         if 'list_type' in kwargs:
-            list_type_allowed_values = ["CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS"]
+            list_type_allowed_values = ["CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS", "GENERIC"]
             if kwargs['list_type'] not in list_type_allowed_values:
                 raise ValueError(
                     "Invalid value for `list_type`, must be one of {0}".format(list_type_allowed_values)
@@ -3949,6 +4356,114 @@ class CloudGuardClient(object):
                 query_params=query_params,
                 header_params=header_params,
                 response_type="ManagedListCollection")
+
+    def list_policies(self, compartment_id, **kwargs):
+        """
+        Returns the list of global policy statements needed by Cloud Guard when enabling
+
+
+        :param str compartment_id: (required)
+            The ID of the compartment in which to list resources.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param int limit: (optional)
+            The maximum number of items to return.
+
+        :param str page: (optional)
+            The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+
+        :param str sort_order: (optional)
+            The sort order to use, either 'asc' or 'desc'.
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str sort_by: (optional)
+            The field to sort by. Only one sort order may be provided. Default order for timeCreated is descending. Default order for displayName is ascending. If no value is specified timeCreated is default.
+
+            Allowed values are: "timeCreated", "displayName"
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.cloud_guard.models.PolicyCollection`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/cloudguard/list_policies.py.html>`__ to see an example of how to use list_policies API.
+        """
+        resource_path = "/policies"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_request_id",
+            "limit",
+            "page",
+            "sort_order",
+            "sort_by"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_policies got unknown kwargs: {!r}".format(extra_kwargs))
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["timeCreated", "displayName"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        query_params = {
+            "compartmentId": compartment_id,
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "sortBy": kwargs.get("sort_by", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="PolicyCollection")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="PolicyCollection")
 
     def list_problem_histories(self, compartment_id, problem_id, **kwargs):
         """
@@ -4096,16 +4611,16 @@ class CloudGuardClient(object):
             The ID of the compartment in which to list resources.
 
         :param datetime time_last_detected_greater_than_or_equal_to: (optional)
-            Start time for a filter. If start time is not specified, start time will be set to today's current time - 30 days.
+            Start time for a filter. If start time is not specified, start time will be set to current time - 30 days.
 
         :param datetime time_last_detected_less_than_or_equal_to: (optional)
-            End time for a filter. If end time is not specified, end time will be set to today's current time.
+            End time for a filter. If end time is not specified, end time will be set to current time.
 
         :param datetime time_first_detected_greater_than_or_equal_to: (optional)
-            Start time for a filter. If start time is not specified, start time will be set to today's current time - 30 days.
+            Start time for a filter. If start time is not specified, start time will be set to current time - 30 days.
 
         :param datetime time_first_detected_less_than_or_equal_to: (optional)
-            End time for a filter. If end time is not specified, end time will be set to today's current time.
+            End time for a filter. If end time is not specified, end time will be set to current time.
 
         :param str lifecycle_detail: (optional)
             The field life cycle state. Only one state can be provided. Default value for state is active. If no value is specified state is active.
@@ -5118,7 +5633,7 @@ class CloudGuardClient(object):
         :param bool resource_metadata_only: (optional)
             Default is false.
             When set to true, the list of all Oracle Managed Resources
-            Metadata supported by Cloud Guard is returned.
+            Metadata supported by Cloud Guard are returned.
 
         :param str display_name: (optional)
             A filter to return only resources that match the entire display name given.
@@ -6986,10 +7501,10 @@ class CloudGuardClient(object):
             The ID of the compartment in which to list resources.
 
         :param datetime time_first_detected_greater_than_or_equal_to: (optional)
-            Start time for a filter. If start time is not specified, start time will be set to today's current time - 30 days.
+            Start time for a filter. If start time is not specified, start time will be set to current time - 30 days.
 
         :param datetime time_first_detected_less_than_or_equal_to: (optional)
-            End time for a filter. If end time is not specified, end time will be set to today's current time.
+            End time for a filter. If end time is not specified, end time will be set to current time.
 
         :param bool compartment_id_in_subtree: (optional)
             Default is false.
@@ -7733,6 +8248,95 @@ class CloudGuardClient(object):
                 header_params=header_params,
                 body=update_configuration_details,
                 response_type="Configuration")
+
+    def update_data_mask_rule(self, data_mask_rule_id, update_data_mask_rule_details, **kwargs):
+        """
+        Updates a DataMaskRule identified by dataMaskRuleId
+
+
+        :param str data_mask_rule_id: (required)
+            OCID of dataMaskRule
+
+        :param oci.cloud_guard.models.UpdateDataMaskRuleDetails update_data_mask_rule_details: (required)
+            The information to be updated.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call
+            for a resource, set the `if-match` parameter to the value of the
+            etag from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the etag you
+            provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.cloud_guard.models.DataMaskRule`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/cloudguard/update_data_mask_rule.py.html>`__ to see an example of how to use update_data_mask_rule API.
+        """
+        resource_path = "/dataMaskRules/{dataMaskRuleId}"
+        method = "PUT"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "update_data_mask_rule got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "dataMaskRuleId": data_mask_rule_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_data_mask_rule_details,
+                response_type="DataMaskRule")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=update_data_mask_rule_details,
+                response_type="DataMaskRule")
 
     def update_detector_recipe(self, detector_recipe_id, update_detector_recipe_details, **kwargs):
         """

--- a/src/oci/cloud_guard/cloud_guard_client_composite_operations.py
+++ b/src/oci/cloud_guard/cloud_guard_client_composite_operations.py
@@ -23,6 +23,44 @@ class CloudGuardClientCompositeOperations(object):
         """
         self.client = client
 
+    def create_data_mask_rule_and_wait_for_state(self, create_data_mask_rule_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.cloud_guard.CloudGuardClient.create_data_mask_rule` and waits for the :py:class:`~oci.cloud_guard.models.DataMaskRule` acted upon
+        to enter the given state(s).
+
+        :param oci.cloud_guard.models.CreateDataMaskRuleDetails create_data_mask_rule_details: (required)
+            Definition for the new Data Mask Rule.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.cloud_guard.models.DataMaskRule.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.cloud_guard.CloudGuardClient.create_data_mask_rule`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.create_data_mask_rule(create_data_mask_rule_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_data_mask_rule(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def create_detector_recipe_and_wait_for_state(self, create_detector_recipe_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.cloud_guard.CloudGuardClient.create_detector_recipe` and waits for the :py:class:`~oci.cloud_guard.models.DetectorRecipe` acted upon
@@ -216,6 +254,53 @@ class CloudGuardClientCompositeOperations(object):
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
+    def delete_data_mask_rule_and_wait_for_state(self, data_mask_rule_id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.cloud_guard.CloudGuardClient.delete_data_mask_rule` and waits for the :py:class:`~oci.cloud_guard.models.DataMaskRule` acted upon
+        to enter the given state(s).
+
+        :param str data_mask_rule_id: (required)
+            OCID of dataMaskRule
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.cloud_guard.models.DataMaskRule.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.cloud_guard.CloudGuardClient.delete_data_mask_rule`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        initial_get_result = self.client.get_data_mask_rule(data_mask_rule_id)
+        operation_result = None
+        try:
+            operation_result = self.client.delete_data_mask_rule(data_mask_rule_id, **operation_kwargs)
+        except oci.exceptions.ServiceError as e:
+            if e.status == 404:
+                return WAIT_RESOURCE_NOT_FOUND
+            else:
+                raise e
+
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                initial_get_result,
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                succeed_on_not_found=True,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def delete_detector_recipe_and_wait_for_state(self, detector_recipe_id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.cloud_guard.CloudGuardClient.delete_detector_recipe` and waits for the :py:class:`~oci.cloud_guard.models.DetectorRecipe` acted upon
@@ -396,6 +481,47 @@ class CloudGuardClientCompositeOperations(object):
                 initial_get_result,
                 evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
                 succeed_on_not_found=True,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def update_data_mask_rule_and_wait_for_state(self, data_mask_rule_id, update_data_mask_rule_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.cloud_guard.CloudGuardClient.update_data_mask_rule` and waits for the :py:class:`~oci.cloud_guard.models.DataMaskRule` acted upon
+        to enter the given state(s).
+
+        :param str data_mask_rule_id: (required)
+            OCID of dataMaskRule
+
+        :param oci.cloud_guard.models.UpdateDataMaskRuleDetails update_data_mask_rule_details: (required)
+            The information to be updated.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.cloud_guard.models.DataMaskRule.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.cloud_guard.CloudGuardClient.update_data_mask_rule`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.update_data_mask_rule(data_mask_rule_id, update_data_mask_rule_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_data_mask_rule(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
                 **waiter_kwargs
             )
             result_to_return = waiter_result

--- a/src/oci/cloud_guard/models/__init__.py
+++ b/src/oci/cloud_guard/models/__init__.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import
 
 from .activity_problem_aggregation import ActivityProblemAggregation
 from .activity_problem_aggregation_collection import ActivityProblemAggregationCollection
+from .all_targets_selected import AllTargetsSelected
 from .attach_target_detector_recipe_details import AttachTargetDetectorRecipeDetails
 from .attach_target_responder_recipe_details import AttachTargetResponderRecipeDetails
 from .candidate_responder_rule import CandidateResponderRule
@@ -21,12 +22,16 @@ from .condition_metadata_type_summary import ConditionMetadataTypeSummary
 from .condition_operator import ConditionOperator
 from .config_value import ConfigValue
 from .configuration import Configuration
+from .create_data_mask_rule_details import CreateDataMaskRuleDetails
 from .create_detector_recipe_details import CreateDetectorRecipeDetails
 from .create_managed_list_details import CreateManagedListDetails
 from .create_responder_recipe_details import CreateResponderRecipeDetails
 from .create_target_details import CreateTargetDetails
 from .create_target_detector_recipe_details import CreateTargetDetectorRecipeDetails
 from .create_target_responder_recipe_details import CreateTargetResponderRecipeDetails
+from .data_mask_rule import DataMaskRule
+from .data_mask_rule_collection import DataMaskRuleCollection
+from .data_mask_rule_summary import DataMaskRuleSummary
 from .detector import Detector
 from .detector_collection import DetectorCollection
 from .detector_configuration import DetectorConfiguration
@@ -51,6 +56,8 @@ from .managed_list_summary import ManagedListSummary
 from .managed_list_type_collection import ManagedListTypeCollection
 from .managed_list_type_summary import ManagedListTypeSummary
 from .operator_summary import OperatorSummary
+from .policy_collection import PolicyCollection
+from .policy_summary import PolicySummary
 from .political_location import PoliticalLocation
 from .problem import Problem
 from .problem_aggregation import ProblemAggregation
@@ -105,16 +112,20 @@ from .target_detector_recipe_detector_rule import TargetDetectorRecipeDetectorRu
 from .target_detector_recipe_detector_rule_collection import TargetDetectorRecipeDetectorRuleCollection
 from .target_detector_recipe_detector_rule_summary import TargetDetectorRecipeDetectorRuleSummary
 from .target_detector_recipe_summary import TargetDetectorRecipeSummary
+from .target_ids_selected import TargetIdsSelected
+from .target_resource_types_selected import TargetResourceTypesSelected
 from .target_responder_recipe import TargetResponderRecipe
 from .target_responder_recipe_collection import TargetResponderRecipeCollection
 from .target_responder_recipe_responder_rule import TargetResponderRecipeResponderRule
 from .target_responder_recipe_responder_rule_collection import TargetResponderRecipeResponderRuleCollection
 from .target_responder_recipe_responder_rule_summary import TargetResponderRecipeResponderRuleSummary
 from .target_responder_recipe_summary import TargetResponderRecipeSummary
+from .target_selected import TargetSelected
 from .target_summary import TargetSummary
 from .trigger_responder_details import TriggerResponderDetails
 from .update_bulk_problem_status_details import UpdateBulkProblemStatusDetails
 from .update_configuration_details import UpdateConfigurationDetails
+from .update_data_mask_rule_details import UpdateDataMaskRuleDetails
 from .update_detector_recipe_details import UpdateDetectorRecipeDetails
 from .update_detector_recipe_detector_rule import UpdateDetectorRecipeDetectorRule
 from .update_detector_recipe_detector_rule_details import UpdateDetectorRecipeDetectorRuleDetails
@@ -141,6 +152,7 @@ from .update_target_responder_rule_details import UpdateTargetResponderRuleDetai
 cloud_guard_type_mapping = {
     "ActivityProblemAggregation": ActivityProblemAggregation,
     "ActivityProblemAggregationCollection": ActivityProblemAggregationCollection,
+    "AllTargetsSelected": AllTargetsSelected,
     "AttachTargetDetectorRecipeDetails": AttachTargetDetectorRecipeDetails,
     "AttachTargetResponderRecipeDetails": AttachTargetResponderRecipeDetails,
     "CandidateResponderRule": CandidateResponderRule,
@@ -156,12 +168,16 @@ cloud_guard_type_mapping = {
     "ConditionOperator": ConditionOperator,
     "ConfigValue": ConfigValue,
     "Configuration": Configuration,
+    "CreateDataMaskRuleDetails": CreateDataMaskRuleDetails,
     "CreateDetectorRecipeDetails": CreateDetectorRecipeDetails,
     "CreateManagedListDetails": CreateManagedListDetails,
     "CreateResponderRecipeDetails": CreateResponderRecipeDetails,
     "CreateTargetDetails": CreateTargetDetails,
     "CreateTargetDetectorRecipeDetails": CreateTargetDetectorRecipeDetails,
     "CreateTargetResponderRecipeDetails": CreateTargetResponderRecipeDetails,
+    "DataMaskRule": DataMaskRule,
+    "DataMaskRuleCollection": DataMaskRuleCollection,
+    "DataMaskRuleSummary": DataMaskRuleSummary,
     "Detector": Detector,
     "DetectorCollection": DetectorCollection,
     "DetectorConfiguration": DetectorConfiguration,
@@ -186,6 +202,8 @@ cloud_guard_type_mapping = {
     "ManagedListTypeCollection": ManagedListTypeCollection,
     "ManagedListTypeSummary": ManagedListTypeSummary,
     "OperatorSummary": OperatorSummary,
+    "PolicyCollection": PolicyCollection,
+    "PolicySummary": PolicySummary,
     "PoliticalLocation": PoliticalLocation,
     "Problem": Problem,
     "ProblemAggregation": ProblemAggregation,
@@ -240,16 +258,20 @@ cloud_guard_type_mapping = {
     "TargetDetectorRecipeDetectorRuleCollection": TargetDetectorRecipeDetectorRuleCollection,
     "TargetDetectorRecipeDetectorRuleSummary": TargetDetectorRecipeDetectorRuleSummary,
     "TargetDetectorRecipeSummary": TargetDetectorRecipeSummary,
+    "TargetIdsSelected": TargetIdsSelected,
+    "TargetResourceTypesSelected": TargetResourceTypesSelected,
     "TargetResponderRecipe": TargetResponderRecipe,
     "TargetResponderRecipeCollection": TargetResponderRecipeCollection,
     "TargetResponderRecipeResponderRule": TargetResponderRecipeResponderRule,
     "TargetResponderRecipeResponderRuleCollection": TargetResponderRecipeResponderRuleCollection,
     "TargetResponderRecipeResponderRuleSummary": TargetResponderRecipeResponderRuleSummary,
     "TargetResponderRecipeSummary": TargetResponderRecipeSummary,
+    "TargetSelected": TargetSelected,
     "TargetSummary": TargetSummary,
     "TriggerResponderDetails": TriggerResponderDetails,
     "UpdateBulkProblemStatusDetails": UpdateBulkProblemStatusDetails,
     "UpdateConfigurationDetails": UpdateConfigurationDetails,
+    "UpdateDataMaskRuleDetails": UpdateDataMaskRuleDetails,
     "UpdateDetectorRecipeDetails": UpdateDetectorRecipeDetails,
     "UpdateDetectorRecipeDetectorRule": UpdateDetectorRecipeDetectorRule,
     "UpdateDetectorRecipeDetectorRuleDetails": UpdateDetectorRecipeDetectorRuleDetails,

--- a/src/oci/cloud_guard/models/all_targets_selected.py
+++ b/src/oci/cloud_guard/models/all_targets_selected.py
@@ -1,0 +1,49 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .target_selected import TargetSelected
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class AllTargetsSelected(TargetSelected):
+    """
+    All Targets selected.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new AllTargetsSelected object with values from keyword arguments. The default value of the :py:attr:`~oci.cloud_guard.models.AllTargetsSelected.kind` attribute
+        of this class is ``ALL`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param kind:
+            The value to assign to the kind property of this AllTargetsSelected.
+            Allowed values for this property are: "ALL", "TARGETTYPES", "TARGETIDS"
+        :type kind: str
+
+        """
+        self.swagger_types = {
+            'kind': 'str'
+        }
+
+        self.attribute_map = {
+            'kind': 'kind'
+        }
+
+        self._kind = None
+        self._kind = 'ALL'
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/cloud_guard/models/create_data_mask_rule_details.py
+++ b/src/oci/cloud_guard/models/create_data_mask_rule_details.py
@@ -1,0 +1,439 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CreateDataMaskRuleDetails(object):
+    """
+    The information about new Data Mask Rule.
+    """
+
+    #: A constant which can be used with the data_mask_categories property of a CreateDataMaskRuleDetails.
+    #: This constant has a value of "ACTOR"
+    DATA_MASK_CATEGORIES_ACTOR = "ACTOR"
+
+    #: A constant which can be used with the data_mask_categories property of a CreateDataMaskRuleDetails.
+    #: This constant has a value of "PII"
+    DATA_MASK_CATEGORIES_PII = "PII"
+
+    #: A constant which can be used with the data_mask_categories property of a CreateDataMaskRuleDetails.
+    #: This constant has a value of "PHI"
+    DATA_MASK_CATEGORIES_PHI = "PHI"
+
+    #: A constant which can be used with the data_mask_categories property of a CreateDataMaskRuleDetails.
+    #: This constant has a value of "FINANCIAL"
+    DATA_MASK_CATEGORIES_FINANCIAL = "FINANCIAL"
+
+    #: A constant which can be used with the data_mask_categories property of a CreateDataMaskRuleDetails.
+    #: This constant has a value of "LOCATION"
+    DATA_MASK_CATEGORIES_LOCATION = "LOCATION"
+
+    #: A constant which can be used with the data_mask_categories property of a CreateDataMaskRuleDetails.
+    #: This constant has a value of "CUSTOM"
+    DATA_MASK_CATEGORIES_CUSTOM = "CUSTOM"
+
+    #: A constant which can be used with the data_mask_rule_status property of a CreateDataMaskRuleDetails.
+    #: This constant has a value of "ENABLED"
+    DATA_MASK_RULE_STATUS_ENABLED = "ENABLED"
+
+    #: A constant which can be used with the data_mask_rule_status property of a CreateDataMaskRuleDetails.
+    #: This constant has a value of "DISABLED"
+    DATA_MASK_RULE_STATUS_DISABLED = "DISABLED"
+
+    #: A constant which can be used with the lifecycle_state property of a CreateDataMaskRuleDetails.
+    #: This constant has a value of "CREATING"
+    LIFECYCLE_STATE_CREATING = "CREATING"
+
+    #: A constant which can be used with the lifecycle_state property of a CreateDataMaskRuleDetails.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a CreateDataMaskRuleDetails.
+    #: This constant has a value of "ACTIVE"
+    LIFECYCLE_STATE_ACTIVE = "ACTIVE"
+
+    #: A constant which can be used with the lifecycle_state property of a CreateDataMaskRuleDetails.
+    #: This constant has a value of "INACTIVE"
+    LIFECYCLE_STATE_INACTIVE = "INACTIVE"
+
+    #: A constant which can be used with the lifecycle_state property of a CreateDataMaskRuleDetails.
+    #: This constant has a value of "DELETING"
+    LIFECYCLE_STATE_DELETING = "DELETING"
+
+    #: A constant which can be used with the lifecycle_state property of a CreateDataMaskRuleDetails.
+    #: This constant has a value of "DELETED"
+    LIFECYCLE_STATE_DELETED = "DELETED"
+
+    #: A constant which can be used with the lifecycle_state property of a CreateDataMaskRuleDetails.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CreateDataMaskRuleDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this CreateDataMaskRuleDetails.
+        :type display_name: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this CreateDataMaskRuleDetails.
+        :type compartment_id: str
+
+        :param description:
+            The value to assign to the description property of this CreateDataMaskRuleDetails.
+        :type description: str
+
+        :param iam_group_id:
+            The value to assign to the iam_group_id property of this CreateDataMaskRuleDetails.
+        :type iam_group_id: str
+
+        :param target_selected:
+            The value to assign to the target_selected property of this CreateDataMaskRuleDetails.
+        :type target_selected: oci.cloud_guard.models.TargetSelected
+
+        :param data_mask_categories:
+            The value to assign to the data_mask_categories property of this CreateDataMaskRuleDetails.
+            Allowed values for items in this list are: "ACTOR", "PII", "PHI", "FINANCIAL", "LOCATION", "CUSTOM"
+        :type data_mask_categories: list[str]
+
+        :param data_mask_rule_status:
+            The value to assign to the data_mask_rule_status property of this CreateDataMaskRuleDetails.
+            Allowed values for this property are: "ENABLED", "DISABLED"
+        :type data_mask_rule_status: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this CreateDataMaskRuleDetails.
+            Allowed values for this property are: "CREATING", "UPDATING", "ACTIVE", "INACTIVE", "DELETING", "DELETED", "FAILED"
+        :type lifecycle_state: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this CreateDataMaskRuleDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this CreateDataMaskRuleDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'compartment_id': 'str',
+            'description': 'str',
+            'iam_group_id': 'str',
+            'target_selected': 'TargetSelected',
+            'data_mask_categories': 'list[str]',
+            'data_mask_rule_status': 'str',
+            'lifecycle_state': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'compartment_id': 'compartmentId',
+            'description': 'description',
+            'iam_group_id': 'iamGroupId',
+            'target_selected': 'targetSelected',
+            'data_mask_categories': 'dataMaskCategories',
+            'data_mask_rule_status': 'dataMaskRuleStatus',
+            'lifecycle_state': 'lifecycleState',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._display_name = None
+        self._compartment_id = None
+        self._description = None
+        self._iam_group_id = None
+        self._target_selected = None
+        self._data_mask_categories = None
+        self._data_mask_rule_status = None
+        self._lifecycle_state = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def display_name(self):
+        """
+        **[Required]** Gets the display_name of this CreateDataMaskRuleDetails.
+        Data Mask Rule name
+
+
+        :return: The display_name of this CreateDataMaskRuleDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this CreateDataMaskRuleDetails.
+        Data Mask Rule name
+
+
+        :param display_name: The display_name of this CreateDataMaskRuleDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this CreateDataMaskRuleDetails.
+        Compartment Identifier where the resource is created
+
+
+        :return: The compartment_id of this CreateDataMaskRuleDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this CreateDataMaskRuleDetails.
+        Compartment Identifier where the resource is created
+
+
+        :param compartment_id: The compartment_id of this CreateDataMaskRuleDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def description(self):
+        """
+        Gets the description of this CreateDataMaskRuleDetails.
+        The Data Mask Rule description.
+
+
+        :return: The description of this CreateDataMaskRuleDetails.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this CreateDataMaskRuleDetails.
+        The Data Mask Rule description.
+
+
+        :param description: The description of this CreateDataMaskRuleDetails.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def iam_group_id(self):
+        """
+        **[Required]** Gets the iam_group_id of this CreateDataMaskRuleDetails.
+        IAM Group id associated with the data mask rule
+
+
+        :return: The iam_group_id of this CreateDataMaskRuleDetails.
+        :rtype: str
+        """
+        return self._iam_group_id
+
+    @iam_group_id.setter
+    def iam_group_id(self, iam_group_id):
+        """
+        Sets the iam_group_id of this CreateDataMaskRuleDetails.
+        IAM Group id associated with the data mask rule
+
+
+        :param iam_group_id: The iam_group_id of this CreateDataMaskRuleDetails.
+        :type: str
+        """
+        self._iam_group_id = iam_group_id
+
+    @property
+    def target_selected(self):
+        """
+        **[Required]** Gets the target_selected of this CreateDataMaskRuleDetails.
+
+        :return: The target_selected of this CreateDataMaskRuleDetails.
+        :rtype: oci.cloud_guard.models.TargetSelected
+        """
+        return self._target_selected
+
+    @target_selected.setter
+    def target_selected(self, target_selected):
+        """
+        Sets the target_selected of this CreateDataMaskRuleDetails.
+
+        :param target_selected: The target_selected of this CreateDataMaskRuleDetails.
+        :type: oci.cloud_guard.models.TargetSelected
+        """
+        self._target_selected = target_selected
+
+    @property
+    def data_mask_categories(self):
+        """
+        **[Required]** Gets the data_mask_categories of this CreateDataMaskRuleDetails.
+        Data Mask Categories
+
+        Allowed values for items in this list are: "ACTOR", "PII", "PHI", "FINANCIAL", "LOCATION", "CUSTOM"
+
+
+        :return: The data_mask_categories of this CreateDataMaskRuleDetails.
+        :rtype: list[str]
+        """
+        return self._data_mask_categories
+
+    @data_mask_categories.setter
+    def data_mask_categories(self, data_mask_categories):
+        """
+        Sets the data_mask_categories of this CreateDataMaskRuleDetails.
+        Data Mask Categories
+
+
+        :param data_mask_categories: The data_mask_categories of this CreateDataMaskRuleDetails.
+        :type: list[str]
+        """
+        allowed_values = ["ACTOR", "PII", "PHI", "FINANCIAL", "LOCATION", "CUSTOM"]
+
+        if data_mask_categories and data_mask_categories is not NONE_SENTINEL:
+            for value in data_mask_categories:
+                if not value_allowed_none_or_none_sentinel(value, allowed_values):
+                    raise ValueError(
+                        "Invalid value for `data_mask_categories`, must be None or one of {0}"
+                        .format(allowed_values)
+                    )
+        self._data_mask_categories = data_mask_categories
+
+    @property
+    def data_mask_rule_status(self):
+        """
+        Gets the data_mask_rule_status of this CreateDataMaskRuleDetails.
+        The status of the dataMaskRule.
+
+        Allowed values for this property are: "ENABLED", "DISABLED"
+
+
+        :return: The data_mask_rule_status of this CreateDataMaskRuleDetails.
+        :rtype: str
+        """
+        return self._data_mask_rule_status
+
+    @data_mask_rule_status.setter
+    def data_mask_rule_status(self, data_mask_rule_status):
+        """
+        Sets the data_mask_rule_status of this CreateDataMaskRuleDetails.
+        The status of the dataMaskRule.
+
+
+        :param data_mask_rule_status: The data_mask_rule_status of this CreateDataMaskRuleDetails.
+        :type: str
+        """
+        allowed_values = ["ENABLED", "DISABLED"]
+        if not value_allowed_none_or_none_sentinel(data_mask_rule_status, allowed_values):
+            raise ValueError(
+                "Invalid value for `data_mask_rule_status`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._data_mask_rule_status = data_mask_rule_status
+
+    @property
+    def lifecycle_state(self):
+        """
+        Gets the lifecycle_state of this CreateDataMaskRuleDetails.
+        The current state of the DataMaskRule.
+
+        Allowed values for this property are: "CREATING", "UPDATING", "ACTIVE", "INACTIVE", "DELETING", "DELETED", "FAILED"
+
+
+        :return: The lifecycle_state of this CreateDataMaskRuleDetails.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this CreateDataMaskRuleDetails.
+        The current state of the DataMaskRule.
+
+
+        :param lifecycle_state: The lifecycle_state of this CreateDataMaskRuleDetails.
+        :type: str
+        """
+        allowed_values = ["CREATING", "UPDATING", "ACTIVE", "INACTIVE", "DELETING", "DELETED", "FAILED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            raise ValueError(
+                "Invalid value for `lifecycle_state`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this CreateDataMaskRuleDetails.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :return: The freeform_tags of this CreateDataMaskRuleDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this CreateDataMaskRuleDetails.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :param freeform_tags: The freeform_tags of this CreateDataMaskRuleDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this CreateDataMaskRuleDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :return: The defined_tags of this CreateDataMaskRuleDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this CreateDataMaskRuleDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :param defined_tags: The defined_tags of this CreateDataMaskRuleDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/cloud_guard/models/create_managed_list_details.py
+++ b/src/oci/cloud_guard/models/create_managed_list_details.py
@@ -57,6 +57,10 @@ class CreateManagedListDetails(object):
     #: This constant has a value of "TAGS"
     LIST_TYPE_TAGS = "TAGS"
 
+    #: A constant which can be used with the list_type property of a CreateManagedListDetails.
+    #: This constant has a value of "GENERIC"
+    LIST_TYPE_GENERIC = "GENERIC"
+
     def __init__(self, **kwargs):
         """
         Initializes a new CreateManagedListDetails object with values from keyword arguments.
@@ -80,7 +84,7 @@ class CreateManagedListDetails(object):
 
         :param list_type:
             The value to assign to the list_type property of this CreateManagedListDetails.
-            Allowed values for this property are: "CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS"
+            Allowed values for this property are: "CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS", "GENERIC"
         :type list_type: str
 
         :param list_items:
@@ -229,7 +233,7 @@ class CreateManagedListDetails(object):
         Gets the list_type of this CreateManagedListDetails.
         type of the list
 
-        Allowed values for this property are: "CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS"
+        Allowed values for this property are: "CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS", "GENERIC"
 
 
         :return: The list_type of this CreateManagedListDetails.
@@ -247,7 +251,7 @@ class CreateManagedListDetails(object):
         :param list_type: The list_type of this CreateManagedListDetails.
         :type: str
         """
-        allowed_values = ["CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS"]
+        allowed_values = ["CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS", "GENERIC"]
         if not value_allowed_none_or_none_sentinel(list_type, allowed_values):
             raise ValueError(
                 "Invalid value for `list_type`, must be None or one of {0}"

--- a/src/oci/cloud_guard/models/data_mask_rule.py
+++ b/src/oci/cloud_guard/models/data_mask_rule.py
@@ -1,0 +1,600 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class DataMaskRule(object):
+    """
+    Description of DataMaskRule.
+    """
+
+    #: A constant which can be used with the data_mask_categories property of a DataMaskRule.
+    #: This constant has a value of "ACTOR"
+    DATA_MASK_CATEGORIES_ACTOR = "ACTOR"
+
+    #: A constant which can be used with the data_mask_categories property of a DataMaskRule.
+    #: This constant has a value of "PII"
+    DATA_MASK_CATEGORIES_PII = "PII"
+
+    #: A constant which can be used with the data_mask_categories property of a DataMaskRule.
+    #: This constant has a value of "PHI"
+    DATA_MASK_CATEGORIES_PHI = "PHI"
+
+    #: A constant which can be used with the data_mask_categories property of a DataMaskRule.
+    #: This constant has a value of "FINANCIAL"
+    DATA_MASK_CATEGORIES_FINANCIAL = "FINANCIAL"
+
+    #: A constant which can be used with the data_mask_categories property of a DataMaskRule.
+    #: This constant has a value of "LOCATION"
+    DATA_MASK_CATEGORIES_LOCATION = "LOCATION"
+
+    #: A constant which can be used with the data_mask_categories property of a DataMaskRule.
+    #: This constant has a value of "CUSTOM"
+    DATA_MASK_CATEGORIES_CUSTOM = "CUSTOM"
+
+    #: A constant which can be used with the data_mask_rule_status property of a DataMaskRule.
+    #: This constant has a value of "ENABLED"
+    DATA_MASK_RULE_STATUS_ENABLED = "ENABLED"
+
+    #: A constant which can be used with the data_mask_rule_status property of a DataMaskRule.
+    #: This constant has a value of "DISABLED"
+    DATA_MASK_RULE_STATUS_DISABLED = "DISABLED"
+
+    #: A constant which can be used with the lifecycle_state property of a DataMaskRule.
+    #: This constant has a value of "CREATING"
+    LIFECYCLE_STATE_CREATING = "CREATING"
+
+    #: A constant which can be used with the lifecycle_state property of a DataMaskRule.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a DataMaskRule.
+    #: This constant has a value of "ACTIVE"
+    LIFECYCLE_STATE_ACTIVE = "ACTIVE"
+
+    #: A constant which can be used with the lifecycle_state property of a DataMaskRule.
+    #: This constant has a value of "INACTIVE"
+    LIFECYCLE_STATE_INACTIVE = "INACTIVE"
+
+    #: A constant which can be used with the lifecycle_state property of a DataMaskRule.
+    #: This constant has a value of "DELETING"
+    LIFECYCLE_STATE_DELETING = "DELETING"
+
+    #: A constant which can be used with the lifecycle_state property of a DataMaskRule.
+    #: This constant has a value of "DELETED"
+    LIFECYCLE_STATE_DELETED = "DELETED"
+
+    #: A constant which can be used with the lifecycle_state property of a DataMaskRule.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new DataMaskRule object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this DataMaskRule.
+        :type id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this DataMaskRule.
+        :type display_name: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this DataMaskRule.
+        :type compartment_id: str
+
+        :param description:
+            The value to assign to the description property of this DataMaskRule.
+        :type description: str
+
+        :param iam_group_id:
+            The value to assign to the iam_group_id property of this DataMaskRule.
+        :type iam_group_id: str
+
+        :param target_selected:
+            The value to assign to the target_selected property of this DataMaskRule.
+        :type target_selected: oci.cloud_guard.models.TargetSelected
+
+        :param data_mask_categories:
+            The value to assign to the data_mask_categories property of this DataMaskRule.
+            Allowed values for items in this list are: "ACTOR", "PII", "PHI", "FINANCIAL", "LOCATION", "CUSTOM", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type data_mask_categories: list[str]
+
+        :param time_created:
+            The value to assign to the time_created property of this DataMaskRule.
+        :type time_created: datetime
+
+        :param time_updated:
+            The value to assign to the time_updated property of this DataMaskRule.
+        :type time_updated: datetime
+
+        :param data_mask_rule_status:
+            The value to assign to the data_mask_rule_status property of this DataMaskRule.
+            Allowed values for this property are: "ENABLED", "DISABLED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type data_mask_rule_status: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this DataMaskRule.
+            Allowed values for this property are: "CREATING", "UPDATING", "ACTIVE", "INACTIVE", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param lifecyle_details:
+            The value to assign to the lifecyle_details property of this DataMaskRule.
+        :type lifecyle_details: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this DataMaskRule.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this DataMaskRule.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param system_tags:
+            The value to assign to the system_tags property of this DataMaskRule.
+        :type system_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'display_name': 'str',
+            'compartment_id': 'str',
+            'description': 'str',
+            'iam_group_id': 'str',
+            'target_selected': 'TargetSelected',
+            'data_mask_categories': 'list[str]',
+            'time_created': 'datetime',
+            'time_updated': 'datetime',
+            'data_mask_rule_status': 'str',
+            'lifecycle_state': 'str',
+            'lifecyle_details': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'system_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'display_name': 'displayName',
+            'compartment_id': 'compartmentId',
+            'description': 'description',
+            'iam_group_id': 'iamGroupId',
+            'target_selected': 'targetSelected',
+            'data_mask_categories': 'dataMaskCategories',
+            'time_created': 'timeCreated',
+            'time_updated': 'timeUpdated',
+            'data_mask_rule_status': 'dataMaskRuleStatus',
+            'lifecycle_state': 'lifecycleState',
+            'lifecyle_details': 'lifecyleDetails',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags',
+            'system_tags': 'systemTags'
+        }
+
+        self._id = None
+        self._display_name = None
+        self._compartment_id = None
+        self._description = None
+        self._iam_group_id = None
+        self._target_selected = None
+        self._data_mask_categories = None
+        self._time_created = None
+        self._time_updated = None
+        self._data_mask_rule_status = None
+        self._lifecycle_state = None
+        self._lifecyle_details = None
+        self._freeform_tags = None
+        self._defined_tags = None
+        self._system_tags = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this DataMaskRule.
+        Unique identifier that is immutable on creation
+
+
+        :return: The id of this DataMaskRule.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this DataMaskRule.
+        Unique identifier that is immutable on creation
+
+
+        :param id: The id of this DataMaskRule.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this DataMaskRule.
+        Data Mask Rule Identifier, can be renamed
+
+
+        :return: The display_name of this DataMaskRule.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this DataMaskRule.
+        Data Mask Rule Identifier, can be renamed
+
+
+        :param display_name: The display_name of this DataMaskRule.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this DataMaskRule.
+        Compartment Identifier where the resource is created
+
+
+        :return: The compartment_id of this DataMaskRule.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this DataMaskRule.
+        Compartment Identifier where the resource is created
+
+
+        :param compartment_id: The compartment_id of this DataMaskRule.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def description(self):
+        """
+        Gets the description of this DataMaskRule.
+        The data mask rule description.
+
+
+        :return: The description of this DataMaskRule.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this DataMaskRule.
+        The data mask rule description.
+
+
+        :param description: The description of this DataMaskRule.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def iam_group_id(self):
+        """
+        **[Required]** Gets the iam_group_id of this DataMaskRule.
+        IAM Group id associated with the data mask rule
+
+
+        :return: The iam_group_id of this DataMaskRule.
+        :rtype: str
+        """
+        return self._iam_group_id
+
+    @iam_group_id.setter
+    def iam_group_id(self, iam_group_id):
+        """
+        Sets the iam_group_id of this DataMaskRule.
+        IAM Group id associated with the data mask rule
+
+
+        :param iam_group_id: The iam_group_id of this DataMaskRule.
+        :type: str
+        """
+        self._iam_group_id = iam_group_id
+
+    @property
+    def target_selected(self):
+        """
+        **[Required]** Gets the target_selected of this DataMaskRule.
+
+        :return: The target_selected of this DataMaskRule.
+        :rtype: oci.cloud_guard.models.TargetSelected
+        """
+        return self._target_selected
+
+    @target_selected.setter
+    def target_selected(self, target_selected):
+        """
+        Sets the target_selected of this DataMaskRule.
+
+        :param target_selected: The target_selected of this DataMaskRule.
+        :type: oci.cloud_guard.models.TargetSelected
+        """
+        self._target_selected = target_selected
+
+    @property
+    def data_mask_categories(self):
+        """
+        Gets the data_mask_categories of this DataMaskRule.
+        Data Mask Categories
+
+        Allowed values for items in this list are: "ACTOR", "PII", "PHI", "FINANCIAL", "LOCATION", "CUSTOM", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The data_mask_categories of this DataMaskRule.
+        :rtype: list[str]
+        """
+        return self._data_mask_categories
+
+    @data_mask_categories.setter
+    def data_mask_categories(self, data_mask_categories):
+        """
+        Sets the data_mask_categories of this DataMaskRule.
+        Data Mask Categories
+
+
+        :param data_mask_categories: The data_mask_categories of this DataMaskRule.
+        :type: list[str]
+        """
+        allowed_values = ["ACTOR", "PII", "PHI", "FINANCIAL", "LOCATION", "CUSTOM"]
+        if data_mask_categories:
+            data_mask_categories[:] = ['UNKNOWN_ENUM_VALUE' if not value_allowed_none_or_none_sentinel(x, allowed_values) else x for x in data_mask_categories]
+        self._data_mask_categories = data_mask_categories
+
+    @property
+    def time_created(self):
+        """
+        Gets the time_created of this DataMaskRule.
+        The date and time the target was created. Format defined by RFC3339.
+
+
+        :return: The time_created of this DataMaskRule.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this DataMaskRule.
+        The date and time the target was created. Format defined by RFC3339.
+
+
+        :param time_created: The time_created of this DataMaskRule.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def time_updated(self):
+        """
+        Gets the time_updated of this DataMaskRule.
+        The date and time the target was updated. Format defined by RFC3339.
+
+
+        :return: The time_updated of this DataMaskRule.
+        :rtype: datetime
+        """
+        return self._time_updated
+
+    @time_updated.setter
+    def time_updated(self, time_updated):
+        """
+        Sets the time_updated of this DataMaskRule.
+        The date and time the target was updated. Format defined by RFC3339.
+
+
+        :param time_updated: The time_updated of this DataMaskRule.
+        :type: datetime
+        """
+        self._time_updated = time_updated
+
+    @property
+    def data_mask_rule_status(self):
+        """
+        Gets the data_mask_rule_status of this DataMaskRule.
+        The status of the dataMaskRule.
+
+        Allowed values for this property are: "ENABLED", "DISABLED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The data_mask_rule_status of this DataMaskRule.
+        :rtype: str
+        """
+        return self._data_mask_rule_status
+
+    @data_mask_rule_status.setter
+    def data_mask_rule_status(self, data_mask_rule_status):
+        """
+        Sets the data_mask_rule_status of this DataMaskRule.
+        The status of the dataMaskRule.
+
+
+        :param data_mask_rule_status: The data_mask_rule_status of this DataMaskRule.
+        :type: str
+        """
+        allowed_values = ["ENABLED", "DISABLED"]
+        if not value_allowed_none_or_none_sentinel(data_mask_rule_status, allowed_values):
+            data_mask_rule_status = 'UNKNOWN_ENUM_VALUE'
+        self._data_mask_rule_status = data_mask_rule_status
+
+    @property
+    def lifecycle_state(self):
+        """
+        Gets the lifecycle_state of this DataMaskRule.
+        The current state of the DataMaskRule.
+
+        Allowed values for this property are: "CREATING", "UPDATING", "ACTIVE", "INACTIVE", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this DataMaskRule.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this DataMaskRule.
+        The current state of the DataMaskRule.
+
+
+        :param lifecycle_state: The lifecycle_state of this DataMaskRule.
+        :type: str
+        """
+        allowed_values = ["CREATING", "UPDATING", "ACTIVE", "INACTIVE", "DELETING", "DELETED", "FAILED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def lifecyle_details(self):
+        """
+        Gets the lifecyle_details of this DataMaskRule.
+        A message describing the current state in more detail. For example, can be used to provide actionable information for a resource in Failed state.
+
+
+        :return: The lifecyle_details of this DataMaskRule.
+        :rtype: str
+        """
+        return self._lifecyle_details
+
+    @lifecyle_details.setter
+    def lifecyle_details(self, lifecyle_details):
+        """
+        Sets the lifecyle_details of this DataMaskRule.
+        A message describing the current state in more detail. For example, can be used to provide actionable information for a resource in Failed state.
+
+
+        :param lifecyle_details: The lifecyle_details of this DataMaskRule.
+        :type: str
+        """
+        self._lifecyle_details = lifecyle_details
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this DataMaskRule.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :return: The freeform_tags of this DataMaskRule.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this DataMaskRule.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :param freeform_tags: The freeform_tags of this DataMaskRule.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this DataMaskRule.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :return: The defined_tags of this DataMaskRule.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this DataMaskRule.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :param defined_tags: The defined_tags of this DataMaskRule.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    @property
+    def system_tags(self):
+        """
+        Gets the system_tags of this DataMaskRule.
+        System tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+        System tags can be viewed by users, but can only be created by the system.
+
+        Example: `{\"orcl-cloud\": {\"free-tier-retained\": \"true\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The system_tags of this DataMaskRule.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._system_tags
+
+    @system_tags.setter
+    def system_tags(self, system_tags):
+        """
+        Sets the system_tags of this DataMaskRule.
+        System tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+        System tags can be viewed by users, but can only be created by the system.
+
+        Example: `{\"orcl-cloud\": {\"free-tier-retained\": \"true\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param system_tags: The system_tags of this DataMaskRule.
+        :type: dict(str, dict(str, object))
+        """
+        self._system_tags = system_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/cloud_guard/models/data_mask_rule_collection.py
+++ b/src/oci/cloud_guard/models/data_mask_rule_collection.py
@@ -1,0 +1,70 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class DataMaskRuleCollection(object):
+    """
+    Collection of Data Mask Rule
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new DataMaskRuleCollection object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param items:
+            The value to assign to the items property of this DataMaskRuleCollection.
+        :type items: list[oci.cloud_guard.models.DataMaskRuleSummary]
+
+        """
+        self.swagger_types = {
+            'items': 'list[DataMaskRuleSummary]'
+        }
+
+        self.attribute_map = {
+            'items': 'items'
+        }
+
+        self._items = None
+
+    @property
+    def items(self):
+        """
+        **[Required]** Gets the items of this DataMaskRuleCollection.
+        List of Data Mask Rule Summary
+
+
+        :return: The items of this DataMaskRuleCollection.
+        :rtype: list[oci.cloud_guard.models.DataMaskRuleSummary]
+        """
+        return self._items
+
+    @items.setter
+    def items(self, items):
+        """
+        Sets the items of this DataMaskRuleCollection.
+        List of Data Mask Rule Summary
+
+
+        :param items: The items of this DataMaskRuleCollection.
+        :type: list[oci.cloud_guard.models.DataMaskRuleSummary]
+        """
+        self._items = items
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/cloud_guard/models/data_mask_rule_summary.py
+++ b/src/oci/cloud_guard/models/data_mask_rule_summary.py
@@ -1,0 +1,600 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class DataMaskRuleSummary(object):
+    """
+    Summary of DataMaskRule.
+    """
+
+    #: A constant which can be used with the data_mask_categories property of a DataMaskRuleSummary.
+    #: This constant has a value of "ACTOR"
+    DATA_MASK_CATEGORIES_ACTOR = "ACTOR"
+
+    #: A constant which can be used with the data_mask_categories property of a DataMaskRuleSummary.
+    #: This constant has a value of "PII"
+    DATA_MASK_CATEGORIES_PII = "PII"
+
+    #: A constant which can be used with the data_mask_categories property of a DataMaskRuleSummary.
+    #: This constant has a value of "PHI"
+    DATA_MASK_CATEGORIES_PHI = "PHI"
+
+    #: A constant which can be used with the data_mask_categories property of a DataMaskRuleSummary.
+    #: This constant has a value of "FINANCIAL"
+    DATA_MASK_CATEGORIES_FINANCIAL = "FINANCIAL"
+
+    #: A constant which can be used with the data_mask_categories property of a DataMaskRuleSummary.
+    #: This constant has a value of "LOCATION"
+    DATA_MASK_CATEGORIES_LOCATION = "LOCATION"
+
+    #: A constant which can be used with the data_mask_categories property of a DataMaskRuleSummary.
+    #: This constant has a value of "CUSTOM"
+    DATA_MASK_CATEGORIES_CUSTOM = "CUSTOM"
+
+    #: A constant which can be used with the data_mask_rule_status property of a DataMaskRuleSummary.
+    #: This constant has a value of "ENABLED"
+    DATA_MASK_RULE_STATUS_ENABLED = "ENABLED"
+
+    #: A constant which can be used with the data_mask_rule_status property of a DataMaskRuleSummary.
+    #: This constant has a value of "DISABLED"
+    DATA_MASK_RULE_STATUS_DISABLED = "DISABLED"
+
+    #: A constant which can be used with the lifecycle_state property of a DataMaskRuleSummary.
+    #: This constant has a value of "CREATING"
+    LIFECYCLE_STATE_CREATING = "CREATING"
+
+    #: A constant which can be used with the lifecycle_state property of a DataMaskRuleSummary.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a DataMaskRuleSummary.
+    #: This constant has a value of "ACTIVE"
+    LIFECYCLE_STATE_ACTIVE = "ACTIVE"
+
+    #: A constant which can be used with the lifecycle_state property of a DataMaskRuleSummary.
+    #: This constant has a value of "INACTIVE"
+    LIFECYCLE_STATE_INACTIVE = "INACTIVE"
+
+    #: A constant which can be used with the lifecycle_state property of a DataMaskRuleSummary.
+    #: This constant has a value of "DELETING"
+    LIFECYCLE_STATE_DELETING = "DELETING"
+
+    #: A constant which can be used with the lifecycle_state property of a DataMaskRuleSummary.
+    #: This constant has a value of "DELETED"
+    LIFECYCLE_STATE_DELETED = "DELETED"
+
+    #: A constant which can be used with the lifecycle_state property of a DataMaskRuleSummary.
+    #: This constant has a value of "FAILED"
+    LIFECYCLE_STATE_FAILED = "FAILED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new DataMaskRuleSummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this DataMaskRuleSummary.
+        :type id: str
+
+        :param display_name:
+            The value to assign to the display_name property of this DataMaskRuleSummary.
+        :type display_name: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this DataMaskRuleSummary.
+        :type compartment_id: str
+
+        :param description:
+            The value to assign to the description property of this DataMaskRuleSummary.
+        :type description: str
+
+        :param iam_group_id:
+            The value to assign to the iam_group_id property of this DataMaskRuleSummary.
+        :type iam_group_id: str
+
+        :param target_selected:
+            The value to assign to the target_selected property of this DataMaskRuleSummary.
+        :type target_selected: oci.cloud_guard.models.TargetSelected
+
+        :param data_mask_categories:
+            The value to assign to the data_mask_categories property of this DataMaskRuleSummary.
+            Allowed values for items in this list are: "ACTOR", "PII", "PHI", "FINANCIAL", "LOCATION", "CUSTOM", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type data_mask_categories: list[str]
+
+        :param time_created:
+            The value to assign to the time_created property of this DataMaskRuleSummary.
+        :type time_created: datetime
+
+        :param time_updated:
+            The value to assign to the time_updated property of this DataMaskRuleSummary.
+        :type time_updated: datetime
+
+        :param data_mask_rule_status:
+            The value to assign to the data_mask_rule_status property of this DataMaskRuleSummary.
+            Allowed values for this property are: "ENABLED", "DISABLED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type data_mask_rule_status: str
+
+        :param lifecycle_state:
+            The value to assign to the lifecycle_state property of this DataMaskRuleSummary.
+            Allowed values for this property are: "CREATING", "UPDATING", "ACTIVE", "INACTIVE", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type lifecycle_state: str
+
+        :param lifecyle_details:
+            The value to assign to the lifecyle_details property of this DataMaskRuleSummary.
+        :type lifecyle_details: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this DataMaskRuleSummary.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this DataMaskRuleSummary.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param system_tags:
+            The value to assign to the system_tags property of this DataMaskRuleSummary.
+        :type system_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'display_name': 'str',
+            'compartment_id': 'str',
+            'description': 'str',
+            'iam_group_id': 'str',
+            'target_selected': 'TargetSelected',
+            'data_mask_categories': 'list[str]',
+            'time_created': 'datetime',
+            'time_updated': 'datetime',
+            'data_mask_rule_status': 'str',
+            'lifecycle_state': 'str',
+            'lifecyle_details': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'system_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'display_name': 'displayName',
+            'compartment_id': 'compartmentId',
+            'description': 'description',
+            'iam_group_id': 'iamGroupId',
+            'target_selected': 'targetSelected',
+            'data_mask_categories': 'dataMaskCategories',
+            'time_created': 'timeCreated',
+            'time_updated': 'timeUpdated',
+            'data_mask_rule_status': 'dataMaskRuleStatus',
+            'lifecycle_state': 'lifecycleState',
+            'lifecyle_details': 'lifecyleDetails',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags',
+            'system_tags': 'systemTags'
+        }
+
+        self._id = None
+        self._display_name = None
+        self._compartment_id = None
+        self._description = None
+        self._iam_group_id = None
+        self._target_selected = None
+        self._data_mask_categories = None
+        self._time_created = None
+        self._time_updated = None
+        self._data_mask_rule_status = None
+        self._lifecycle_state = None
+        self._lifecyle_details = None
+        self._freeform_tags = None
+        self._defined_tags = None
+        self._system_tags = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this DataMaskRuleSummary.
+        Unique identifier that is immutable on creation
+
+
+        :return: The id of this DataMaskRuleSummary.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this DataMaskRuleSummary.
+        Unique identifier that is immutable on creation
+
+
+        :param id: The id of this DataMaskRuleSummary.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this DataMaskRuleSummary.
+        Data Mask Rule Name.
+
+
+        :return: The display_name of this DataMaskRuleSummary.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this DataMaskRuleSummary.
+        Data Mask Rule Name.
+
+
+        :param display_name: The display_name of this DataMaskRuleSummary.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this DataMaskRuleSummary.
+        Compartment Identifier where the resource is created
+
+
+        :return: The compartment_id of this DataMaskRuleSummary.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this DataMaskRuleSummary.
+        Compartment Identifier where the resource is created
+
+
+        :param compartment_id: The compartment_id of this DataMaskRuleSummary.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def description(self):
+        """
+        Gets the description of this DataMaskRuleSummary.
+        The data mask rule description.
+
+
+        :return: The description of this DataMaskRuleSummary.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this DataMaskRuleSummary.
+        The data mask rule description.
+
+
+        :param description: The description of this DataMaskRuleSummary.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def iam_group_id(self):
+        """
+        **[Required]** Gets the iam_group_id of this DataMaskRuleSummary.
+        IAM Group id associated with the data mask rule
+
+
+        :return: The iam_group_id of this DataMaskRuleSummary.
+        :rtype: str
+        """
+        return self._iam_group_id
+
+    @iam_group_id.setter
+    def iam_group_id(self, iam_group_id):
+        """
+        Sets the iam_group_id of this DataMaskRuleSummary.
+        IAM Group id associated with the data mask rule
+
+
+        :param iam_group_id: The iam_group_id of this DataMaskRuleSummary.
+        :type: str
+        """
+        self._iam_group_id = iam_group_id
+
+    @property
+    def target_selected(self):
+        """
+        **[Required]** Gets the target_selected of this DataMaskRuleSummary.
+
+        :return: The target_selected of this DataMaskRuleSummary.
+        :rtype: oci.cloud_guard.models.TargetSelected
+        """
+        return self._target_selected
+
+    @target_selected.setter
+    def target_selected(self, target_selected):
+        """
+        Sets the target_selected of this DataMaskRuleSummary.
+
+        :param target_selected: The target_selected of this DataMaskRuleSummary.
+        :type: oci.cloud_guard.models.TargetSelected
+        """
+        self._target_selected = target_selected
+
+    @property
+    def data_mask_categories(self):
+        """
+        Gets the data_mask_categories of this DataMaskRuleSummary.
+        Data Mask Categories
+
+        Allowed values for items in this list are: "ACTOR", "PII", "PHI", "FINANCIAL", "LOCATION", "CUSTOM", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The data_mask_categories of this DataMaskRuleSummary.
+        :rtype: list[str]
+        """
+        return self._data_mask_categories
+
+    @data_mask_categories.setter
+    def data_mask_categories(self, data_mask_categories):
+        """
+        Sets the data_mask_categories of this DataMaskRuleSummary.
+        Data Mask Categories
+
+
+        :param data_mask_categories: The data_mask_categories of this DataMaskRuleSummary.
+        :type: list[str]
+        """
+        allowed_values = ["ACTOR", "PII", "PHI", "FINANCIAL", "LOCATION", "CUSTOM"]
+        if data_mask_categories:
+            data_mask_categories[:] = ['UNKNOWN_ENUM_VALUE' if not value_allowed_none_or_none_sentinel(x, allowed_values) else x for x in data_mask_categories]
+        self._data_mask_categories = data_mask_categories
+
+    @property
+    def time_created(self):
+        """
+        Gets the time_created of this DataMaskRuleSummary.
+        The date and time the target was created. Format defined by RFC3339.
+
+
+        :return: The time_created of this DataMaskRuleSummary.
+        :rtype: datetime
+        """
+        return self._time_created
+
+    @time_created.setter
+    def time_created(self, time_created):
+        """
+        Sets the time_created of this DataMaskRuleSummary.
+        The date and time the target was created. Format defined by RFC3339.
+
+
+        :param time_created: The time_created of this DataMaskRuleSummary.
+        :type: datetime
+        """
+        self._time_created = time_created
+
+    @property
+    def time_updated(self):
+        """
+        Gets the time_updated of this DataMaskRuleSummary.
+        The date and time the target was updated. Format defined by RFC3339.
+
+
+        :return: The time_updated of this DataMaskRuleSummary.
+        :rtype: datetime
+        """
+        return self._time_updated
+
+    @time_updated.setter
+    def time_updated(self, time_updated):
+        """
+        Sets the time_updated of this DataMaskRuleSummary.
+        The date and time the target was updated. Format defined by RFC3339.
+
+
+        :param time_updated: The time_updated of this DataMaskRuleSummary.
+        :type: datetime
+        """
+        self._time_updated = time_updated
+
+    @property
+    def data_mask_rule_status(self):
+        """
+        Gets the data_mask_rule_status of this DataMaskRuleSummary.
+        The status of the dataMaskRule.
+
+        Allowed values for this property are: "ENABLED", "DISABLED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The data_mask_rule_status of this DataMaskRuleSummary.
+        :rtype: str
+        """
+        return self._data_mask_rule_status
+
+    @data_mask_rule_status.setter
+    def data_mask_rule_status(self, data_mask_rule_status):
+        """
+        Sets the data_mask_rule_status of this DataMaskRuleSummary.
+        The status of the dataMaskRule.
+
+
+        :param data_mask_rule_status: The data_mask_rule_status of this DataMaskRuleSummary.
+        :type: str
+        """
+        allowed_values = ["ENABLED", "DISABLED"]
+        if not value_allowed_none_or_none_sentinel(data_mask_rule_status, allowed_values):
+            data_mask_rule_status = 'UNKNOWN_ENUM_VALUE'
+        self._data_mask_rule_status = data_mask_rule_status
+
+    @property
+    def lifecycle_state(self):
+        """
+        Gets the lifecycle_state of this DataMaskRuleSummary.
+        The current state of the DataMaskRule.
+
+        Allowed values for this property are: "CREATING", "UPDATING", "ACTIVE", "INACTIVE", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The lifecycle_state of this DataMaskRuleSummary.
+        :rtype: str
+        """
+        return self._lifecycle_state
+
+    @lifecycle_state.setter
+    def lifecycle_state(self, lifecycle_state):
+        """
+        Sets the lifecycle_state of this DataMaskRuleSummary.
+        The current state of the DataMaskRule.
+
+
+        :param lifecycle_state: The lifecycle_state of this DataMaskRuleSummary.
+        :type: str
+        """
+        allowed_values = ["CREATING", "UPDATING", "ACTIVE", "INACTIVE", "DELETING", "DELETED", "FAILED"]
+        if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
+            lifecycle_state = 'UNKNOWN_ENUM_VALUE'
+        self._lifecycle_state = lifecycle_state
+
+    @property
+    def lifecyle_details(self):
+        """
+        Gets the lifecyle_details of this DataMaskRuleSummary.
+        A message describing the current state in more detail. For example, can be used to provide actionable information for a resource in Failed state.
+
+
+        :return: The lifecyle_details of this DataMaskRuleSummary.
+        :rtype: str
+        """
+        return self._lifecyle_details
+
+    @lifecyle_details.setter
+    def lifecyle_details(self, lifecyle_details):
+        """
+        Sets the lifecyle_details of this DataMaskRuleSummary.
+        A message describing the current state in more detail. For example, can be used to provide actionable information for a resource in Failed state.
+
+
+        :param lifecyle_details: The lifecyle_details of this DataMaskRuleSummary.
+        :type: str
+        """
+        self._lifecyle_details = lifecyle_details
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this DataMaskRuleSummary.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :return: The freeform_tags of this DataMaskRuleSummary.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this DataMaskRuleSummary.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :param freeform_tags: The freeform_tags of this DataMaskRuleSummary.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this DataMaskRuleSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :return: The defined_tags of this DataMaskRuleSummary.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this DataMaskRuleSummary.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :param defined_tags: The defined_tags of this DataMaskRuleSummary.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    @property
+    def system_tags(self):
+        """
+        Gets the system_tags of this DataMaskRuleSummary.
+        System tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+        System tags can be viewed by users, but can only be created by the system.
+
+        Example: `{\"orcl-cloud\": {\"free-tier-retained\": \"true\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The system_tags of this DataMaskRuleSummary.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._system_tags
+
+    @system_tags.setter
+    def system_tags(self, system_tags):
+        """
+        Sets the system_tags of this DataMaskRuleSummary.
+        System tags for this resource. Each key is predefined and scoped to a namespace.
+        For more information, see `Resource Tags`__.
+        System tags can be viewed by users, but can only be created by the system.
+
+        Example: `{\"orcl-cloud\": {\"free-tier-retained\": \"true\"}}`
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm
+
+
+        :param system_tags: The system_tags of this DataMaskRuleSummary.
+        :type: dict(str, dict(str, object))
+        """
+        self._system_tags = system_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/cloud_guard/models/detector_recipe.py
+++ b/src/oci/cloud_guard/models/detector_recipe.py
@@ -365,7 +365,7 @@ class DetectorRecipe(object):
     def detector_rules(self):
         """
         Gets the detector_rules of this DetectorRecipe.
-        List of detetor rules for the detector type for recipe
+        List of detector rules for the detector type for recipe - user input
 
 
         :return: The detector_rules of this DetectorRecipe.
@@ -377,7 +377,7 @@ class DetectorRecipe(object):
     def detector_rules(self, detector_rules):
         """
         Sets the detector_rules of this DetectorRecipe.
-        List of detetor rules for the detector type for recipe
+        List of detector rules for the detector type for recipe - user input
 
 
         :param detector_rules: The detector_rules of this DetectorRecipe.
@@ -389,7 +389,7 @@ class DetectorRecipe(object):
     def effective_detector_rules(self):
         """
         Gets the effective_detector_rules of this DetectorRecipe.
-        List of detetor rules for the detector type for recipe
+        List of effective detector rules for the detector type for recipe after applying defaults
 
 
         :return: The effective_detector_rules of this DetectorRecipe.
@@ -401,7 +401,7 @@ class DetectorRecipe(object):
     def effective_detector_rules(self, effective_detector_rules):
         """
         Sets the effective_detector_rules of this DetectorRecipe.
-        List of detetor rules for the detector type for recipe
+        List of effective detector rules for the detector type for recipe after applying defaults
 
 
         :param effective_detector_rules: The effective_detector_rules of this DetectorRecipe.

--- a/src/oci/cloud_guard/models/detector_recipe_detector_rule.py
+++ b/src/oci/cloud_guard/models/detector_recipe_detector_rule.py
@@ -65,6 +65,10 @@ class DetectorRecipeDetectorRule(object):
     #: This constant has a value of "TAGS"
     MANAGED_LIST_TYPES_TAGS = "TAGS"
 
+    #: A constant which can be used with the managed_list_types property of a DetectorRecipeDetectorRule.
+    #: This constant has a value of "GENERIC"
+    MANAGED_LIST_TYPES_GENERIC = "GENERIC"
+
     #: A constant which can be used with the lifecycle_state property of a DetectorRecipeDetectorRule.
     #: This constant has a value of "CREATING"
     LIFECYCLE_STATE_CREATING = "CREATING"
@@ -134,7 +138,7 @@ class DetectorRecipeDetectorRule(object):
 
         :param managed_list_types:
             The value to assign to the managed_list_types property of this DetectorRecipeDetectorRule.
-            Allowed values for items in this list are: "CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for items in this list are: "CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS", "GENERIC", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type managed_list_types: list[str]
 
@@ -410,7 +414,7 @@ class DetectorRecipeDetectorRule(object):
         Gets the managed_list_types of this DetectorRecipeDetectorRule.
         List of cloudguard managed list types related to this rule
 
-        Allowed values for items in this list are: "CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for items in this list are: "CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS", "GENERIC", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -429,7 +433,7 @@ class DetectorRecipeDetectorRule(object):
         :param managed_list_types: The managed_list_types of this DetectorRecipeDetectorRule.
         :type: list[str]
         """
-        allowed_values = ["CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS"]
+        allowed_values = ["CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS", "GENERIC"]
         if managed_list_types:
             managed_list_types[:] = ['UNKNOWN_ENUM_VALUE' if not value_allowed_none_or_none_sentinel(x, allowed_values) else x for x in managed_list_types]
         self._managed_list_types = managed_list_types

--- a/src/oci/cloud_guard/models/detector_recipe_detector_rule_summary.py
+++ b/src/oci/cloud_guard/models/detector_recipe_detector_rule_summary.py
@@ -65,6 +65,10 @@ class DetectorRecipeDetectorRuleSummary(object):
     #: This constant has a value of "TAGS"
     MANAGED_LIST_TYPES_TAGS = "TAGS"
 
+    #: A constant which can be used with the managed_list_types property of a DetectorRecipeDetectorRuleSummary.
+    #: This constant has a value of "GENERIC"
+    MANAGED_LIST_TYPES_GENERIC = "GENERIC"
+
     #: A constant which can be used with the lifecycle_state property of a DetectorRecipeDetectorRuleSummary.
     #: This constant has a value of "CREATING"
     LIFECYCLE_STATE_CREATING = "CREATING"
@@ -130,7 +134,7 @@ class DetectorRecipeDetectorRuleSummary(object):
 
         :param managed_list_types:
             The value to assign to the managed_list_types property of this DetectorRecipeDetectorRuleSummary.
-            Allowed values for items in this list are: "CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for items in this list are: "CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS", "GENERIC", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type managed_list_types: list[str]
 
@@ -390,7 +394,7 @@ class DetectorRecipeDetectorRuleSummary(object):
         Gets the managed_list_types of this DetectorRecipeDetectorRuleSummary.
         List of cloudguard managed list types related to this rule
 
-        Allowed values for items in this list are: "CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for items in this list are: "CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS", "GENERIC", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -409,7 +413,7 @@ class DetectorRecipeDetectorRuleSummary(object):
         :param managed_list_types: The managed_list_types of this DetectorRecipeDetectorRuleSummary.
         :type: list[str]
         """
-        allowed_values = ["CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS"]
+        allowed_values = ["CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS", "GENERIC"]
         if managed_list_types:
             managed_list_types[:] = ['UNKNOWN_ENUM_VALUE' if not value_allowed_none_or_none_sentinel(x, allowed_values) else x for x in managed_list_types]
         self._managed_list_types = managed_list_types

--- a/src/oci/cloud_guard/models/detector_rule.py
+++ b/src/oci/cloud_guard/models/detector_rule.py
@@ -65,6 +65,10 @@ class DetectorRule(object):
     #: This constant has a value of "TAGS"
     MANAGED_LIST_TYPES_TAGS = "TAGS"
 
+    #: A constant which can be used with the managed_list_types property of a DetectorRule.
+    #: This constant has a value of "GENERIC"
+    MANAGED_LIST_TYPES_GENERIC = "GENERIC"
+
     #: A constant which can be used with the lifecycle_state property of a DetectorRule.
     #: This constant has a value of "CREATING"
     LIFECYCLE_STATE_CREATING = "CREATING"
@@ -134,7 +138,7 @@ class DetectorRule(object):
 
         :param managed_list_types:
             The value to assign to the managed_list_types property of this DetectorRule.
-            Allowed values for items in this list are: "CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for items in this list are: "CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS", "GENERIC", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type managed_list_types: list[str]
 
@@ -410,7 +414,7 @@ class DetectorRule(object):
         Gets the managed_list_types of this DetectorRule.
         List of cloudguard managed list types related to this rule
 
-        Allowed values for items in this list are: "CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for items in this list are: "CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS", "GENERIC", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -429,7 +433,7 @@ class DetectorRule(object):
         :param managed_list_types: The managed_list_types of this DetectorRule.
         :type: list[str]
         """
-        allowed_values = ["CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS"]
+        allowed_values = ["CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS", "GENERIC"]
         if managed_list_types:
             managed_list_types[:] = ['UNKNOWN_ENUM_VALUE' if not value_allowed_none_or_none_sentinel(x, allowed_values) else x for x in managed_list_types]
         self._managed_list_types = managed_list_types

--- a/src/oci/cloud_guard/models/detector_rule_summary.py
+++ b/src/oci/cloud_guard/models/detector_rule_summary.py
@@ -65,6 +65,10 @@ class DetectorRuleSummary(object):
     #: This constant has a value of "TAGS"
     MANAGED_LIST_TYPES_TAGS = "TAGS"
 
+    #: A constant which can be used with the managed_list_types property of a DetectorRuleSummary.
+    #: This constant has a value of "GENERIC"
+    MANAGED_LIST_TYPES_GENERIC = "GENERIC"
+
     #: A constant which can be used with the lifecycle_state property of a DetectorRuleSummary.
     #: This constant has a value of "CREATING"
     LIFECYCLE_STATE_CREATING = "CREATING"
@@ -130,7 +134,7 @@ class DetectorRuleSummary(object):
 
         :param managed_list_types:
             The value to assign to the managed_list_types property of this DetectorRuleSummary.
-            Allowed values for items in this list are: "CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for items in this list are: "CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS", "GENERIC", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type managed_list_types: list[str]
 
@@ -390,7 +394,7 @@ class DetectorRuleSummary(object):
         Gets the managed_list_types of this DetectorRuleSummary.
         List of cloudguard managed list types related to this rule
 
-        Allowed values for items in this list are: "CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for items in this list are: "CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS", "GENERIC", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -409,7 +413,7 @@ class DetectorRuleSummary(object):
         :param managed_list_types: The managed_list_types of this DetectorRuleSummary.
         :type: list[str]
         """
-        allowed_values = ["CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS"]
+        allowed_values = ["CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS", "GENERIC"]
         if managed_list_types:
             managed_list_types[:] = ['UNKNOWN_ENUM_VALUE' if not value_allowed_none_or_none_sentinel(x, allowed_values) else x for x in managed_list_types]
         self._managed_list_types = managed_list_types

--- a/src/oci/cloud_guard/models/managed_list.py
+++ b/src/oci/cloud_guard/models/managed_list.py
@@ -57,6 +57,10 @@ class ManagedList(object):
     #: This constant has a value of "TAGS"
     LIST_TYPE_TAGS = "TAGS"
 
+    #: A constant which can be used with the list_type property of a ManagedList.
+    #: This constant has a value of "GENERIC"
+    LIST_TYPE_GENERIC = "GENERIC"
+
     #: A constant which can be used with the feed_provider property of a ManagedList.
     #: This constant has a value of "CUSTOMER"
     FEED_PROVIDER_CUSTOMER = "CUSTOMER"
@@ -120,7 +124,7 @@ class ManagedList(object):
 
         :param list_type:
             The value to assign to the list_type property of this ManagedList.
-            Allowed values for this property are: "CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS", "GENERIC", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type list_type: str
 
@@ -350,7 +354,7 @@ class ManagedList(object):
         **[Required]** Gets the list_type of this ManagedList.
         type of the list
 
-        Allowed values for this property are: "CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS", "GENERIC", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -369,7 +373,7 @@ class ManagedList(object):
         :param list_type: The list_type of this ManagedList.
         :type: str
         """
-        allowed_values = ["CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS"]
+        allowed_values = ["CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS", "GENERIC"]
         if not value_allowed_none_or_none_sentinel(list_type, allowed_values):
             list_type = 'UNKNOWN_ENUM_VALUE'
         self._list_type = list_type

--- a/src/oci/cloud_guard/models/managed_list_summary.py
+++ b/src/oci/cloud_guard/models/managed_list_summary.py
@@ -57,6 +57,10 @@ class ManagedListSummary(object):
     #: This constant has a value of "TAGS"
     LIST_TYPE_TAGS = "TAGS"
 
+    #: A constant which can be used with the list_type property of a ManagedListSummary.
+    #: This constant has a value of "GENERIC"
+    LIST_TYPE_GENERIC = "GENERIC"
+
     #: A constant which can be used with the feed_provider property of a ManagedListSummary.
     #: This constant has a value of "CUSTOMER"
     FEED_PROVIDER_CUSTOMER = "CUSTOMER"
@@ -120,7 +124,7 @@ class ManagedListSummary(object):
 
         :param list_type:
             The value to assign to the list_type property of this ManagedListSummary.
-            Allowed values for this property are: "CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS", "GENERIC", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type list_type: str
 
@@ -350,7 +354,7 @@ class ManagedListSummary(object):
         **[Required]** Gets the list_type of this ManagedListSummary.
         type of the list
 
-        Allowed values for this property are: "CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS", "GENERIC", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -369,7 +373,7 @@ class ManagedListSummary(object):
         :param list_type: The list_type of this ManagedListSummary.
         :type: str
         """
-        allowed_values = ["CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS"]
+        allowed_values = ["CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS", "GENERIC"]
         if not value_allowed_none_or_none_sentinel(list_type, allowed_values):
             list_type = 'UNKNOWN_ENUM_VALUE'
         self._list_type = list_type

--- a/src/oci/cloud_guard/models/policy_collection.py
+++ b/src/oci/cloud_guard/models/policy_collection.py
@@ -1,0 +1,70 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class PolicyCollection(object):
+    """
+    Collection of policy statements required by cloud guard
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new PolicyCollection object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param items:
+            The value to assign to the items property of this PolicyCollection.
+        :type items: list[oci.cloud_guard.models.PolicySummary]
+
+        """
+        self.swagger_types = {
+            'items': 'list[PolicySummary]'
+        }
+
+        self.attribute_map = {
+            'items': 'items'
+        }
+
+        self._items = None
+
+    @property
+    def items(self):
+        """
+        **[Required]** Gets the items of this PolicyCollection.
+        List of global policy statements
+
+
+        :return: The items of this PolicyCollection.
+        :rtype: list[oci.cloud_guard.models.PolicySummary]
+        """
+        return self._items
+
+    @items.setter
+    def items(self, items):
+        """
+        Sets the items of this PolicyCollection.
+        List of global policy statements
+
+
+        :param items: The items of this PolicyCollection.
+        :type: list[oci.cloud_guard.models.PolicySummary]
+        """
+        self._items = items
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/cloud_guard/models/policy_summary.py
+++ b/src/oci/cloud_guard/models/policy_summary.py
@@ -1,0 +1,70 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class PolicySummary(object):
+    """
+    Global policy statement
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new PolicySummary object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param policy:
+            The value to assign to the policy property of this PolicySummary.
+        :type policy: str
+
+        """
+        self.swagger_types = {
+            'policy': 'str'
+        }
+
+        self.attribute_map = {
+            'policy': 'policy'
+        }
+
+        self._policy = None
+
+    @property
+    def policy(self):
+        """
+        **[Required]** Gets the policy of this PolicySummary.
+        Global policy statement
+
+
+        :return: The policy of this PolicySummary.
+        :rtype: str
+        """
+        return self._policy
+
+    @policy.setter
+    def policy(self, policy):
+        """
+        Sets the policy of this PolicySummary.
+        Global policy statement
+
+
+        :param policy: The policy of this PolicySummary.
+        :type: str
+        """
+        self._policy = policy
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/cloud_guard/models/problem.py
+++ b/src/oci/cloud_guard/models/problem.py
@@ -138,6 +138,18 @@ class Problem(object):
             The value to assign to the target_id property of this Problem.
         :type target_id: str
 
+        :param additional_details:
+            The value to assign to the additional_details property of this Problem.
+        :type additional_details: dict(str, str)
+
+        :param description:
+            The value to assign to the description property of this Problem.
+        :type description: str
+
+        :param recommendation:
+            The value to assign to the recommendation property of this Problem.
+        :type recommendation: str
+
         :param comment:
             The value to assign to the comment property of this Problem.
         :type comment: str
@@ -160,6 +172,9 @@ class Problem(object):
             'lifecycle_detail': 'str',
             'detector_id': 'str',
             'target_id': 'str',
+            'additional_details': 'dict(str, str)',
+            'description': 'str',
+            'recommendation': 'str',
             'comment': 'str'
         }
 
@@ -180,6 +195,9 @@ class Problem(object):
             'lifecycle_detail': 'lifecycleDetail',
             'detector_id': 'detectorId',
             'target_id': 'targetId',
+            'additional_details': 'additionalDetails',
+            'description': 'description',
+            'recommendation': 'recommendation',
             'comment': 'comment'
         }
 
@@ -199,6 +217,9 @@ class Problem(object):
         self._lifecycle_detail = None
         self._detector_id = None
         self._target_id = None
+        self._additional_details = None
+        self._description = None
+        self._recommendation = None
         self._comment = None
 
     @property
@@ -608,6 +629,78 @@ class Problem(object):
         :type: str
         """
         self._target_id = target_id
+
+    @property
+    def additional_details(self):
+        """
+        Gets the additional_details of this Problem.
+        The additional details of the Problem
+
+
+        :return: The additional_details of this Problem.
+        :rtype: dict(str, str)
+        """
+        return self._additional_details
+
+    @additional_details.setter
+    def additional_details(self, additional_details):
+        """
+        Sets the additional_details of this Problem.
+        The additional details of the Problem
+
+
+        :param additional_details: The additional_details of this Problem.
+        :type: dict(str, str)
+        """
+        self._additional_details = additional_details
+
+    @property
+    def description(self):
+        """
+        Gets the description of this Problem.
+        Description of the problem
+
+
+        :return: The description of this Problem.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this Problem.
+        Description of the problem
+
+
+        :param description: The description of this Problem.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def recommendation(self):
+        """
+        Gets the recommendation of this Problem.
+        Recommendation for the problem
+
+
+        :return: The recommendation of this Problem.
+        :rtype: str
+        """
+        return self._recommendation
+
+    @recommendation.setter
+    def recommendation(self, recommendation):
+        """
+        Sets the recommendation of this Problem.
+        Recommendation for the problem
+
+
+        :param recommendation: The recommendation of this Problem.
+        :type: str
+        """
+        self._recommendation = recommendation
 
     @property
     def comment(self):

--- a/src/oci/cloud_guard/models/security_score_aggregation.py
+++ b/src/oci/cloud_guard/models/security_score_aggregation.py
@@ -29,6 +29,10 @@ class SecurityScoreAggregation(object):
     #: This constant has a value of "POOR"
     SECURITY_RATING_POOR = "POOR"
 
+    #: A constant which can be used with the security_rating property of a SecurityScoreAggregation.
+    #: This constant has a value of "NA"
+    SECURITY_RATING_NA = "NA"
+
     def __init__(self, **kwargs):
         """
         Initializes a new SecurityScoreAggregation object with values from keyword arguments.
@@ -40,7 +44,7 @@ class SecurityScoreAggregation(object):
 
         :param security_rating:
             The value to assign to the security_rating property of this SecurityScoreAggregation.
-            Allowed values for this property are: "EXCELLENT", "GOOD", "FAIR", "POOR", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "EXCELLENT", "GOOD", "FAIR", "POOR", "NA", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type security_rating: str
 
@@ -95,7 +99,7 @@ class SecurityScoreAggregation(object):
         **[Required]** Gets the security_rating of this SecurityScoreAggregation.
         The security rating with given dimension/s
 
-        Allowed values for this property are: "EXCELLENT", "GOOD", "FAIR", "POOR", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "EXCELLENT", "GOOD", "FAIR", "POOR", "NA", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -114,7 +118,7 @@ class SecurityScoreAggregation(object):
         :param security_rating: The security_rating of this SecurityScoreAggregation.
         :type: str
         """
-        allowed_values = ["EXCELLENT", "GOOD", "FAIR", "POOR"]
+        allowed_values = ["EXCELLENT", "GOOD", "FAIR", "POOR", "NA"]
         if not value_allowed_none_or_none_sentinel(security_rating, allowed_values):
             security_rating = 'UNKNOWN_ENUM_VALUE'
         self._security_rating = security_rating

--- a/src/oci/cloud_guard/models/security_score_trend_aggregation.py
+++ b/src/oci/cloud_guard/models/security_score_trend_aggregation.py
@@ -29,6 +29,10 @@ class SecurityScoreTrendAggregation(object):
     #: This constant has a value of "POOR"
     SECURITY_RATING_POOR = "POOR"
 
+    #: A constant which can be used with the security_rating property of a SecurityScoreTrendAggregation.
+    #: This constant has a value of "NA"
+    SECURITY_RATING_NA = "NA"
+
     def __init__(self, **kwargs):
         """
         Initializes a new SecurityScoreTrendAggregation object with values from keyword arguments.
@@ -48,7 +52,7 @@ class SecurityScoreTrendAggregation(object):
 
         :param security_rating:
             The value to assign to the security_rating property of this SecurityScoreTrendAggregation.
-            Allowed values for this property are: "EXCELLENT", "GOOD", "FAIR", "POOR", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "EXCELLENT", "GOOD", "FAIR", "POOR", "NA", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type security_rating: str
 
@@ -157,7 +161,7 @@ class SecurityScoreTrendAggregation(object):
         **[Required]** Gets the security_rating of this SecurityScoreTrendAggregation.
         The security rating with given dimensions and time range
 
-        Allowed values for this property are: "EXCELLENT", "GOOD", "FAIR", "POOR", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "EXCELLENT", "GOOD", "FAIR", "POOR", "NA", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -176,7 +180,7 @@ class SecurityScoreTrendAggregation(object):
         :param security_rating: The security_rating of this SecurityScoreTrendAggregation.
         :type: str
         """
-        allowed_values = ["EXCELLENT", "GOOD", "FAIR", "POOR"]
+        allowed_values = ["EXCELLENT", "GOOD", "FAIR", "POOR", "NA"]
         if not value_allowed_none_or_none_sentinel(security_rating, allowed_values):
             security_rating = 'UNKNOWN_ENUM_VALUE'
         self._security_rating = security_rating

--- a/src/oci/cloud_guard/models/target_detector_recipe_detector_rule.py
+++ b/src/oci/cloud_guard/models/target_detector_recipe_detector_rule.py
@@ -65,6 +65,10 @@ class TargetDetectorRecipeDetectorRule(object):
     #: This constant has a value of "TAGS"
     MANAGED_LIST_TYPES_TAGS = "TAGS"
 
+    #: A constant which can be used with the managed_list_types property of a TargetDetectorRecipeDetectorRule.
+    #: This constant has a value of "GENERIC"
+    MANAGED_LIST_TYPES_GENERIC = "GENERIC"
+
     #: A constant which can be used with the lifecycle_state property of a TargetDetectorRecipeDetectorRule.
     #: This constant has a value of "CREATING"
     LIFECYCLE_STATE_CREATING = "CREATING"
@@ -134,7 +138,7 @@ class TargetDetectorRecipeDetectorRule(object):
 
         :param managed_list_types:
             The value to assign to the managed_list_types property of this TargetDetectorRecipeDetectorRule.
-            Allowed values for items in this list are: "CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for items in this list are: "CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS", "GENERIC", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type managed_list_types: list[str]
 
@@ -403,7 +407,7 @@ class TargetDetectorRecipeDetectorRule(object):
         Gets the managed_list_types of this TargetDetectorRecipeDetectorRule.
         List of cloudguard managed list types related to this rule
 
-        Allowed values for items in this list are: "CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for items in this list are: "CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS", "GENERIC", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -422,7 +426,7 @@ class TargetDetectorRecipeDetectorRule(object):
         :param managed_list_types: The managed_list_types of this TargetDetectorRecipeDetectorRule.
         :type: list[str]
         """
-        allowed_values = ["CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS"]
+        allowed_values = ["CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS", "GENERIC"]
         if managed_list_types:
             managed_list_types[:] = ['UNKNOWN_ENUM_VALUE' if not value_allowed_none_or_none_sentinel(x, allowed_values) else x for x in managed_list_types]
         self._managed_list_types = managed_list_types

--- a/src/oci/cloud_guard/models/target_detector_recipe_detector_rule_summary.py
+++ b/src/oci/cloud_guard/models/target_detector_recipe_detector_rule_summary.py
@@ -65,6 +65,10 @@ class TargetDetectorRecipeDetectorRuleSummary(object):
     #: This constant has a value of "TAGS"
     MANAGED_LIST_TYPES_TAGS = "TAGS"
 
+    #: A constant which can be used with the managed_list_types property of a TargetDetectorRecipeDetectorRuleSummary.
+    #: This constant has a value of "GENERIC"
+    MANAGED_LIST_TYPES_GENERIC = "GENERIC"
+
     #: A constant which can be used with the lifecycle_state property of a TargetDetectorRecipeDetectorRuleSummary.
     #: This constant has a value of "CREATING"
     LIFECYCLE_STATE_CREATING = "CREATING"
@@ -130,7 +134,7 @@ class TargetDetectorRecipeDetectorRuleSummary(object):
 
         :param managed_list_types:
             The value to assign to the managed_list_types property of this TargetDetectorRecipeDetectorRuleSummary.
-            Allowed values for items in this list are: "CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for items in this list are: "CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS", "GENERIC", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type managed_list_types: list[str]
 
@@ -383,7 +387,7 @@ class TargetDetectorRecipeDetectorRuleSummary(object):
         Gets the managed_list_types of this TargetDetectorRecipeDetectorRuleSummary.
         List of cloudguard managed list types related to this rule
 
-        Allowed values for items in this list are: "CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for items in this list are: "CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS", "GENERIC", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -402,7 +406,7 @@ class TargetDetectorRecipeDetectorRuleSummary(object):
         :param managed_list_types: The managed_list_types of this TargetDetectorRecipeDetectorRuleSummary.
         :type: list[str]
         """
-        allowed_values = ["CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS"]
+        allowed_values = ["CIDR_BLOCK", "USERS", "GROUPS", "IPV4ADDRESS", "IPV6ADDRESS", "RESOURCE_OCID", "REGION", "COUNTRY", "STATE", "CITY", "TAGS", "GENERIC"]
         if managed_list_types:
             managed_list_types[:] = ['UNKNOWN_ENUM_VALUE' if not value_allowed_none_or_none_sentinel(x, allowed_values) else x for x in managed_list_types]
         self._managed_list_types = managed_list_types

--- a/src/oci/cloud_guard/models/target_ids_selected.py
+++ b/src/oci/cloud_guard/models/target_ids_selected.py
@@ -1,0 +1,80 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .target_selected import TargetSelected
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class TargetIdsSelected(TargetSelected):
+    """
+    Target selection on basis of TargetIds.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new TargetIdsSelected object with values from keyword arguments. The default value of the :py:attr:`~oci.cloud_guard.models.TargetIdsSelected.kind` attribute
+        of this class is ``TARGETIDS`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param kind:
+            The value to assign to the kind property of this TargetIdsSelected.
+            Allowed values for this property are: "ALL", "TARGETTYPES", "TARGETIDS"
+        :type kind: str
+
+        :param values:
+            The value to assign to the values property of this TargetIdsSelected.
+        :type values: list[str]
+
+        """
+        self.swagger_types = {
+            'kind': 'str',
+            'values': 'list[str]'
+        }
+
+        self.attribute_map = {
+            'kind': 'kind',
+            'values': 'values'
+        }
+
+        self._kind = None
+        self._values = None
+        self._kind = 'TARGETIDS'
+
+    @property
+    def values(self):
+        """
+        Gets the values of this TargetIdsSelected.
+        Ids of Target
+
+
+        :return: The values of this TargetIdsSelected.
+        :rtype: list[str]
+        """
+        return self._values
+
+    @values.setter
+    def values(self, values):
+        """
+        Sets the values of this TargetIdsSelected.
+        Ids of Target
+
+
+        :param values: The values of this TargetIdsSelected.
+        :type: list[str]
+        """
+        self._values = values
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/cloud_guard/models/target_resource_types_selected.py
+++ b/src/oci/cloud_guard/models/target_resource_types_selected.py
@@ -1,0 +1,101 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .target_selected import TargetSelected
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class TargetResourceTypesSelected(TargetSelected):
+    """
+    Target selection on basis of TargetResourceTypes.
+    """
+
+    #: A constant which can be used with the values property of a TargetResourceTypesSelected.
+    #: This constant has a value of "COMPARTMENT"
+    VALUES_COMPARTMENT = "COMPARTMENT"
+
+    #: A constant which can be used with the values property of a TargetResourceTypesSelected.
+    #: This constant has a value of "ERPCLOUD"
+    VALUES_ERPCLOUD = "ERPCLOUD"
+
+    #: A constant which can be used with the values property of a TargetResourceTypesSelected.
+    #: This constant has a value of "HCMCLOUD"
+    VALUES_HCMCLOUD = "HCMCLOUD"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new TargetResourceTypesSelected object with values from keyword arguments. The default value of the :py:attr:`~oci.cloud_guard.models.TargetResourceTypesSelected.kind` attribute
+        of this class is ``TARGETTYPES`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param kind:
+            The value to assign to the kind property of this TargetResourceTypesSelected.
+            Allowed values for this property are: "ALL", "TARGETTYPES", "TARGETIDS", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type kind: str
+
+        :param values:
+            The value to assign to the values property of this TargetResourceTypesSelected.
+            Allowed values for items in this list are: "COMPARTMENT", "ERPCLOUD", "HCMCLOUD", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type values: list[str]
+
+        """
+        self.swagger_types = {
+            'kind': 'str',
+            'values': 'list[str]'
+        }
+
+        self.attribute_map = {
+            'kind': 'kind',
+            'values': 'values'
+        }
+
+        self._kind = None
+        self._values = None
+        self._kind = 'TARGETTYPES'
+
+    @property
+    def values(self):
+        """
+        Gets the values of this TargetResourceTypesSelected.
+        Types of Targets
+
+        Allowed values for items in this list are: "COMPARTMENT", "ERPCLOUD", "HCMCLOUD", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The values of this TargetResourceTypesSelected.
+        :rtype: list[str]
+        """
+        return self._values
+
+    @values.setter
+    def values(self, values):
+        """
+        Sets the values of this TargetResourceTypesSelected.
+        Types of Targets
+
+
+        :param values: The values of this TargetResourceTypesSelected.
+        :type: list[str]
+        """
+        allowed_values = ["COMPARTMENT", "ERPCLOUD", "HCMCLOUD"]
+        if values:
+            values[:] = ['UNKNOWN_ENUM_VALUE' if not value_allowed_none_or_none_sentinel(x, allowed_values) else x for x in values]
+        self._values = values
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/cloud_guard/models/target_selected.py
+++ b/src/oci/cloud_guard/models/target_selected.py
@@ -1,0 +1,115 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class TargetSelected(object):
+    """
+    Target Selection eg select ALL or select on basis of TargetResourceTypes or TargetIds.
+    """
+
+    #: A constant which can be used with the kind property of a TargetSelected.
+    #: This constant has a value of "ALL"
+    KIND_ALL = "ALL"
+
+    #: A constant which can be used with the kind property of a TargetSelected.
+    #: This constant has a value of "TARGETTYPES"
+    KIND_TARGETTYPES = "TARGETTYPES"
+
+    #: A constant which can be used with the kind property of a TargetSelected.
+    #: This constant has a value of "TARGETIDS"
+    KIND_TARGETIDS = "TARGETIDS"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new TargetSelected object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
+        to a service operations then you should favor using a subclass over the base class:
+
+        * :class:`~oci.cloud_guard.models.AllTargetsSelected`
+        * :class:`~oci.cloud_guard.models.TargetResourceTypesSelected`
+        * :class:`~oci.cloud_guard.models.TargetIdsSelected`
+
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param kind:
+            The value to assign to the kind property of this TargetSelected.
+            Allowed values for this property are: "ALL", "TARGETTYPES", "TARGETIDS", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type kind: str
+
+        """
+        self.swagger_types = {
+            'kind': 'str'
+        }
+
+        self.attribute_map = {
+            'kind': 'kind'
+        }
+
+        self._kind = None
+
+    @staticmethod
+    def get_subtype(object_dictionary):
+        """
+        Given the hash representation of a subtype of this class,
+        use the info in the hash to return the class of the subtype.
+        """
+        type = object_dictionary['kind']
+
+        if type == 'ALL':
+            return 'AllTargetsSelected'
+
+        if type == 'TARGETTYPES':
+            return 'TargetResourceTypesSelected'
+
+        if type == 'TARGETIDS':
+            return 'TargetIdsSelected'
+        else:
+            return 'TargetSelected'
+
+    @property
+    def kind(self):
+        """
+        **[Required]** Gets the kind of this TargetSelected.
+        Target selection.
+
+        Allowed values for this property are: "ALL", "TARGETTYPES", "TARGETIDS", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The kind of this TargetSelected.
+        :rtype: str
+        """
+        return self._kind
+
+    @kind.setter
+    def kind(self, kind):
+        """
+        Sets the kind of this TargetSelected.
+        Target selection.
+
+
+        :param kind: The kind of this TargetSelected.
+        :type: str
+        """
+        allowed_values = ["ALL", "TARGETTYPES", "TARGETIDS"]
+        if not value_allowed_none_or_none_sentinel(kind, allowed_values):
+            kind = 'UNKNOWN_ENUM_VALUE'
+        self._kind = kind
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/cloud_guard/models/update_bulk_problem_status_details.py
+++ b/src/oci/cloud_guard/models/update_bulk_problem_status_details.py
@@ -39,19 +39,26 @@ class UpdateBulkProblemStatusDetails(object):
             The value to assign to the problem_ids property of this UpdateBulkProblemStatusDetails.
         :type problem_ids: list[str]
 
+        :param comment:
+            The value to assign to the comment property of this UpdateBulkProblemStatusDetails.
+        :type comment: str
+
         """
         self.swagger_types = {
             'status': 'str',
-            'problem_ids': 'list[str]'
+            'problem_ids': 'list[str]',
+            'comment': 'str'
         }
 
         self.attribute_map = {
             'status': 'status',
-            'problem_ids': 'problemIds'
+            'problem_ids': 'problemIds',
+            'comment': 'comment'
         }
 
         self._status = None
         self._problem_ids = None
+        self._comment = None
 
     @property
     def status(self):
@@ -108,6 +115,30 @@ class UpdateBulkProblemStatusDetails(object):
         :type: list[str]
         """
         self._problem_ids = problem_ids
+
+    @property
+    def comment(self):
+        """
+        Gets the comment of this UpdateBulkProblemStatusDetails.
+        User defined comment to be passed in to update the problem.
+
+
+        :return: The comment of this UpdateBulkProblemStatusDetails.
+        :rtype: str
+        """
+        return self._comment
+
+    @comment.setter
+    def comment(self, comment):
+        """
+        Sets the comment of this UpdateBulkProblemStatusDetails.
+        User defined comment to be passed in to update the problem.
+
+
+        :param comment: The comment of this UpdateBulkProblemStatusDetails.
+        :type: str
+        """
+        self._comment = comment
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/cloud_guard/models/update_data_mask_rule_details.py
+++ b/src/oci/cloud_guard/models/update_data_mask_rule_details.py
@@ -1,0 +1,340 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateDataMaskRuleDetails(object):
+    """
+    The information to be updated.
+    """
+
+    #: A constant which can be used with the data_mask_categories property of a UpdateDataMaskRuleDetails.
+    #: This constant has a value of "ACTOR"
+    DATA_MASK_CATEGORIES_ACTOR = "ACTOR"
+
+    #: A constant which can be used with the data_mask_categories property of a UpdateDataMaskRuleDetails.
+    #: This constant has a value of "PII"
+    DATA_MASK_CATEGORIES_PII = "PII"
+
+    #: A constant which can be used with the data_mask_categories property of a UpdateDataMaskRuleDetails.
+    #: This constant has a value of "PHI"
+    DATA_MASK_CATEGORIES_PHI = "PHI"
+
+    #: A constant which can be used with the data_mask_categories property of a UpdateDataMaskRuleDetails.
+    #: This constant has a value of "FINANCIAL"
+    DATA_MASK_CATEGORIES_FINANCIAL = "FINANCIAL"
+
+    #: A constant which can be used with the data_mask_categories property of a UpdateDataMaskRuleDetails.
+    #: This constant has a value of "LOCATION"
+    DATA_MASK_CATEGORIES_LOCATION = "LOCATION"
+
+    #: A constant which can be used with the data_mask_categories property of a UpdateDataMaskRuleDetails.
+    #: This constant has a value of "CUSTOM"
+    DATA_MASK_CATEGORIES_CUSTOM = "CUSTOM"
+
+    #: A constant which can be used with the data_mask_rule_status property of a UpdateDataMaskRuleDetails.
+    #: This constant has a value of "ENABLED"
+    DATA_MASK_RULE_STATUS_ENABLED = "ENABLED"
+
+    #: A constant which can be used with the data_mask_rule_status property of a UpdateDataMaskRuleDetails.
+    #: This constant has a value of "DISABLED"
+    DATA_MASK_RULE_STATUS_DISABLED = "DISABLED"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateDataMaskRuleDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param display_name:
+            The value to assign to the display_name property of this UpdateDataMaskRuleDetails.
+        :type display_name: str
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this UpdateDataMaskRuleDetails.
+        :type compartment_id: str
+
+        :param iam_group_id:
+            The value to assign to the iam_group_id property of this UpdateDataMaskRuleDetails.
+        :type iam_group_id: str
+
+        :param target_selected:
+            The value to assign to the target_selected property of this UpdateDataMaskRuleDetails.
+        :type target_selected: oci.cloud_guard.models.TargetSelected
+
+        :param data_mask_categories:
+            The value to assign to the data_mask_categories property of this UpdateDataMaskRuleDetails.
+            Allowed values for items in this list are: "ACTOR", "PII", "PHI", "FINANCIAL", "LOCATION", "CUSTOM"
+        :type data_mask_categories: list[str]
+
+        :param data_mask_rule_status:
+            The value to assign to the data_mask_rule_status property of this UpdateDataMaskRuleDetails.
+            Allowed values for this property are: "ENABLED", "DISABLED"
+        :type data_mask_rule_status: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this UpdateDataMaskRuleDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this UpdateDataMaskRuleDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        """
+        self.swagger_types = {
+            'display_name': 'str',
+            'compartment_id': 'str',
+            'iam_group_id': 'str',
+            'target_selected': 'TargetSelected',
+            'data_mask_categories': 'list[str]',
+            'data_mask_rule_status': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'defined_tags': 'dict(str, dict(str, object))'
+        }
+
+        self.attribute_map = {
+            'display_name': 'displayName',
+            'compartment_id': 'compartmentId',
+            'iam_group_id': 'iamGroupId',
+            'target_selected': 'targetSelected',
+            'data_mask_categories': 'dataMaskCategories',
+            'data_mask_rule_status': 'dataMaskRuleStatus',
+            'freeform_tags': 'freeformTags',
+            'defined_tags': 'definedTags'
+        }
+
+        self._display_name = None
+        self._compartment_id = None
+        self._iam_group_id = None
+        self._target_selected = None
+        self._data_mask_categories = None
+        self._data_mask_rule_status = None
+        self._freeform_tags = None
+        self._defined_tags = None
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this UpdateDataMaskRuleDetails.
+        Data Mask Rule Name
+
+
+        :return: The display_name of this UpdateDataMaskRuleDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this UpdateDataMaskRuleDetails.
+        Data Mask Rule Name
+
+
+        :param display_name: The display_name of this UpdateDataMaskRuleDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def compartment_id(self):
+        """
+        Gets the compartment_id of this UpdateDataMaskRuleDetails.
+        Compartment Identifier where the resource is created
+
+
+        :return: The compartment_id of this UpdateDataMaskRuleDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this UpdateDataMaskRuleDetails.
+        Compartment Identifier where the resource is created
+
+
+        :param compartment_id: The compartment_id of this UpdateDataMaskRuleDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    @property
+    def iam_group_id(self):
+        """
+        Gets the iam_group_id of this UpdateDataMaskRuleDetails.
+        IAM Group id associated with the data mask rule
+
+
+        :return: The iam_group_id of this UpdateDataMaskRuleDetails.
+        :rtype: str
+        """
+        return self._iam_group_id
+
+    @iam_group_id.setter
+    def iam_group_id(self, iam_group_id):
+        """
+        Sets the iam_group_id of this UpdateDataMaskRuleDetails.
+        IAM Group id associated with the data mask rule
+
+
+        :param iam_group_id: The iam_group_id of this UpdateDataMaskRuleDetails.
+        :type: str
+        """
+        self._iam_group_id = iam_group_id
+
+    @property
+    def target_selected(self):
+        """
+        Gets the target_selected of this UpdateDataMaskRuleDetails.
+
+        :return: The target_selected of this UpdateDataMaskRuleDetails.
+        :rtype: oci.cloud_guard.models.TargetSelected
+        """
+        return self._target_selected
+
+    @target_selected.setter
+    def target_selected(self, target_selected):
+        """
+        Sets the target_selected of this UpdateDataMaskRuleDetails.
+
+        :param target_selected: The target_selected of this UpdateDataMaskRuleDetails.
+        :type: oci.cloud_guard.models.TargetSelected
+        """
+        self._target_selected = target_selected
+
+    @property
+    def data_mask_categories(self):
+        """
+        Gets the data_mask_categories of this UpdateDataMaskRuleDetails.
+        Data Mask Categories
+
+        Allowed values for items in this list are: "ACTOR", "PII", "PHI", "FINANCIAL", "LOCATION", "CUSTOM"
+
+
+        :return: The data_mask_categories of this UpdateDataMaskRuleDetails.
+        :rtype: list[str]
+        """
+        return self._data_mask_categories
+
+    @data_mask_categories.setter
+    def data_mask_categories(self, data_mask_categories):
+        """
+        Sets the data_mask_categories of this UpdateDataMaskRuleDetails.
+        Data Mask Categories
+
+
+        :param data_mask_categories: The data_mask_categories of this UpdateDataMaskRuleDetails.
+        :type: list[str]
+        """
+        allowed_values = ["ACTOR", "PII", "PHI", "FINANCIAL", "LOCATION", "CUSTOM"]
+
+        if data_mask_categories and data_mask_categories is not NONE_SENTINEL:
+            for value in data_mask_categories:
+                if not value_allowed_none_or_none_sentinel(value, allowed_values):
+                    raise ValueError(
+                        "Invalid value for `data_mask_categories`, must be None or one of {0}"
+                        .format(allowed_values)
+                    )
+        self._data_mask_categories = data_mask_categories
+
+    @property
+    def data_mask_rule_status(self):
+        """
+        Gets the data_mask_rule_status of this UpdateDataMaskRuleDetails.
+        The status of the dataMaskRule.
+
+        Allowed values for this property are: "ENABLED", "DISABLED"
+
+
+        :return: The data_mask_rule_status of this UpdateDataMaskRuleDetails.
+        :rtype: str
+        """
+        return self._data_mask_rule_status
+
+    @data_mask_rule_status.setter
+    def data_mask_rule_status(self, data_mask_rule_status):
+        """
+        Sets the data_mask_rule_status of this UpdateDataMaskRuleDetails.
+        The status of the dataMaskRule.
+
+
+        :param data_mask_rule_status: The data_mask_rule_status of this UpdateDataMaskRuleDetails.
+        :type: str
+        """
+        allowed_values = ["ENABLED", "DISABLED"]
+        if not value_allowed_none_or_none_sentinel(data_mask_rule_status, allowed_values):
+            raise ValueError(
+                "Invalid value for `data_mask_rule_status`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._data_mask_rule_status = data_mask_rule_status
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this UpdateDataMaskRuleDetails.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :return: The freeform_tags of this UpdateDataMaskRuleDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this UpdateDataMaskRuleDetails.
+        Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+        Example: `{\"bar-key\": \"value\"}`
+
+
+        :param freeform_tags: The freeform_tags of this UpdateDataMaskRuleDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this UpdateDataMaskRuleDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :return: The defined_tags of this UpdateDataMaskRuleDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this UpdateDataMaskRuleDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a namespace.
+        Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+
+
+        :param defined_tags: The defined_tags of this UpdateDataMaskRuleDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/__init__.py
+++ b/src/oci/core/models/__init__.py
@@ -345,6 +345,7 @@ from .update_boot_volume_details import UpdateBootVolumeDetails
 from .update_boot_volume_kms_key_details import UpdateBootVolumeKmsKeyDetails
 from .update_byoip_range_details import UpdateByoipRangeDetails
 from .update_cluster_network_details import UpdateClusterNetworkDetails
+from .update_cluster_network_instance_pool_details import UpdateClusterNetworkInstancePoolDetails
 from .update_compute_capacity_reservation_details import UpdateComputeCapacityReservationDetails
 from .update_compute_image_capability_schema_details import UpdateComputeImageCapabilitySchemaDetails
 from .update_console_history_details import UpdateConsoleHistoryDetails
@@ -778,6 +779,7 @@ core_type_mapping = {
     "UpdateBootVolumeKmsKeyDetails": UpdateBootVolumeKmsKeyDetails,
     "UpdateByoipRangeDetails": UpdateByoipRangeDetails,
     "UpdateClusterNetworkDetails": UpdateClusterNetworkDetails,
+    "UpdateClusterNetworkInstancePoolDetails": UpdateClusterNetworkInstancePoolDetails,
     "UpdateComputeCapacityReservationDetails": UpdateComputeCapacityReservationDetails,
     "UpdateComputeImageCapabilitySchemaDetails": UpdateComputeImageCapabilitySchemaDetails,
     "UpdateConsoleHistoryDetails": UpdateConsoleHistoryDetails,

--- a/src/oci/core/models/create_vnic_details.py
+++ b/src/oci/core/models/create_vnic_details.py
@@ -27,6 +27,10 @@ class CreateVnicDetails(object):
             The value to assign to the assign_public_ip property of this CreateVnicDetails.
         :type assign_public_ip: bool
 
+        :param assign_private_dns_record:
+            The value to assign to the assign_private_dns_record property of this CreateVnicDetails.
+        :type assign_private_dns_record: bool
+
         :param defined_tags:
             The value to assign to the defined_tags property of this CreateVnicDetails.
         :type defined_tags: dict(str, dict(str, object))
@@ -66,6 +70,7 @@ class CreateVnicDetails(object):
         """
         self.swagger_types = {
             'assign_public_ip': 'bool',
+            'assign_private_dns_record': 'bool',
             'defined_tags': 'dict(str, dict(str, object))',
             'display_name': 'str',
             'freeform_tags': 'dict(str, str)',
@@ -79,6 +84,7 @@ class CreateVnicDetails(object):
 
         self.attribute_map = {
             'assign_public_ip': 'assignPublicIp',
+            'assign_private_dns_record': 'assignPrivateDnsRecord',
             'defined_tags': 'definedTags',
             'display_name': 'displayName',
             'freeform_tags': 'freeformTags',
@@ -91,6 +97,7 @@ class CreateVnicDetails(object):
         }
 
         self._assign_public_ip = None
+        self._assign_private_dns_record = None
         self._defined_tags = None
         self._display_name = None
         self._freeform_tags = None
@@ -174,6 +181,38 @@ class CreateVnicDetails(object):
         :type: bool
         """
         self._assign_public_ip = assign_public_ip
+
+    @property
+    def assign_private_dns_record(self):
+        """
+        Gets the assign_private_dns_record of this CreateVnicDetails.
+        Whether the VNIC should be assigned a DNS record. If set to false, there will be no DNS record
+        registration for the VNIC. If set to true, the DNS record will be registered. The default
+        value is true.
+
+        If you specify a `hostnameLabel`, then `assignPrivateDnsRecord` must be set to true.
+
+
+        :return: The assign_private_dns_record of this CreateVnicDetails.
+        :rtype: bool
+        """
+        return self._assign_private_dns_record
+
+    @assign_private_dns_record.setter
+    def assign_private_dns_record(self, assign_private_dns_record):
+        """
+        Sets the assign_private_dns_record of this CreateVnicDetails.
+        Whether the VNIC should be assigned a DNS record. If set to false, there will be no DNS record
+        registration for the VNIC. If set to true, the DNS record will be registered. The default
+        value is true.
+
+        If you specify a `hostnameLabel`, then `assignPrivateDnsRecord` must be set to true.
+
+
+        :param assign_private_dns_record: The assign_private_dns_record of this CreateVnicDetails.
+        :type: bool
+        """
+        self._assign_private_dns_record = assign_private_dns_record
 
     @property
     def defined_tags(self):

--- a/src/oci/core/models/instance_configuration_create_vnic_details.py
+++ b/src/oci/core/models/instance_configuration_create_vnic_details.py
@@ -25,6 +25,10 @@ class InstanceConfigurationCreateVnicDetails(object):
             The value to assign to the assign_public_ip property of this InstanceConfigurationCreateVnicDetails.
         :type assign_public_ip: bool
 
+        :param assign_private_dns_record:
+            The value to assign to the assign_private_dns_record property of this InstanceConfigurationCreateVnicDetails.
+        :type assign_private_dns_record: bool
+
         :param defined_tags:
             The value to assign to the defined_tags property of this InstanceConfigurationCreateVnicDetails.
         :type defined_tags: dict(str, dict(str, object))
@@ -60,6 +64,7 @@ class InstanceConfigurationCreateVnicDetails(object):
         """
         self.swagger_types = {
             'assign_public_ip': 'bool',
+            'assign_private_dns_record': 'bool',
             'defined_tags': 'dict(str, dict(str, object))',
             'display_name': 'str',
             'freeform_tags': 'dict(str, str)',
@@ -72,6 +77,7 @@ class InstanceConfigurationCreateVnicDetails(object):
 
         self.attribute_map = {
             'assign_public_ip': 'assignPublicIp',
+            'assign_private_dns_record': 'assignPrivateDnsRecord',
             'defined_tags': 'definedTags',
             'display_name': 'displayName',
             'freeform_tags': 'freeformTags',
@@ -83,6 +89,7 @@ class InstanceConfigurationCreateVnicDetails(object):
         }
 
         self._assign_public_ip = None
+        self._assign_private_dns_record = None
         self._defined_tags = None
         self._display_name = None
         self._freeform_tags = None
@@ -117,6 +124,32 @@ class InstanceConfigurationCreateVnicDetails(object):
         :type: bool
         """
         self._assign_public_ip = assign_public_ip
+
+    @property
+    def assign_private_dns_record(self):
+        """
+        Gets the assign_private_dns_record of this InstanceConfigurationCreateVnicDetails.
+        Whether the VNIC should be assigned a private DNS record. See the `assignPrivateDnsRecord` attribute of :class:`CreateVnicDetails`
+        for more information.
+
+
+        :return: The assign_private_dns_record of this InstanceConfigurationCreateVnicDetails.
+        :rtype: bool
+        """
+        return self._assign_private_dns_record
+
+    @assign_private_dns_record.setter
+    def assign_private_dns_record(self, assign_private_dns_record):
+        """
+        Sets the assign_private_dns_record of this InstanceConfigurationCreateVnicDetails.
+        Whether the VNIC should be assigned a private DNS record. See the `assignPrivateDnsRecord` attribute of :class:`CreateVnicDetails`
+        for more information.
+
+
+        :param assign_private_dns_record: The assign_private_dns_record of this InstanceConfigurationCreateVnicDetails.
+        :type: bool
+        """
+        self._assign_private_dns_record = assign_private_dns_record
 
     @property
     def defined_tags(self):

--- a/src/oci/core/models/update_cluster_network_details.py
+++ b/src/oci/core/models/update_cluster_network_details.py
@@ -30,22 +30,29 @@ class UpdateClusterNetworkDetails(object):
             The value to assign to the freeform_tags property of this UpdateClusterNetworkDetails.
         :type freeform_tags: dict(str, str)
 
+        :param instance_pools:
+            The value to assign to the instance_pools property of this UpdateClusterNetworkDetails.
+        :type instance_pools: list[oci.core.models.UpdateClusterNetworkInstancePoolDetails]
+
         """
         self.swagger_types = {
             'defined_tags': 'dict(str, dict(str, object))',
             'display_name': 'str',
-            'freeform_tags': 'dict(str, str)'
+            'freeform_tags': 'dict(str, str)',
+            'instance_pools': 'list[UpdateClusterNetworkInstancePoolDetails]'
         }
 
         self.attribute_map = {
             'defined_tags': 'definedTags',
             'display_name': 'displayName',
-            'freeform_tags': 'freeformTags'
+            'freeform_tags': 'freeformTags',
+            'instance_pools': 'instancePools'
         }
 
         self._defined_tags = None
         self._display_name = None
         self._freeform_tags = None
+        self._instance_pools = None
 
     @property
     def defined_tags(self):
@@ -140,6 +147,30 @@ class UpdateClusterNetworkDetails(object):
         :type: dict(str, str)
         """
         self._freeform_tags = freeform_tags
+
+    @property
+    def instance_pools(self):
+        """
+        Gets the instance_pools of this UpdateClusterNetworkDetails.
+        The instance pools in the cluster network to update.
+
+
+        :return: The instance_pools of this UpdateClusterNetworkDetails.
+        :rtype: list[oci.core.models.UpdateClusterNetworkInstancePoolDetails]
+        """
+        return self._instance_pools
+
+    @instance_pools.setter
+    def instance_pools(self, instance_pools):
+        """
+        Sets the instance_pools of this UpdateClusterNetworkDetails.
+        The instance pools in the cluster network to update.
+
+
+        :param instance_pools: The instance_pools of this UpdateClusterNetworkDetails.
+        :type: list[oci.core.models.UpdateClusterNetworkInstancePoolDetails]
+        """
+        self._instance_pools = instance_pools
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/core/models/update_cluster_network_instance_pool_details.py
+++ b/src/oci/core/models/update_cluster_network_instance_pool_details.py
@@ -1,0 +1,220 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class UpdateClusterNetworkInstancePoolDetails(object):
+    """
+    The data to update an instance pool within a cluster network.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new UpdateClusterNetworkInstancePoolDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this UpdateClusterNetworkInstancePoolDetails.
+        :type id: str
+
+        :param defined_tags:
+            The value to assign to the defined_tags property of this UpdateClusterNetworkInstancePoolDetails.
+        :type defined_tags: dict(str, dict(str, object))
+
+        :param display_name:
+            The value to assign to the display_name property of this UpdateClusterNetworkInstancePoolDetails.
+        :type display_name: str
+
+        :param freeform_tags:
+            The value to assign to the freeform_tags property of this UpdateClusterNetworkInstancePoolDetails.
+        :type freeform_tags: dict(str, str)
+
+        :param size:
+            The value to assign to the size property of this UpdateClusterNetworkInstancePoolDetails.
+        :type size: int
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'defined_tags': 'dict(str, dict(str, object))',
+            'display_name': 'str',
+            'freeform_tags': 'dict(str, str)',
+            'size': 'int'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'defined_tags': 'definedTags',
+            'display_name': 'displayName',
+            'freeform_tags': 'freeformTags',
+            'size': 'size'
+        }
+
+        self._id = None
+        self._defined_tags = None
+        self._display_name = None
+        self._freeform_tags = None
+        self._size = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this UpdateClusterNetworkInstancePoolDetails.
+        The `OCID`__ of the instance pool.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :return: The id of this UpdateClusterNetworkInstancePoolDetails.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this UpdateClusterNetworkInstancePoolDetails.
+        The `OCID`__ of the instance pool.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :param id: The id of this UpdateClusterNetworkInstancePoolDetails.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def defined_tags(self):
+        """
+        Gets the defined_tags of this UpdateClusterNetworkInstancePoolDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The defined_tags of this UpdateClusterNetworkInstancePoolDetails.
+        :rtype: dict(str, dict(str, object))
+        """
+        return self._defined_tags
+
+    @defined_tags.setter
+    def defined_tags(self, defined_tags):
+        """
+        Sets the defined_tags of this UpdateClusterNetworkInstancePoolDetails.
+        Defined tags for this resource. Each key is predefined and scoped to a
+        namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm
+
+
+        :param defined_tags: The defined_tags of this UpdateClusterNetworkInstancePoolDetails.
+        :type: dict(str, dict(str, object))
+        """
+        self._defined_tags = defined_tags
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this UpdateClusterNetworkInstancePoolDetails.
+        A user-friendly name for the instance pool. Does not have to be unique, and it's
+        changeable. Avoid entering confidential information.
+
+
+        :return: The display_name of this UpdateClusterNetworkInstancePoolDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this UpdateClusterNetworkInstancePoolDetails.
+        A user-friendly name for the instance pool. Does not have to be unique, and it's
+        changeable. Avoid entering confidential information.
+
+
+        :param display_name: The display_name of this UpdateClusterNetworkInstancePoolDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def freeform_tags(self):
+        """
+        Gets the freeform_tags of this UpdateClusterNetworkInstancePoolDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm
+
+
+        :return: The freeform_tags of this UpdateClusterNetworkInstancePoolDetails.
+        :rtype: dict(str, str)
+        """
+        return self._freeform_tags
+
+    @freeform_tags.setter
+    def freeform_tags(self, freeform_tags):
+        """
+        Sets the freeform_tags of this UpdateClusterNetworkInstancePoolDetails.
+        Free-form tags for this resource. Each tag is a simple key-value pair with no
+        predefined name, type, or namespace. For more information, see `Resource Tags`__.
+
+        Example: `{\"Department\": \"Finance\"}`
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm
+
+
+        :param freeform_tags: The freeform_tags of this UpdateClusterNetworkInstancePoolDetails.
+        :type: dict(str, str)
+        """
+        self._freeform_tags = freeform_tags
+
+    @property
+    def size(self):
+        """
+        Gets the size of this UpdateClusterNetworkInstancePoolDetails.
+        The number of instances that should be in the instance pool.
+
+
+        :return: The size of this UpdateClusterNetworkInstancePoolDetails.
+        :rtype: int
+        """
+        return self._size
+
+    @size.setter
+    def size(self, size):
+        """
+        Sets the size of this UpdateClusterNetworkInstancePoolDetails.
+        The number of instances that should be in the instance pool.
+
+
+        :param size: The size of this UpdateClusterNetworkInstancePoolDetails.
+        :type: int
+        """
+        self._size = size
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/virtual_network_client.py
+++ b/src/oci/core/virtual_network_client.py
@@ -16259,18 +16259,13 @@ class VirtualNetworkClient(object):
                 header_params=header_params,
                 response_type="list[VirtualCircuit]")
 
-    def list_vlans(self, compartment_id, vcn_id, **kwargs):
+    def list_vlans(self, compartment_id, **kwargs):
         """
         Lists the VLANs in the specified VCN and the specified compartment.
 
 
         :param str compartment_id: (required)
             The `OCID`__ of the compartment.
-
-            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
-
-        :param str vcn_id: (required)
-            The `OCID`__ of the VCN.
 
             __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
@@ -16289,6 +16284,11 @@ class VirtualNetworkClient(object):
             `List Pagination`__.
 
             __ https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine
+
+        :param str vcn_id: (optional)
+            The `OCID`__ of the VCN.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param str display_name: (optional)
             A filter to return only resources that match the given display name exactly.
@@ -16343,6 +16343,7 @@ class VirtualNetworkClient(object):
             "retry_strategy",
             "limit",
             "page",
+            "vcn_id",
             "display_name",
             "sort_by",
             "sort_order",
@@ -16379,7 +16380,7 @@ class VirtualNetworkClient(object):
             "compartmentId": compartment_id,
             "limit": kwargs.get("limit", missing),
             "page": kwargs.get("page", missing),
-            "vcnId": vcn_id,
+            "vcnId": kwargs.get("vcn_id", missing),
             "displayName": kwargs.get("display_name", missing),
             "sortBy": kwargs.get("sort_by", missing),
             "sortOrder": kwargs.get("sort_order", missing),

--- a/src/oci/database/models/external_container_database.py
+++ b/src/oci/database/models/external_container_database.py
@@ -57,6 +57,14 @@ class ExternalContainerDatabase(object):
     #: This constant has a value of "ENTERPRISE_EDITION_EXTREME_PERFORMANCE"
     DATABASE_EDITION_ENTERPRISE_EDITION_EXTREME_PERFORMANCE = "ENTERPRISE_EDITION_EXTREME_PERFORMANCE"
 
+    #: A constant which can be used with the database_configuration property of a ExternalContainerDatabase.
+    #: This constant has a value of "RAC"
+    DATABASE_CONFIGURATION_RAC = "RAC"
+
+    #: A constant which can be used with the database_configuration property of a ExternalContainerDatabase.
+    #: This constant has a value of "SINGLE_INSTANCE"
+    DATABASE_CONFIGURATION_SINGLE_INSTANCE = "SINGLE_INSTANCE"
+
     def __init__(self, **kwargs):
         """
         Initializes a new ExternalContainerDatabase object with values from keyword arguments.
@@ -130,6 +138,12 @@ class ExternalContainerDatabase(object):
             The value to assign to the db_packs property of this ExternalContainerDatabase.
         :type db_packs: str
 
+        :param database_configuration:
+            The value to assign to the database_configuration property of this ExternalContainerDatabase.
+            Allowed values for this property are: "RAC", "SINGLE_INSTANCE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type database_configuration: str
+
         :param database_management_config:
             The value to assign to the database_management_config property of this ExternalContainerDatabase.
         :type database_management_config: oci.database.models.DatabaseManagementConfig
@@ -152,6 +166,7 @@ class ExternalContainerDatabase(object):
             'character_set': 'str',
             'ncharacter_set': 'str',
             'db_packs': 'str',
+            'database_configuration': 'str',
             'database_management_config': 'DatabaseManagementConfig'
         }
 
@@ -172,6 +187,7 @@ class ExternalContainerDatabase(object):
             'character_set': 'characterSet',
             'ncharacter_set': 'ncharacterSet',
             'db_packs': 'dbPacks',
+            'database_configuration': 'databaseConfiguration',
             'database_management_config': 'databaseManagementConfig'
         }
 
@@ -191,6 +207,7 @@ class ExternalContainerDatabase(object):
         self._character_set = None
         self._ncharacter_set = None
         self._db_packs = None
+        self._database_configuration = None
         self._database_management_config = None
 
     @property
@@ -616,6 +633,36 @@ class ExternalContainerDatabase(object):
         :type: str
         """
         self._db_packs = db_packs
+
+    @property
+    def database_configuration(self):
+        """
+        Gets the database_configuration of this ExternalContainerDatabase.
+        The Oracle Database configuration
+
+        Allowed values for this property are: "RAC", "SINGLE_INSTANCE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The database_configuration of this ExternalContainerDatabase.
+        :rtype: str
+        """
+        return self._database_configuration
+
+    @database_configuration.setter
+    def database_configuration(self, database_configuration):
+        """
+        Sets the database_configuration of this ExternalContainerDatabase.
+        The Oracle Database configuration
+
+
+        :param database_configuration: The database_configuration of this ExternalContainerDatabase.
+        :type: str
+        """
+        allowed_values = ["RAC", "SINGLE_INSTANCE"]
+        if not value_allowed_none_or_none_sentinel(database_configuration, allowed_values):
+            database_configuration = 'UNKNOWN_ENUM_VALUE'
+        self._database_configuration = database_configuration
 
     @property
     def database_management_config(self):

--- a/src/oci/database/models/external_container_database_summary.py
+++ b/src/oci/database/models/external_container_database_summary.py
@@ -57,6 +57,14 @@ class ExternalContainerDatabaseSummary(object):
     #: This constant has a value of "ENTERPRISE_EDITION_EXTREME_PERFORMANCE"
     DATABASE_EDITION_ENTERPRISE_EDITION_EXTREME_PERFORMANCE = "ENTERPRISE_EDITION_EXTREME_PERFORMANCE"
 
+    #: A constant which can be used with the database_configuration property of a ExternalContainerDatabaseSummary.
+    #: This constant has a value of "RAC"
+    DATABASE_CONFIGURATION_RAC = "RAC"
+
+    #: A constant which can be used with the database_configuration property of a ExternalContainerDatabaseSummary.
+    #: This constant has a value of "SINGLE_INSTANCE"
+    DATABASE_CONFIGURATION_SINGLE_INSTANCE = "SINGLE_INSTANCE"
+
     def __init__(self, **kwargs):
         """
         Initializes a new ExternalContainerDatabaseSummary object with values from keyword arguments.
@@ -130,6 +138,12 @@ class ExternalContainerDatabaseSummary(object):
             The value to assign to the db_packs property of this ExternalContainerDatabaseSummary.
         :type db_packs: str
 
+        :param database_configuration:
+            The value to assign to the database_configuration property of this ExternalContainerDatabaseSummary.
+            Allowed values for this property are: "RAC", "SINGLE_INSTANCE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type database_configuration: str
+
         :param database_management_config:
             The value to assign to the database_management_config property of this ExternalContainerDatabaseSummary.
         :type database_management_config: oci.database.models.DatabaseManagementConfig
@@ -152,6 +166,7 @@ class ExternalContainerDatabaseSummary(object):
             'character_set': 'str',
             'ncharacter_set': 'str',
             'db_packs': 'str',
+            'database_configuration': 'str',
             'database_management_config': 'DatabaseManagementConfig'
         }
 
@@ -172,6 +187,7 @@ class ExternalContainerDatabaseSummary(object):
             'character_set': 'characterSet',
             'ncharacter_set': 'ncharacterSet',
             'db_packs': 'dbPacks',
+            'database_configuration': 'databaseConfiguration',
             'database_management_config': 'databaseManagementConfig'
         }
 
@@ -191,6 +207,7 @@ class ExternalContainerDatabaseSummary(object):
         self._character_set = None
         self._ncharacter_set = None
         self._db_packs = None
+        self._database_configuration = None
         self._database_management_config = None
 
     @property
@@ -616,6 +633,36 @@ class ExternalContainerDatabaseSummary(object):
         :type: str
         """
         self._db_packs = db_packs
+
+    @property
+    def database_configuration(self):
+        """
+        Gets the database_configuration of this ExternalContainerDatabaseSummary.
+        The Oracle Database configuration
+
+        Allowed values for this property are: "RAC", "SINGLE_INSTANCE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The database_configuration of this ExternalContainerDatabaseSummary.
+        :rtype: str
+        """
+        return self._database_configuration
+
+    @database_configuration.setter
+    def database_configuration(self, database_configuration):
+        """
+        Sets the database_configuration of this ExternalContainerDatabaseSummary.
+        The Oracle Database configuration
+
+
+        :param database_configuration: The database_configuration of this ExternalContainerDatabaseSummary.
+        :type: str
+        """
+        allowed_values = ["RAC", "SINGLE_INSTANCE"]
+        if not value_allowed_none_or_none_sentinel(database_configuration, allowed_values):
+            database_configuration = 'UNKNOWN_ENUM_VALUE'
+        self._database_configuration = database_configuration
 
     @property
     def database_management_config(self):

--- a/src/oci/database/models/external_database_base.py
+++ b/src/oci/database/models/external_database_base.py
@@ -57,6 +57,14 @@ class ExternalDatabaseBase(object):
     #: This constant has a value of "ENTERPRISE_EDITION_EXTREME_PERFORMANCE"
     DATABASE_EDITION_ENTERPRISE_EDITION_EXTREME_PERFORMANCE = "ENTERPRISE_EDITION_EXTREME_PERFORMANCE"
 
+    #: A constant which can be used with the database_configuration property of a ExternalDatabaseBase.
+    #: This constant has a value of "RAC"
+    DATABASE_CONFIGURATION_RAC = "RAC"
+
+    #: A constant which can be used with the database_configuration property of a ExternalDatabaseBase.
+    #: This constant has a value of "SINGLE_INSTANCE"
+    DATABASE_CONFIGURATION_SINGLE_INSTANCE = "SINGLE_INSTANCE"
+
     def __init__(self, **kwargs):
         """
         Initializes a new ExternalDatabaseBase object with values from keyword arguments.
@@ -128,6 +136,11 @@ class ExternalDatabaseBase(object):
             The value to assign to the db_packs property of this ExternalDatabaseBase.
         :type db_packs: str
 
+        :param database_configuration:
+            The value to assign to the database_configuration property of this ExternalDatabaseBase.
+            Allowed values for this property are: "RAC", "SINGLE_INSTANCE"
+        :type database_configuration: str
+
         :param database_management_config:
             The value to assign to the database_management_config property of this ExternalDatabaseBase.
         :type database_management_config: oci.database.models.DatabaseManagementConfig
@@ -150,6 +163,7 @@ class ExternalDatabaseBase(object):
             'character_set': 'str',
             'ncharacter_set': 'str',
             'db_packs': 'str',
+            'database_configuration': 'str',
             'database_management_config': 'DatabaseManagementConfig'
         }
 
@@ -170,6 +184,7 @@ class ExternalDatabaseBase(object):
             'character_set': 'characterSet',
             'ncharacter_set': 'ncharacterSet',
             'db_packs': 'dbPacks',
+            'database_configuration': 'databaseConfiguration',
             'database_management_config': 'databaseManagementConfig'
         }
 
@@ -189,6 +204,7 @@ class ExternalDatabaseBase(object):
         self._character_set = None
         self._ncharacter_set = None
         self._db_packs = None
+        self._database_configuration = None
         self._database_management_config = None
 
     @property
@@ -618,6 +634,38 @@ class ExternalDatabaseBase(object):
         :type: str
         """
         self._db_packs = db_packs
+
+    @property
+    def database_configuration(self):
+        """
+        Gets the database_configuration of this ExternalDatabaseBase.
+        The Oracle Database configuration
+
+        Allowed values for this property are: "RAC", "SINGLE_INSTANCE"
+
+
+        :return: The database_configuration of this ExternalDatabaseBase.
+        :rtype: str
+        """
+        return self._database_configuration
+
+    @database_configuration.setter
+    def database_configuration(self, database_configuration):
+        """
+        Sets the database_configuration of this ExternalDatabaseBase.
+        The Oracle Database configuration
+
+
+        :param database_configuration: The database_configuration of this ExternalDatabaseBase.
+        :type: str
+        """
+        allowed_values = ["RAC", "SINGLE_INSTANCE"]
+        if not value_allowed_none_or_none_sentinel(database_configuration, allowed_values):
+            raise ValueError(
+                "Invalid value for `database_configuration`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._database_configuration = database_configuration
 
     @property
     def database_management_config(self):

--- a/src/oci/database/models/external_non_container_database.py
+++ b/src/oci/database/models/external_non_container_database.py
@@ -57,6 +57,14 @@ class ExternalNonContainerDatabase(object):
     #: This constant has a value of "ENTERPRISE_EDITION_EXTREME_PERFORMANCE"
     DATABASE_EDITION_ENTERPRISE_EDITION_EXTREME_PERFORMANCE = "ENTERPRISE_EDITION_EXTREME_PERFORMANCE"
 
+    #: A constant which can be used with the database_configuration property of a ExternalNonContainerDatabase.
+    #: This constant has a value of "RAC"
+    DATABASE_CONFIGURATION_RAC = "RAC"
+
+    #: A constant which can be used with the database_configuration property of a ExternalNonContainerDatabase.
+    #: This constant has a value of "SINGLE_INSTANCE"
+    DATABASE_CONFIGURATION_SINGLE_INSTANCE = "SINGLE_INSTANCE"
+
     def __init__(self, **kwargs):
         """
         Initializes a new ExternalNonContainerDatabase object with values from keyword arguments.
@@ -134,6 +142,12 @@ class ExternalNonContainerDatabase(object):
             The value to assign to the db_packs property of this ExternalNonContainerDatabase.
         :type db_packs: str
 
+        :param database_configuration:
+            The value to assign to the database_configuration property of this ExternalNonContainerDatabase.
+            Allowed values for this property are: "RAC", "SINGLE_INSTANCE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type database_configuration: str
+
         :param database_management_config:
             The value to assign to the database_management_config property of this ExternalNonContainerDatabase.
         :type database_management_config: oci.database.models.DatabaseManagementConfig
@@ -157,6 +171,7 @@ class ExternalNonContainerDatabase(object):
             'character_set': 'str',
             'ncharacter_set': 'str',
             'db_packs': 'str',
+            'database_configuration': 'str',
             'database_management_config': 'DatabaseManagementConfig'
         }
 
@@ -178,6 +193,7 @@ class ExternalNonContainerDatabase(object):
             'character_set': 'characterSet',
             'ncharacter_set': 'ncharacterSet',
             'db_packs': 'dbPacks',
+            'database_configuration': 'databaseConfiguration',
             'database_management_config': 'databaseManagementConfig'
         }
 
@@ -198,6 +214,7 @@ class ExternalNonContainerDatabase(object):
         self._character_set = None
         self._ncharacter_set = None
         self._db_packs = None
+        self._database_configuration = None
         self._database_management_config = None
 
     @property
@@ -643,6 +660,36 @@ class ExternalNonContainerDatabase(object):
         :type: str
         """
         self._db_packs = db_packs
+
+    @property
+    def database_configuration(self):
+        """
+        Gets the database_configuration of this ExternalNonContainerDatabase.
+        The Oracle Database configuration
+
+        Allowed values for this property are: "RAC", "SINGLE_INSTANCE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The database_configuration of this ExternalNonContainerDatabase.
+        :rtype: str
+        """
+        return self._database_configuration
+
+    @database_configuration.setter
+    def database_configuration(self, database_configuration):
+        """
+        Sets the database_configuration of this ExternalNonContainerDatabase.
+        The Oracle Database configuration
+
+
+        :param database_configuration: The database_configuration of this ExternalNonContainerDatabase.
+        :type: str
+        """
+        allowed_values = ["RAC", "SINGLE_INSTANCE"]
+        if not value_allowed_none_or_none_sentinel(database_configuration, allowed_values):
+            database_configuration = 'UNKNOWN_ENUM_VALUE'
+        self._database_configuration = database_configuration
 
     @property
     def database_management_config(self):

--- a/src/oci/database/models/external_non_container_database_summary.py
+++ b/src/oci/database/models/external_non_container_database_summary.py
@@ -58,6 +58,14 @@ class ExternalNonContainerDatabaseSummary(object):
     #: This constant has a value of "ENTERPRISE_EDITION_EXTREME_PERFORMANCE"
     DATABASE_EDITION_ENTERPRISE_EDITION_EXTREME_PERFORMANCE = "ENTERPRISE_EDITION_EXTREME_PERFORMANCE"
 
+    #: A constant which can be used with the database_configuration property of a ExternalNonContainerDatabaseSummary.
+    #: This constant has a value of "RAC"
+    DATABASE_CONFIGURATION_RAC = "RAC"
+
+    #: A constant which can be used with the database_configuration property of a ExternalNonContainerDatabaseSummary.
+    #: This constant has a value of "SINGLE_INSTANCE"
+    DATABASE_CONFIGURATION_SINGLE_INSTANCE = "SINGLE_INSTANCE"
+
     def __init__(self, **kwargs):
         """
         Initializes a new ExternalNonContainerDatabaseSummary object with values from keyword arguments.
@@ -135,6 +143,12 @@ class ExternalNonContainerDatabaseSummary(object):
             The value to assign to the db_packs property of this ExternalNonContainerDatabaseSummary.
         :type db_packs: str
 
+        :param database_configuration:
+            The value to assign to the database_configuration property of this ExternalNonContainerDatabaseSummary.
+            Allowed values for this property are: "RAC", "SINGLE_INSTANCE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type database_configuration: str
+
         :param database_management_config:
             The value to assign to the database_management_config property of this ExternalNonContainerDatabaseSummary.
         :type database_management_config: oci.database.models.DatabaseManagementConfig
@@ -158,6 +172,7 @@ class ExternalNonContainerDatabaseSummary(object):
             'character_set': 'str',
             'ncharacter_set': 'str',
             'db_packs': 'str',
+            'database_configuration': 'str',
             'database_management_config': 'DatabaseManagementConfig'
         }
 
@@ -179,6 +194,7 @@ class ExternalNonContainerDatabaseSummary(object):
             'character_set': 'characterSet',
             'ncharacter_set': 'ncharacterSet',
             'db_packs': 'dbPacks',
+            'database_configuration': 'databaseConfiguration',
             'database_management_config': 'databaseManagementConfig'
         }
 
@@ -199,6 +215,7 @@ class ExternalNonContainerDatabaseSummary(object):
         self._character_set = None
         self._ncharacter_set = None
         self._db_packs = None
+        self._database_configuration = None
         self._database_management_config = None
 
     @property
@@ -644,6 +661,36 @@ class ExternalNonContainerDatabaseSummary(object):
         :type: str
         """
         self._db_packs = db_packs
+
+    @property
+    def database_configuration(self):
+        """
+        Gets the database_configuration of this ExternalNonContainerDatabaseSummary.
+        The Oracle Database configuration
+
+        Allowed values for this property are: "RAC", "SINGLE_INSTANCE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The database_configuration of this ExternalNonContainerDatabaseSummary.
+        :rtype: str
+        """
+        return self._database_configuration
+
+    @database_configuration.setter
+    def database_configuration(self, database_configuration):
+        """
+        Sets the database_configuration of this ExternalNonContainerDatabaseSummary.
+        The Oracle Database configuration
+
+
+        :param database_configuration: The database_configuration of this ExternalNonContainerDatabaseSummary.
+        :type: str
+        """
+        allowed_values = ["RAC", "SINGLE_INSTANCE"]
+        if not value_allowed_none_or_none_sentinel(database_configuration, allowed_values):
+            database_configuration = 'UNKNOWN_ENUM_VALUE'
+        self._database_configuration = database_configuration
 
     @property
     def database_management_config(self):

--- a/src/oci/database/models/external_pluggable_database.py
+++ b/src/oci/database/models/external_pluggable_database.py
@@ -57,6 +57,14 @@ class ExternalPluggableDatabase(object):
     #: This constant has a value of "ENTERPRISE_EDITION_EXTREME_PERFORMANCE"
     DATABASE_EDITION_ENTERPRISE_EDITION_EXTREME_PERFORMANCE = "ENTERPRISE_EDITION_EXTREME_PERFORMANCE"
 
+    #: A constant which can be used with the database_configuration property of a ExternalPluggableDatabase.
+    #: This constant has a value of "RAC"
+    DATABASE_CONFIGURATION_RAC = "RAC"
+
+    #: A constant which can be used with the database_configuration property of a ExternalPluggableDatabase.
+    #: This constant has a value of "SINGLE_INSTANCE"
+    DATABASE_CONFIGURATION_SINGLE_INSTANCE = "SINGLE_INSTANCE"
+
     def __init__(self, **kwargs):
         """
         Initializes a new ExternalPluggableDatabase object with values from keyword arguments.
@@ -142,6 +150,12 @@ class ExternalPluggableDatabase(object):
             The value to assign to the db_packs property of this ExternalPluggableDatabase.
         :type db_packs: str
 
+        :param database_configuration:
+            The value to assign to the database_configuration property of this ExternalPluggableDatabase.
+            Allowed values for this property are: "RAC", "SINGLE_INSTANCE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type database_configuration: str
+
         :param database_management_config:
             The value to assign to the database_management_config property of this ExternalPluggableDatabase.
         :type database_management_config: oci.database.models.DatabaseManagementConfig
@@ -167,6 +181,7 @@ class ExternalPluggableDatabase(object):
             'character_set': 'str',
             'ncharacter_set': 'str',
             'db_packs': 'str',
+            'database_configuration': 'str',
             'database_management_config': 'DatabaseManagementConfig'
         }
 
@@ -190,6 +205,7 @@ class ExternalPluggableDatabase(object):
             'character_set': 'characterSet',
             'ncharacter_set': 'ncharacterSet',
             'db_packs': 'dbPacks',
+            'database_configuration': 'databaseConfiguration',
             'database_management_config': 'databaseManagementConfig'
         }
 
@@ -212,6 +228,7 @@ class ExternalPluggableDatabase(object):
         self._character_set = None
         self._ncharacter_set = None
         self._db_packs = None
+        self._database_configuration = None
         self._database_management_config = None
 
     @property
@@ -719,6 +736,36 @@ class ExternalPluggableDatabase(object):
         :type: str
         """
         self._db_packs = db_packs
+
+    @property
+    def database_configuration(self):
+        """
+        Gets the database_configuration of this ExternalPluggableDatabase.
+        The Oracle Database configuration
+
+        Allowed values for this property are: "RAC", "SINGLE_INSTANCE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The database_configuration of this ExternalPluggableDatabase.
+        :rtype: str
+        """
+        return self._database_configuration
+
+    @database_configuration.setter
+    def database_configuration(self, database_configuration):
+        """
+        Sets the database_configuration of this ExternalPluggableDatabase.
+        The Oracle Database configuration
+
+
+        :param database_configuration: The database_configuration of this ExternalPluggableDatabase.
+        :type: str
+        """
+        allowed_values = ["RAC", "SINGLE_INSTANCE"]
+        if not value_allowed_none_or_none_sentinel(database_configuration, allowed_values):
+            database_configuration = 'UNKNOWN_ENUM_VALUE'
+        self._database_configuration = database_configuration
 
     @property
     def database_management_config(self):

--- a/src/oci/database/models/external_pluggable_database_summary.py
+++ b/src/oci/database/models/external_pluggable_database_summary.py
@@ -57,6 +57,14 @@ class ExternalPluggableDatabaseSummary(object):
     #: This constant has a value of "ENTERPRISE_EDITION_EXTREME_PERFORMANCE"
     DATABASE_EDITION_ENTERPRISE_EDITION_EXTREME_PERFORMANCE = "ENTERPRISE_EDITION_EXTREME_PERFORMANCE"
 
+    #: A constant which can be used with the database_configuration property of a ExternalPluggableDatabaseSummary.
+    #: This constant has a value of "RAC"
+    DATABASE_CONFIGURATION_RAC = "RAC"
+
+    #: A constant which can be used with the database_configuration property of a ExternalPluggableDatabaseSummary.
+    #: This constant has a value of "SINGLE_INSTANCE"
+    DATABASE_CONFIGURATION_SINGLE_INSTANCE = "SINGLE_INSTANCE"
+
     def __init__(self, **kwargs):
         """
         Initializes a new ExternalPluggableDatabaseSummary object with values from keyword arguments.
@@ -142,6 +150,12 @@ class ExternalPluggableDatabaseSummary(object):
             The value to assign to the db_packs property of this ExternalPluggableDatabaseSummary.
         :type db_packs: str
 
+        :param database_configuration:
+            The value to assign to the database_configuration property of this ExternalPluggableDatabaseSummary.
+            Allowed values for this property are: "RAC", "SINGLE_INSTANCE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type database_configuration: str
+
         :param database_management_config:
             The value to assign to the database_management_config property of this ExternalPluggableDatabaseSummary.
         :type database_management_config: oci.database.models.DatabaseManagementConfig
@@ -167,6 +181,7 @@ class ExternalPluggableDatabaseSummary(object):
             'character_set': 'str',
             'ncharacter_set': 'str',
             'db_packs': 'str',
+            'database_configuration': 'str',
             'database_management_config': 'DatabaseManagementConfig'
         }
 
@@ -190,6 +205,7 @@ class ExternalPluggableDatabaseSummary(object):
             'character_set': 'characterSet',
             'ncharacter_set': 'ncharacterSet',
             'db_packs': 'dbPacks',
+            'database_configuration': 'databaseConfiguration',
             'database_management_config': 'databaseManagementConfig'
         }
 
@@ -212,6 +228,7 @@ class ExternalPluggableDatabaseSummary(object):
         self._character_set = None
         self._ncharacter_set = None
         self._db_packs = None
+        self._database_configuration = None
         self._database_management_config = None
 
     @property
@@ -719,6 +736,36 @@ class ExternalPluggableDatabaseSummary(object):
         :type: str
         """
         self._db_packs = db_packs
+
+    @property
+    def database_configuration(self):
+        """
+        Gets the database_configuration of this ExternalPluggableDatabaseSummary.
+        The Oracle Database configuration
+
+        Allowed values for this property are: "RAC", "SINGLE_INSTANCE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The database_configuration of this ExternalPluggableDatabaseSummary.
+        :rtype: str
+        """
+        return self._database_configuration
+
+    @database_configuration.setter
+    def database_configuration(self, database_configuration):
+        """
+        Sets the database_configuration of this ExternalPluggableDatabaseSummary.
+        The Oracle Database configuration
+
+
+        :param database_configuration: The database_configuration of this ExternalPluggableDatabaseSummary.
+        :type: str
+        """
+        allowed_values = ["RAC", "SINGLE_INSTANCE"]
+        if not value_allowed_none_or_none_sentinel(database_configuration, allowed_values):
+            database_configuration = 'UNKNOWN_ENUM_VALUE'
+        self._database_configuration = database_configuration
 
     @property
     def database_management_config(self):

--- a/src/oci/database_migration/database_migration_client.py
+++ b/src/oci/database_migration/database_migration_client.py
@@ -18,7 +18,7 @@ missing = Sentinel("Missing")
 
 class DatabaseMigrationClient(object):
     """
-    Provides users the ability to perform Zero Downtime migration operations
+    Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
     """
 
     def __init__(self, config, **kwargs):
@@ -183,7 +183,7 @@ class DatabaseMigrationClient(object):
 
     def change_agent_compartment(self, agent_id, change_agent_compartment_details, **kwargs):
         """
-        Used to configure a ODMS Agent Compartment Id.
+        Used to configure an ODMS Agent Compartment ID.
 
 
         :param str agent_id: (required)
@@ -282,11 +282,11 @@ class DatabaseMigrationClient(object):
 
     def change_connection_compartment(self, connection_id, change_connection_compartment_details, **kwargs):
         """
-        Used to change the Databasee Connection compartment.
+        Used to change the Database Connection compartment.
 
 
         :param str connection_id: (required)
-            The OCID of the job
+            The OCID of the database connection
 
         :param oci.database_migration.models.ChangeConnectionCompartmentDetails change_connection_compartment_details: (required)
             Details to change the compartment.
@@ -385,7 +385,7 @@ class DatabaseMigrationClient(object):
 
 
         :param str migration_id: (required)
-            The OCID of the job
+            The OCID of the migration
 
         :param oci.database_migration.models.ChangeMigrationCompartmentDetails change_migration_compartment_details: (required)
             Details to change the compartment.
@@ -484,7 +484,7 @@ class DatabaseMigrationClient(object):
 
 
         :param str migration_id: (required)
-            The OCID of the job
+            The OCID of the migration
 
         :param oci.database_migration.models.CloneMigrationDetails clone_migration_details: (required)
             Clone Migration properties.
@@ -660,7 +660,7 @@ class DatabaseMigrationClient(object):
     def create_migration(self, create_migration_details, **kwargs):
         """
         Create a Migration resource that contains all the details to perform the
-        database migration operation like source and destination database
+        database migration operation, such as source and destination database
         details, credentials, etc.
 
 
@@ -738,7 +738,7 @@ class DatabaseMigrationClient(object):
 
     def delete_agent(self, agent_id, **kwargs):
         """
-        Delete the ODMS Agent represented by the given ODMS Agent id.
+        Delete the ODMS Agent represented by the specified ODMS Agent ID.
 
 
         :param str agent_id: (required)
@@ -825,7 +825,7 @@ class DatabaseMigrationClient(object):
 
 
         :param str connection_id: (required)
-            The OCID of the job
+            The OCID of the database connection
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
@@ -991,7 +991,7 @@ class DatabaseMigrationClient(object):
 
 
         :param str migration_id: (required)
-            The OCID of the job
+            The OCID of the migration
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
@@ -1074,7 +1074,7 @@ class DatabaseMigrationClient(object):
 
 
         :param str migration_id: (required)
-            The OCID of the job
+            The OCID of the migration
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call
@@ -1246,7 +1246,7 @@ class DatabaseMigrationClient(object):
 
 
         :param str connection_id: (required)
-            The OCID of the job
+            The OCID of the database connection
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
@@ -1474,7 +1474,7 @@ class DatabaseMigrationClient(object):
 
 
         :param str migration_id: (required)
-            The OCID of the job
+            The OCID of the migration
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
@@ -2825,7 +2825,7 @@ class DatabaseMigrationClient(object):
 
 
         :param str migration_id: (required)
-            The OCID of the job
+            The OCID of the migration
 
         :param str opc_request_id: (optional)
             Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
@@ -2901,7 +2901,7 @@ class DatabaseMigrationClient(object):
 
 
         :param str migration_id: (required)
-            The OCID of the job
+            The OCID of the migration
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call
@@ -2999,7 +2999,7 @@ class DatabaseMigrationClient(object):
 
     def update_agent(self, agent_id, update_agent_details, **kwargs):
         """
-        Modifies the ODMS Agent represented by the given ODMS agent Id.
+        Modifies the ODMS Agent represented by the given ODMS Agent ID.
 
 
         :param str agent_id: (required)
@@ -3100,11 +3100,11 @@ class DatabaseMigrationClient(object):
 
     def update_connection(self, connection_id, update_connection_details, **kwargs):
         """
-        Update a Database Connection resource details.
+        Update Database Connection resource details.
 
 
         :param str connection_id: (required)
-            The OCID of the job
+            The OCID of the database connection
 
         :param oci.database_migration.models.UpdateConnectionDetails update_connection_details: (required)
             Database Connection properties.
@@ -3188,7 +3188,7 @@ class DatabaseMigrationClient(object):
 
     def update_job(self, job_id, update_job_details, **kwargs):
         """
-        Update a Migration Job resource details.
+        Update Migration Job resource details.
 
 
         :param str job_id: (required)
@@ -3278,11 +3278,11 @@ class DatabaseMigrationClient(object):
 
     def update_migration(self, migration_id, update_migration_details, **kwargs):
         """
-        Update a Migration resource details.
+        Update Migration resource details.
 
 
         :param str migration_id: (required)
-            The OCID of the job
+            The OCID of the migration
 
         :param oci.database_migration.models.UpdateMigrationDetails update_migration_details: (required)
             Migration properties.

--- a/src/oci/database_migration/database_migration_client_composite_operations.py
+++ b/src/oci/database_migration/database_migration_client_composite_operations.py
@@ -67,7 +67,7 @@ class DatabaseMigrationClientCompositeOperations(object):
         to enter the given state(s).
 
         :param str migration_id: (required)
-            The OCID of the job
+            The OCID of the migration
 
         :param oci.database_migration.models.CloneMigrationDetails clone_migration_details: (required)
             Clone Migration properties.
@@ -230,7 +230,7 @@ class DatabaseMigrationClientCompositeOperations(object):
         to enter the given state(s).
 
         :param str connection_id: (required)
-            The OCID of the job
+            The OCID of the database connection
 
         :param list[str] wait_for_states:
             An array of states to wait on. These should be valid values for :py:attr:`~oci.database_migration.models.WorkRequest.status`
@@ -323,7 +323,7 @@ class DatabaseMigrationClientCompositeOperations(object):
         to enter the given state(s).
 
         :param str migration_id: (required)
-            The OCID of the job
+            The OCID of the migration
 
         :param list[str] wait_for_states:
             An array of states to wait on. These should be valid values for :py:attr:`~oci.database_migration.models.WorkRequest.status`
@@ -369,7 +369,7 @@ class DatabaseMigrationClientCompositeOperations(object):
         to enter the given state(s).
 
         :param str migration_id: (required)
-            The OCID of the job
+            The OCID of the migration
 
         :param list[str] wait_for_states:
             An array of states to wait on. These should be valid values for :py:attr:`~oci.database_migration.models.WorkRequest.status`
@@ -445,7 +445,7 @@ class DatabaseMigrationClientCompositeOperations(object):
         to enter the given state(s).
 
         :param str migration_id: (required)
-            The OCID of the job
+            The OCID of the migration
 
         :param list[str] wait_for_states:
             An array of states to wait on. These should be valid values for :py:attr:`~oci.database_migration.models.WorkRequest.status`
@@ -524,7 +524,7 @@ class DatabaseMigrationClientCompositeOperations(object):
         to enter the given state(s).
 
         :param str connection_id: (required)
-            The OCID of the job
+            The OCID of the database connection
 
         :param oci.database_migration.models.UpdateConnectionDetails update_connection_details: (required)
             Database Connection properties.
@@ -606,7 +606,7 @@ class DatabaseMigrationClientCompositeOperations(object):
         to enter the given state(s).
 
         :param str migration_id: (required)
-            The OCID of the job
+            The OCID of the migration
 
         :param oci.database_migration.models.UpdateMigrationDetails update_migration_details: (required)
             Migration properties.

--- a/src/oci/database_migration/models/admin_credentials.py
+++ b/src/oci/database_migration/models/admin_credentials.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class AdminCredentials(object):
     """
-    Database Admin Credentials details.
+    Database Administrator Credentials details.
     """
 
     def __init__(self, **kwargs):
@@ -37,7 +37,7 @@ class AdminCredentials(object):
     def username(self):
         """
         **[Required]** Gets the username of this AdminCredentials.
-        Admin username
+        Administrator username
 
 
         :return: The username of this AdminCredentials.
@@ -49,7 +49,7 @@ class AdminCredentials(object):
     def username(self, username):
         """
         Sets the username of this AdminCredentials.
-        Admin username
+        Administrator username
 
 
         :param username: The username of this AdminCredentials.

--- a/src/oci/database_migration/models/agent.py
+++ b/src/oci/database_migration/models/agent.py
@@ -343,7 +343,7 @@ class Agent(object):
     def lifecycle_state(self):
         """
         **[Required]** Gets the lifecycle_state of this Agent.
-        The current state of the ODMS On Prem Agent.
+        The current state of the ODMS on-premises Agent.
 
         Allowed values for this property are: "CREATING", "UPDATING", "ACTIVE", "INACTIVE", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -358,7 +358,7 @@ class Agent(object):
     def lifecycle_state(self, lifecycle_state):
         """
         Sets the lifecycle_state of this Agent.
-        The current state of the ODMS On Prem Agent.
+        The current state of the ODMS on-premises Agent.
 
 
         :param lifecycle_state: The lifecycle_state of this Agent.

--- a/src/oci/database_migration/models/agent_collection.py
+++ b/src/oci/database_migration/models/agent_collection.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class AgentCollection(object):
     """
-    Results of a Agent search. Contains AgentSummary items.
+    Results of an Agent search. Contains AgentSummary items.
     """
 
     def __init__(self, **kwargs):

--- a/src/oci/database_migration/models/agent_image_collection.py
+++ b/src/oci/database_migration/models/agent_image_collection.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class AgentImageCollection(object):
     """
-    Results of a ODMS Agent Image search. Contains AgentImageSummary items.
+    Results of an ODMS Agent Image search. Contains AgentImageSummary items.
     """
 
     def __init__(self, **kwargs):

--- a/src/oci/database_migration/models/agent_summary.py
+++ b/src/oci/database_migration/models/agent_summary.py
@@ -312,7 +312,7 @@ class AgentSummary(object):
     def lifecycle_state(self):
         """
         **[Required]** Gets the lifecycle_state of this AgentSummary.
-        The current state of the ODMS On Prem Agent.
+        The current state of the ODMS on-premises Agent.
 
         Allowed values for this property are: "CREATING", "UPDATING", "ACTIVE", "INACTIVE", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -327,7 +327,7 @@ class AgentSummary(object):
     def lifecycle_state(self, lifecycle_state):
         """
         Sets the lifecycle_state of this AgentSummary.
-        The current state of the ODMS On Prem Agent.
+        The current state of the ODMS on-premises Agent.
 
 
         :param lifecycle_state: The lifecycle_state of this AgentSummary.

--- a/src/oci/database_migration/models/change_agent_compartment_details.py
+++ b/src/oci/database_migration/models/change_agent_compartment_details.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class ChangeAgentCompartmentDetails(object):
     """
-    ChangeAgentCompartmentDetails description
+    Change Agent compartment details
     """
 
     def __init__(self, **kwargs):

--- a/src/oci/database_migration/models/clone_migration_details.py
+++ b/src/oci/database_migration/models/clone_migration_details.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class CloneMigrationDetails(object):
     """
-    Details to specify that will override an existing Migration configuration that will be cloned.
+    Details that will override an existing Migration configuration that will be cloned.
     """
 
     def __init__(self, **kwargs):
@@ -148,7 +148,7 @@ class CloneMigrationDetails(object):
     def agent_id(self):
         """
         Gets the agent_id of this CloneMigrationDetails.
-        The OCID of the registered On-Prem ODMS Agent. Required for OFFLINE Migrations.
+        The OCID of the registered on-premises ODMS Agent. Only valid for Offline Logical Migrations.
 
 
         :return: The agent_id of this CloneMigrationDetails.
@@ -160,7 +160,7 @@ class CloneMigrationDetails(object):
     def agent_id(self, agent_id):
         """
         Sets the agent_id of this CloneMigrationDetails.
-        The OCID of the registered On-Prem ODMS Agent. Required for OFFLINE Migrations.
+        The OCID of the registered on-premises ODMS Agent. Only valid for Offline Logical Migrations.
 
 
         :param agent_id: The agent_id of this CloneMigrationDetails.
@@ -196,7 +196,7 @@ class CloneMigrationDetails(object):
     def source_container_database_connection_id(self):
         """
         Gets the source_container_database_connection_id of this CloneMigrationDetails.
-        The OCID of the Source Container Database Connection. Only used for ONLINE migrations.
+        The OCID of the Source Container Database Connection. Only used for Online migrations.
         Only Connections of type Non-Autonomous can be used as source container databases.
 
 
@@ -209,7 +209,7 @@ class CloneMigrationDetails(object):
     def source_container_database_connection_id(self, source_container_database_connection_id):
         """
         Sets the source_container_database_connection_id of this CloneMigrationDetails.
-        The OCID of the Source Container Database Connection. Only used for ONLINE migrations.
+        The OCID of the Source Container Database Connection. Only used for Online migrations.
         Only Connections of type Non-Autonomous can be used as source container databases.
 
 

--- a/src/oci/database_migration/models/create_admin_credentials.py
+++ b/src/oci/database_migration/models/create_admin_credentials.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class CreateAdminCredentials(object):
     """
-    Database Admin Credentials details.
+    Database Administrator Credentials details.
     """
 
     def __init__(self, **kwargs):
@@ -44,7 +44,7 @@ class CreateAdminCredentials(object):
     def username(self):
         """
         **[Required]** Gets the username of this CreateAdminCredentials.
-        Admin username
+        Administrator username
 
 
         :return: The username of this CreateAdminCredentials.
@@ -56,7 +56,7 @@ class CreateAdminCredentials(object):
     def username(self, username):
         """
         Sets the username of this CreateAdminCredentials.
-        Admin username
+        Administrator username
 
 
         :param username: The username of this CreateAdminCredentials.
@@ -68,7 +68,7 @@ class CreateAdminCredentials(object):
     def password(self):
         """
         **[Required]** Gets the password of this CreateAdminCredentials.
-        Admin password
+        Administrator password
 
 
         :return: The password of this CreateAdminCredentials.
@@ -80,7 +80,7 @@ class CreateAdminCredentials(object):
     def password(self, password):
         """
         Sets the password of this CreateAdminCredentials.
-        Admin password
+        Administrator password
 
 
         :param password: The password of this CreateAdminCredentials.

--- a/src/oci/database_migration/models/create_data_pump_parameters.py
+++ b/src/oci/database_migration/models/create_data_pump_parameters.py
@@ -10,7 +10,9 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class CreateDataPumpParameters(object):
     """
-    Optional parameters for Datapump Export and Import. Refer to https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/ODMS_DATAPUMP.html#GUID-62324358-2F26-4A94-B69F-1075D53FA96D__BABDECJE
+    Optional parameters for Data Pump Export and Import. Refer to `Configuring Optional Initial Load Advanced Settings`__
+
+    __ https://docs.us.oracle.com/en/cloud/paas/database-migration/dmsus/working-migration-resources.html#GUID-24BD3054-FDF8-48FF-8492-636C1D4B71ED
     """
 
     #: A constant which can be used with the estimate property of a CreateDataPumpParameters.
@@ -98,7 +100,7 @@ class CreateDataPumpParameters(object):
     def is_cluster(self):
         """
         Gets the is_cluster of this CreateDataPumpParameters.
-        False to force datapump worker process to run on one instance.
+        Set to false to force Data Pump worker process to run on one instance.
 
 
         :return: The is_cluster of this CreateDataPumpParameters.
@@ -110,7 +112,7 @@ class CreateDataPumpParameters(object):
     def is_cluster(self, is_cluster):
         """
         Sets the is_cluster of this CreateDataPumpParameters.
-        False to force datapump worker process to run on one instance.
+        Set to false to force Data Pump worker process to run on one instance.
 
 
         :param is_cluster: The is_cluster of this CreateDataPumpParameters.
@@ -186,7 +188,7 @@ class CreateDataPumpParameters(object):
     def exclude_parameters(self):
         """
         Gets the exclude_parameters of this CreateDataPumpParameters.
-        Exclude paratemers for export and import.
+        Exclude paratemers for Export and Import.
 
 
         :return: The exclude_parameters of this CreateDataPumpParameters.
@@ -198,7 +200,7 @@ class CreateDataPumpParameters(object):
     def exclude_parameters(self, exclude_parameters):
         """
         Sets the exclude_parameters of this CreateDataPumpParameters.
-        Exclude paratemers for export and import.
+        Exclude paratemers for Export and Import.
 
 
         :param exclude_parameters: The exclude_parameters of this CreateDataPumpParameters.
@@ -210,7 +212,7 @@ class CreateDataPumpParameters(object):
     def import_parallelism_degree(self):
         """
         Gets the import_parallelism_degree of this CreateDataPumpParameters.
-        Maximum number of worker processes that can be used for a Datapump Import job.
+        Maximum number of worker processes that can be used for a Data Pump Import job.
         For an Autonomous Database, ODMS will automatically query its CPU core count and set this property.
 
 
@@ -223,7 +225,7 @@ class CreateDataPumpParameters(object):
     def import_parallelism_degree(self, import_parallelism_degree):
         """
         Sets the import_parallelism_degree of this CreateDataPumpParameters.
-        Maximum number of worker processes that can be used for a Datapump Import job.
+        Maximum number of worker processes that can be used for a Data Pump Import job.
         For an Autonomous Database, ODMS will automatically query its CPU core count and set this property.
 
 
@@ -236,7 +238,7 @@ class CreateDataPumpParameters(object):
     def export_parallelism_degree(self):
         """
         Gets the export_parallelism_degree of this CreateDataPumpParameters.
-        Maximum number of worker processes that can be used for a Datapump Export job.
+        Maximum number of worker processes that can be used for a Data Pump Export job.
 
 
         :return: The export_parallelism_degree of this CreateDataPumpParameters.
@@ -248,7 +250,7 @@ class CreateDataPumpParameters(object):
     def export_parallelism_degree(self, export_parallelism_degree):
         """
         Sets the export_parallelism_degree of this CreateDataPumpParameters.
-        Maximum number of worker processes that can be used for a Datapump Export job.
+        Maximum number of worker processes that can be used for a Data Pump Export job.
 
 
         :param export_parallelism_degree: The export_parallelism_degree of this CreateDataPumpParameters.

--- a/src/oci/database_migration/models/create_data_pump_settings.py
+++ b/src/oci/database_migration/models/create_data_pump_settings.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class CreateDataPumpSettings(object):
     """
-    Optional settings for Datapump Export and Import jobs
+    Optional settings for Data Pump Export and Import jobs
     """
 
     #: A constant which can be used with the job_mode property of a CreateDataPumpSettings.
@@ -86,8 +86,10 @@ class CreateDataPumpSettings(object):
     def job_mode(self):
         """
         Gets the job_mode of this CreateDataPumpSettings.
-        DataPump job mode.
-        Refer to docs.oracle.com/en/database/oracle/oracle-database/19/arpls/ODMS_DATAPUMP.html#GUID-92C2CB46-8BC9-414D-B62E-79CD788C1E62__BABBDEHD
+        Data Pump job mode.
+        Refer to `link text`__
+
+        __ https://docs.oracle.com/en/database/oracle/oracle-database/19/sutil/oracle-data-pump-export-utility.html#GUID-8E497131-6B9B-4CC8-AA50-35F480CAC2C4
 
         Allowed values for this property are: "FULL", "SCHEMA", "TABLE", "TABLESPACE", "TRANSPORTABLE"
 
@@ -101,8 +103,10 @@ class CreateDataPumpSettings(object):
     def job_mode(self, job_mode):
         """
         Sets the job_mode of this CreateDataPumpSettings.
-        DataPump job mode.
-        Refer to docs.oracle.com/en/database/oracle/oracle-database/19/arpls/ODMS_DATAPUMP.html#GUID-92C2CB46-8BC9-414D-B62E-79CD788C1E62__BABBDEHD
+        Data Pump job mode.
+        Refer to `link text`__
+
+        __ https://docs.oracle.com/en/database/oracle/oracle-database/19/sutil/oracle-data-pump-export-utility.html#GUID-8E497131-6B9B-4CC8-AA50-35F480CAC2C4
 
 
         :param job_mode: The job_mode of this CreateDataPumpSettings.
@@ -141,7 +145,9 @@ class CreateDataPumpSettings(object):
         """
         Gets the metadata_remaps of this CreateDataPumpSettings.
         Defines remapping to be applied to objects as they are processed.
-        Refer to https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/ODMS_DATAPUMP.html#GUID-0FC32790-91E6-4781-87A3-229DE024CB3D.
+        Refer to `DATA_REMAP`__
+
+        __ https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/DBMS_DATAPUMP.html#GUID-E75AAE6F-4EA6-4737-A752-6B62F5E9D460
 
 
         :return: The metadata_remaps of this CreateDataPumpSettings.
@@ -154,7 +160,9 @@ class CreateDataPumpSettings(object):
         """
         Sets the metadata_remaps of this CreateDataPumpSettings.
         Defines remapping to be applied to objects as they are processed.
-        Refer to https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/ODMS_DATAPUMP.html#GUID-0FC32790-91E6-4781-87A3-229DE024CB3D.
+        Refer to `DATA_REMAP`__
+
+        __ https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/DBMS_DATAPUMP.html#GUID-E75AAE6F-4EA6-4737-A752-6B62F5E9D460
 
 
         :param metadata_remaps: The metadata_remaps of this CreateDataPumpSettings.

--- a/src/oci/database_migration/models/create_data_transfer_medium_details.py
+++ b/src/oci/database_migration/models/create_data_transfer_medium_details.py
@@ -11,7 +11,7 @@ from oci.decorators import init_model_state_from_kwargs
 class CreateDataTransferMediumDetails(object):
     """
     Data Transfer Medium details for the Migration. If not specified, it will default to Database Link. Only one type
-    of medium details can be specified.
+    of data transfer medium can be specified.
     """
 
     def __init__(self, **kwargs):

--- a/src/oci/database_migration/models/create_extract.py
+++ b/src/oci/database_migration/models/create_extract.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class CreateExtract(object):
     """
-    Parameters for Extract processes.
+    Parameters for GoldenGate Extract processes.
     """
 
     #: A constant which can be used with the performance_profile property of a CreateExtract.

--- a/src/oci/database_migration/models/create_golden_gate_hub.py
+++ b/src/oci/database_migration/models/create_golden_gate_hub.py
@@ -166,7 +166,7 @@ class CreateGoldenGateHub(object):
     def url(self):
         """
         **[Required]** Gets the url of this CreateGoldenGateHub.
-        Oracle GoldenGate hub's REST endpoint.
+        Oracle GoldenGate Microservices hub's REST endpoint.
         Refer to https://docs.oracle.com/en/middleware/goldengate/core/19.1/securing/network.html#GUID-A709DA55-111D-455E-8942-C9BDD1E38CAA
 
 
@@ -179,7 +179,7 @@ class CreateGoldenGateHub(object):
     def url(self, url):
         """
         Sets the url of this CreateGoldenGateHub.
-        Oracle GoldenGate hub's REST endpoint.
+        Oracle GoldenGate Microservices hub's REST endpoint.
         Refer to https://docs.oracle.com/en/middleware/goldengate/core/19.1/securing/network.html#GUID-A709DA55-111D-455E-8942-C9BDD1E38CAA
 
 
@@ -192,7 +192,7 @@ class CreateGoldenGateHub(object):
     def source_microservices_deployment_name(self):
         """
         **[Required]** Gets the source_microservices_deployment_name of this CreateGoldenGateHub.
-        Name of Microservices deployment to operate on source DB
+        Name of GoldenGate Microservices deployment to operate on source database
 
 
         :return: The source_microservices_deployment_name of this CreateGoldenGateHub.
@@ -204,7 +204,7 @@ class CreateGoldenGateHub(object):
     def source_microservices_deployment_name(self, source_microservices_deployment_name):
         """
         Sets the source_microservices_deployment_name of this CreateGoldenGateHub.
-        Name of Microservices deployment to operate on source DB
+        Name of GoldenGate Microservices deployment to operate on source database
 
 
         :param source_microservices_deployment_name: The source_microservices_deployment_name of this CreateGoldenGateHub.
@@ -216,7 +216,7 @@ class CreateGoldenGateHub(object):
     def target_microservices_deployment_name(self):
         """
         **[Required]** Gets the target_microservices_deployment_name of this CreateGoldenGateHub.
-        Name of Microservices deployment to operate on target DB
+        Name of GoldenGate Microservices deployment to operate on target database
 
 
         :return: The target_microservices_deployment_name of this CreateGoldenGateHub.
@@ -228,7 +228,7 @@ class CreateGoldenGateHub(object):
     def target_microservices_deployment_name(self, target_microservices_deployment_name):
         """
         Sets the target_microservices_deployment_name of this CreateGoldenGateHub.
-        Name of Microservices deployment to operate on target DB
+        Name of GoldenGate Microservices deployment to operate on target database
 
 
         :param target_microservices_deployment_name: The target_microservices_deployment_name of this CreateGoldenGateHub.
@@ -240,7 +240,7 @@ class CreateGoldenGateHub(object):
     def compute_id(self):
         """
         Gets the compute_id of this CreateGoldenGateHub.
-        OCID of Golden Gate compute instance.
+        OCID of GoldenGate Microservices compute instance.
 
 
         :return: The compute_id of this CreateGoldenGateHub.
@@ -252,7 +252,7 @@ class CreateGoldenGateHub(object):
     def compute_id(self, compute_id):
         """
         Sets the compute_id of this CreateGoldenGateHub.
-        OCID of Golden Gate compute instance.
+        OCID of GoldenGate Microservices compute instance.
 
 
         :param compute_id: The compute_id of this CreateGoldenGateHub.

--- a/src/oci/database_migration/models/create_golden_gate_settings.py
+++ b/src/oci/database_migration/models/create_golden_gate_settings.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class CreateGoldenGateSettings(object):
     """
-    Optional settings for Oracle GoldenGate processes
+    Optional settings for GoldenGate Microservices processes
     """
 
     def __init__(self, **kwargs):

--- a/src/oci/database_migration/models/create_migration_details.py
+++ b/src/oci/database_migration/models/create_migration_details.py
@@ -217,7 +217,7 @@ class CreateMigrationDetails(object):
     def agent_id(self):
         """
         Gets the agent_id of this CreateMigrationDetails.
-        The OCID of the registered ODMS Agent. Required for OFFLINE Migrations.
+        The OCID of the registered ODMS Agent. Only valid for Offline Logical Migrations.
 
 
         :return: The agent_id of this CreateMigrationDetails.
@@ -229,7 +229,7 @@ class CreateMigrationDetails(object):
     def agent_id(self, agent_id):
         """
         Sets the agent_id of this CreateMigrationDetails.
-        The OCID of the registered ODMS Agent. Required for OFFLINE Migrations.
+        The OCID of the registered ODMS Agent. Only valid for Offline Logical Migrations.
 
 
         :param agent_id: The agent_id of this CreateMigrationDetails.
@@ -265,7 +265,7 @@ class CreateMigrationDetails(object):
     def source_container_database_connection_id(self):
         """
         Gets the source_container_database_connection_id of this CreateMigrationDetails.
-        The OCID of the Source Container Database Connection. Only used for ONLINE migrations.
+        The OCID of the Source Container Database Connection. Only used for Online migrations.
         Only Connections of type Non-Autonomous can be used as source container databases.
 
 
@@ -278,7 +278,7 @@ class CreateMigrationDetails(object):
     def source_container_database_connection_id(self, source_container_database_connection_id):
         """
         Sets the source_container_database_connection_id of this CreateMigrationDetails.
-        The OCID of the Source Container Database Connection. Only used for ONLINE migrations.
+        The OCID of the Source Container Database Connection. Only used for Online migrations.
         Only Connections of type Non-Autonomous can be used as source container databases.
 
 

--- a/src/oci/database_migration/models/create_object_store_bucket.py
+++ b/src/oci/database_migration/models/create_object_store_bucket.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class CreateObjectStoreBucket(object):
     """
-    In lieu of a network database link, OCI Object Storage bucket will be used to store Datapump dump files for the migration.
+    In lieu of a network database link, OCI Object Storage bucket will be used to store Data Pump dump files for the migration.
     """
 
     def __init__(self, **kwargs):

--- a/src/oci/database_migration/models/create_private_endpoint.py
+++ b/src/oci/database_migration/models/create_private_endpoint.py
@@ -53,7 +53,7 @@ class CreatePrivateEndpoint(object):
         """
         **[Required]** Gets the compartment_id of this CreatePrivateEndpoint.
         The `OCID`__ of the compartment to contain the
-        private endpoint. Required if the id was not specified.
+        private endpoint.
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
@@ -68,7 +68,7 @@ class CreatePrivateEndpoint(object):
         """
         Sets the compartment_id of this CreatePrivateEndpoint.
         The `OCID`__ of the compartment to contain the
-        private endpoint. Required if the id was not specified.
+        private endpoint.
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
@@ -83,7 +83,6 @@ class CreatePrivateEndpoint(object):
         """
         **[Required]** Gets the vcn_id of this CreatePrivateEndpoint.
         The `OCID`__ of the VCN where the Private Endpoint will be bound to.
-        Required if the id was not specified.
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
@@ -98,7 +97,6 @@ class CreatePrivateEndpoint(object):
         """
         Sets the vcn_id of this CreatePrivateEndpoint.
         The `OCID`__ of the VCN where the Private Endpoint will be bound to.
-        Required if the id was not specified.
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
@@ -113,7 +111,7 @@ class CreatePrivateEndpoint(object):
         """
         **[Required]** Gets the subnet_id of this CreatePrivateEndpoint.
         The `OCID`__ of the customer's subnet where the private endpoint VNIC
-        will reside.  Required if the id was not specified.
+        will reside.
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 
@@ -128,7 +126,7 @@ class CreatePrivateEndpoint(object):
         """
         Sets the subnet_id of this CreatePrivateEndpoint.
         The `OCID`__ of the customer's subnet where the private endpoint VNIC
-        will reside.  Required if the id was not specified.
+        will reside.
 
         __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
 

--- a/src/oci/database_migration/models/create_replicat.py
+++ b/src/oci/database_migration/models/create_replicat.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class CreateReplicat(object):
     """
-    Parameters for Replicat processes.
+    Parameters for GoldenGate Replicat processes.
     """
 
     def __init__(self, **kwargs):

--- a/src/oci/database_migration/models/create_ssh_details.py
+++ b/src/oci/database_migration/models/create_ssh_details.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class CreateSshDetails(object):
     """
-    Details of the ssh key that will be used. Required for source database Manual and UserManagerOci connection types.
+    Details of the SSH key that will be used. Required for source database Manual and UserManagerOci connection types.
     Not required for source container database connections.
     """
 
@@ -59,7 +59,7 @@ class CreateSshDetails(object):
     def host(self):
         """
         **[Required]** Gets the host of this CreateSshDetails.
-        Name of the host the sshkey is valid for.
+        Name of the host the SSH key is valid for.
 
 
         :return: The host of this CreateSshDetails.
@@ -71,7 +71,7 @@ class CreateSshDetails(object):
     def host(self, host):
         """
         Sets the host of this CreateSshDetails.
-        Name of the host the sshkey is valid for.
+        Name of the host the SSH key is valid for.
 
 
         :param host: The host of this CreateSshDetails.
@@ -83,7 +83,7 @@ class CreateSshDetails(object):
     def sshkey(self):
         """
         **[Required]** Gets the sshkey of this CreateSshDetails.
-        Private ssh key string.
+        Private SSH key string.
 
 
         :return: The sshkey of this CreateSshDetails.
@@ -95,7 +95,7 @@ class CreateSshDetails(object):
     def sshkey(self, sshkey):
         """
         Sets the sshkey of this CreateSshDetails.
-        Private ssh key string.
+        Private SSH key string.
 
 
         :param sshkey: The sshkey of this CreateSshDetails.

--- a/src/oci/database_migration/models/data_pump_parameters.py
+++ b/src/oci/database_migration/models/data_pump_parameters.py
@@ -10,7 +10,9 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class DataPumpParameters(object):
     """
-    Optional parameters for Datapump Export and Import. Refer to https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/ODMS_DATAPUMP.html#GUID-62324358-2F26-4A94-B69F-1075D53FA96D__BABDECJE
+    Optional parameters for Data Pump Export and Import. Refer to `Configuring Optional Initial Load Advanced Settings`__
+
+    __ https://docs.us.oracle.com/en/cloud/paas/database-migration/dmsus/working-migration-resources.html#GUID-24BD3054-FDF8-48FF-8492-636C1D4B71ED
     """
 
     #: A constant which can be used with the estimate property of a DataPumpParameters.
@@ -100,7 +102,7 @@ class DataPumpParameters(object):
     def is_cluster(self):
         """
         Gets the is_cluster of this DataPumpParameters.
-        False to force datapump worker process to run on one instance.
+        Set to false to force Data Pump worker processes to run on one instance.
 
 
         :return: The is_cluster of this DataPumpParameters.
@@ -112,7 +114,7 @@ class DataPumpParameters(object):
     def is_cluster(self, is_cluster):
         """
         Sets the is_cluster of this DataPumpParameters.
-        False to force datapump worker process to run on one instance.
+        Set to false to force Data Pump worker processes to run on one instance.
 
 
         :param is_cluster: The is_cluster of this DataPumpParameters.
@@ -184,7 +186,7 @@ class DataPumpParameters(object):
     def exclude_parameters(self):
         """
         Gets the exclude_parameters of this DataPumpParameters.
-        Exclude paratemers for export and import.
+        Exclude paratemers for Export and Import.
 
 
         :return: The exclude_parameters of this DataPumpParameters.
@@ -196,7 +198,7 @@ class DataPumpParameters(object):
     def exclude_parameters(self, exclude_parameters):
         """
         Sets the exclude_parameters of this DataPumpParameters.
-        Exclude paratemers for export and import.
+        Exclude paratemers for Export and Import.
 
 
         :param exclude_parameters: The exclude_parameters of this DataPumpParameters.
@@ -208,7 +210,7 @@ class DataPumpParameters(object):
     def import_parallelism_degree(self):
         """
         Gets the import_parallelism_degree of this DataPumpParameters.
-        Maximum number of worker processes that can be used for a Datapump Import job.
+        Maximum number of worker processes that can be used for a Data Pump Import job.
         For an Autonomous Database, ODMS will automatically query its CPU core count and set this property.
 
 
@@ -221,7 +223,7 @@ class DataPumpParameters(object):
     def import_parallelism_degree(self, import_parallelism_degree):
         """
         Sets the import_parallelism_degree of this DataPumpParameters.
-        Maximum number of worker processes that can be used for a Datapump Import job.
+        Maximum number of worker processes that can be used for a Data Pump Import job.
         For an Autonomous Database, ODMS will automatically query its CPU core count and set this property.
 
 
@@ -234,7 +236,7 @@ class DataPumpParameters(object):
     def export_parallelism_degree(self):
         """
         Gets the export_parallelism_degree of this DataPumpParameters.
-        Maximum number of worker processes that can be used for a Datapump Export job.
+        Maximum number of worker processes that can be used for a Data Pump Export job.
 
 
         :return: The export_parallelism_degree of this DataPumpParameters.
@@ -246,7 +248,7 @@ class DataPumpParameters(object):
     def export_parallelism_degree(self, export_parallelism_degree):
         """
         Sets the export_parallelism_degree of this DataPumpParameters.
-        Maximum number of worker processes that can be used for a Datapump Export job.
+        Maximum number of worker processes that can be used for a Data Pump Export job.
 
 
         :param export_parallelism_degree: The export_parallelism_degree of this DataPumpParameters.

--- a/src/oci/database_migration/models/data_pump_settings.py
+++ b/src/oci/database_migration/models/data_pump_settings.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class DataPumpSettings(object):
     """
-    Optional settings for Datapump Export and Import jobs
+    Optional settings for Data Pump Export and Import jobs
     """
 
     #: A constant which can be used with the job_mode property of a DataPumpSettings.
@@ -87,8 +87,10 @@ class DataPumpSettings(object):
     def job_mode(self):
         """
         Gets the job_mode of this DataPumpSettings.
-        DataPump job mode.
-        Refer to docs.oracle.com/en/database/oracle/oracle-database/19/arpls/ODMS_DATAPUMP.html#GUID-92C2CB46-8BC9-414D-B62E-79CD788C1E62__BABBDEHD
+        Data Pump job mode.
+        Refer to `Data Pump Export Modes `__
+
+        __ https://docs.oracle.com/en/database/oracle/oracle-database/19/sutil/oracle-data-pump-export-utility.html#GUID-8E497131-6B9B-4CC8-AA50-35F480CAC2C4
 
         Allowed values for this property are: "FULL", "SCHEMA", "TABLE", "TABLESPACE", "TRANSPORTABLE", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -103,8 +105,10 @@ class DataPumpSettings(object):
     def job_mode(self, job_mode):
         """
         Sets the job_mode of this DataPumpSettings.
-        DataPump job mode.
-        Refer to docs.oracle.com/en/database/oracle/oracle-database/19/arpls/ODMS_DATAPUMP.html#GUID-92C2CB46-8BC9-414D-B62E-79CD788C1E62__BABBDEHD
+        Data Pump job mode.
+        Refer to `Data Pump Export Modes `__
+
+        __ https://docs.oracle.com/en/database/oracle/oracle-database/19/sutil/oracle-data-pump-export-utility.html#GUID-8E497131-6B9B-4CC8-AA50-35F480CAC2C4
 
 
         :param job_mode: The job_mode of this DataPumpSettings.
@@ -140,7 +144,9 @@ class DataPumpSettings(object):
         """
         Gets the metadata_remaps of this DataPumpSettings.
         Defines remapping to be applied to objects as they are processed.
-        Refer to https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/ODMS_DATAPUMP.html#GUID-0FC32790-91E6-4781-87A3-229DE024CB3D.
+        Refer to `METADATA_REMAP Procedure `__
+
+        __ https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/DBMS_DATAPUMP.html#GUID-0FC32790-91E6-4781-87A3-229DE024CB3D
 
 
         :return: The metadata_remaps of this DataPumpSettings.
@@ -153,7 +159,9 @@ class DataPumpSettings(object):
         """
         Sets the metadata_remaps of this DataPumpSettings.
         Defines remapping to be applied to objects as they are processed.
-        Refer to https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/ODMS_DATAPUMP.html#GUID-0FC32790-91E6-4781-87A3-229DE024CB3D.
+        Refer to `METADATA_REMAP Procedure `__
+
+        __ https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/DBMS_DATAPUMP.html#GUID-0FC32790-91E6-4781-87A3-229DE024CB3D
 
 
         :param metadata_remaps: The metadata_remaps of this DataPumpSettings.

--- a/src/oci/database_migration/models/golden_gate_hub.py
+++ b/src/oci/database_migration/models/golden_gate_hub.py
@@ -192,7 +192,7 @@ class GoldenGateHub(object):
     def source_microservices_deployment_name(self):
         """
         **[Required]** Gets the source_microservices_deployment_name of this GoldenGateHub.
-        Name of Microservices deployment to operate on source DB
+        Name of GoldenGate deployment to operate on source database
 
 
         :return: The source_microservices_deployment_name of this GoldenGateHub.
@@ -204,7 +204,7 @@ class GoldenGateHub(object):
     def source_microservices_deployment_name(self, source_microservices_deployment_name):
         """
         Sets the source_microservices_deployment_name of this GoldenGateHub.
-        Name of Microservices deployment to operate on source DB
+        Name of GoldenGate deployment to operate on source database
 
 
         :param source_microservices_deployment_name: The source_microservices_deployment_name of this GoldenGateHub.
@@ -216,7 +216,7 @@ class GoldenGateHub(object):
     def target_microservices_deployment_name(self):
         """
         **[Required]** Gets the target_microservices_deployment_name of this GoldenGateHub.
-        Name of Microservices deployment to operate on target DB
+        Name of GoldenGate deployment to operate on target database
 
 
         :return: The target_microservices_deployment_name of this GoldenGateHub.
@@ -228,7 +228,7 @@ class GoldenGateHub(object):
     def target_microservices_deployment_name(self, target_microservices_deployment_name):
         """
         Sets the target_microservices_deployment_name of this GoldenGateHub.
-        Name of Microservices deployment to operate on target DB
+        Name of GoldenGate deployment to operate on target database
 
 
         :param target_microservices_deployment_name: The target_microservices_deployment_name of this GoldenGateHub.
@@ -240,7 +240,7 @@ class GoldenGateHub(object):
     def compute_id(self):
         """
         Gets the compute_id of this GoldenGateHub.
-        OCID of Golden Gate compute instance.
+        OCID of GoldenGate compute instance.
 
 
         :return: The compute_id of this GoldenGateHub.
@@ -252,7 +252,7 @@ class GoldenGateHub(object):
     def compute_id(self, compute_id):
         """
         Sets the compute_id of this GoldenGateHub.
-        OCID of Golden Gate compute instance.
+        OCID of GoldenGate compute instance.
 
 
         :param compute_id: The compute_id of this GoldenGateHub.

--- a/src/oci/database_migration/models/job.py
+++ b/src/oci/database_migration/models/job.py
@@ -271,7 +271,7 @@ class Job(object):
     def time_created(self):
         """
         **[Required]** Gets the time_created of this Job.
-        The time the DB Migration Job was created. An RFC3339 formatted datetime string
+        The time the Migration Job was created. An RFC3339 formatted datetime string
 
 
         :return: The time_created of this Job.
@@ -283,7 +283,7 @@ class Job(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this Job.
-        The time the DB Migration Job was created. An RFC3339 formatted datetime string
+        The time the Migration Job was created. An RFC3339 formatted datetime string
 
 
         :param time_created: The time_created of this Job.
@@ -295,7 +295,7 @@ class Job(object):
     def time_updated(self):
         """
         Gets the time_updated of this Job.
-        The time the DB Migration Job was last updated. An RFC3339 formatted datetime string
+        The time the Migration Job was last updated. An RFC3339 formatted datetime string
 
 
         :return: The time_updated of this Job.
@@ -307,7 +307,7 @@ class Job(object):
     def time_updated(self, time_updated):
         """
         Sets the time_updated of this Job.
-        The time the DB Migration Job was last updated. An RFC3339 formatted datetime string
+        The time the Migration Job was last updated. An RFC3339 formatted datetime string
 
 
         :param time_updated: The time_updated of this Job.

--- a/src/oci/database_migration/models/job_summary.py
+++ b/src/oci/database_migration/models/job_summary.py
@@ -284,7 +284,7 @@ class JobSummary(object):
     def time_created(self):
         """
         **[Required]** Gets the time_created of this JobSummary.
-        The time the DB Migration Job was created. An RFC3339 formatted datetime string
+        The time the Migration Job was created. An RFC3339 formatted datetime string
 
 
         :return: The time_created of this JobSummary.
@@ -296,7 +296,7 @@ class JobSummary(object):
     def time_created(self, time_created):
         """
         Sets the time_created of this JobSummary.
-        The time the DB Migration Job was created. An RFC3339 formatted datetime string
+        The time the Migration Job was created. An RFC3339 formatted datetime string
 
 
         :param time_created: The time_created of this JobSummary.
@@ -308,7 +308,7 @@ class JobSummary(object):
     def time_updated(self):
         """
         Gets the time_updated of this JobSummary.
-        The time the DB Migration Job was last updated. An RFC3339 formatted datetime string
+        The time the Migration Job was last updated. An RFC3339 formatted datetime string
 
 
         :return: The time_updated of this JobSummary.
@@ -320,7 +320,7 @@ class JobSummary(object):
     def time_updated(self, time_updated):
         """
         Sets the time_updated of this JobSummary.
-        The time the DB Migration Job was last updated. An RFC3339 formatted datetime string
+        The time the Migration Job was last updated. An RFC3339 formatted datetime string
 
 
         :param time_updated: The time_updated of this JobSummary.

--- a/src/oci/database_migration/models/metadata_remap.py
+++ b/src/oci/database_migration/models/metadata_remap.py
@@ -11,7 +11,9 @@ from oci.decorators import init_model_state_from_kwargs
 class MetadataRemap(object):
     """
     Defines remapping to be applied to objects as they are processed.
-    Refer to https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/ODMS_DATAPUMP.html#GUID-0FC32790-91E6-4781-87A3-229DE024CB3D.
+    Refer to `METADATA_REMAP Procedure `__
+
+    __ https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/DBMS_DATAPUMP.html#GUID-0FC32790-91E6-4781-87A3-229DE024CB3D
     """
 
     #: A constant which can be used with the type property of a MetadataRemap.
@@ -70,7 +72,9 @@ class MetadataRemap(object):
     def type(self):
         """
         **[Required]** Gets the type of this MetadataRemap.
-        Type of remap. Refer to https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/ODMS_DATAPUMP.html#GUID-0FC32790-91E6-4781-87A3-229DE024CB3D__BABDJGDI
+        Type of remap. Refer to `METADATA_REMAP Procedure `__
+
+        __ https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/DBMS_DATAPUMP.html#GUID-0FC32790-91E6-4781-87A3-229DE024CB3D
 
         Allowed values for this property are: "SCHEMA", "TABLESPACE", "DATAFILE", "TABLE", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -85,7 +89,9 @@ class MetadataRemap(object):
     def type(self, type):
         """
         Sets the type of this MetadataRemap.
-        Type of remap. Refer to https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/ODMS_DATAPUMP.html#GUID-0FC32790-91E6-4781-87A3-229DE024CB3D__BABDJGDI
+        Type of remap. Refer to `METADATA_REMAP Procedure `__
+
+        __ https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/DBMS_DATAPUMP.html#GUID-0FC32790-91E6-4781-87A3-229DE024CB3D
 
 
         :param type: The type of this MetadataRemap.

--- a/src/oci/database_migration/models/migration.py
+++ b/src/oci/database_migration/models/migration.py
@@ -468,7 +468,7 @@ class Migration(object):
     def agent_id(self):
         """
         Gets the agent_id of this Migration.
-        The OCID of the registered On-Prem ODMS Agent. Required for Offline Migrations.
+        The OCID of the registered on-premises ODMS Agent. Only valid for Offline Migrations.
 
 
         :return: The agent_id of this Migration.
@@ -480,7 +480,7 @@ class Migration(object):
     def agent_id(self, agent_id):
         """
         Sets the agent_id of this Migration.
-        The OCID of the registered On-Prem ODMS Agent. Required for Offline Migrations.
+        The OCID of the registered on-premises ODMS Agent. Only valid for Offline Migrations.
 
 
         :param agent_id: The agent_id of this Migration.
@@ -492,7 +492,7 @@ class Migration(object):
     def credentials_secret_id(self):
         """
         Gets the credentials_secret_id of this Migration.
-        OCID of the Secret in the OCI vault containing the Migration credentials. Used to store Golden Gate admin user credentials.
+        OCID of the Secret in the OCI vault containing the Migration credentials. Used to store GoldenGate administrator user credentials.
 
 
         :return: The credentials_secret_id of this Migration.
@@ -504,7 +504,7 @@ class Migration(object):
     def credentials_secret_id(self, credentials_secret_id):
         """
         Sets the credentials_secret_id of this Migration.
-        OCID of the Secret in the OCI vault containing the Migration credentials. Used to store Golden Gate admin user credentials.
+        OCID of the Secret in the OCI vault containing the Migration credentials. Used to store GoldenGate administrator user credentials.
 
 
         :param credentials_secret_id: The credentials_secret_id of this Migration.
@@ -788,7 +788,7 @@ class Migration(object):
     def lifecycle_state(self):
         """
         **[Required]** Gets the lifecycle_state of this Migration.
-        The current state of the Migration Resource.
+        The current state of the Migration resource.
 
         Allowed values for this property are: "CREATING", "UPDATING", "ACTIVE", "INACTIVE", "DELETING", "DELETED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
@@ -803,7 +803,7 @@ class Migration(object):
     def lifecycle_state(self, lifecycle_state):
         """
         Sets the lifecycle_state of this Migration.
-        The current state of the Migration Resource.
+        The current state of the Migration resource.
 
 
         :param lifecycle_state: The lifecycle_state of this Migration.

--- a/src/oci/database_migration/models/migration_summary.py
+++ b/src/oci/database_migration/models/migration_summary.py
@@ -424,7 +424,7 @@ class MigrationSummary(object):
     def agent_id(self):
         """
         Gets the agent_id of this MigrationSummary.
-        The OCID of the registered On-Prem ODMS Agent. Required for Offline Migrations.
+        The OCID of the registered on-premises ODMS Agent. Only valid for Offline Migrations.
 
 
         :return: The agent_id of this MigrationSummary.
@@ -436,7 +436,7 @@ class MigrationSummary(object):
     def agent_id(self, agent_id):
         """
         Sets the agent_id of this MigrationSummary.
-        The OCID of the registered On-Prem ODMS Agent. Required for Offline Migrations.
+        The OCID of the registered on-premises ODMS Agent. Only valid for Offline Migrations.
 
 
         :param agent_id: The agent_id of this MigrationSummary.

--- a/src/oci/database_migration/models/object_store_bucket.py
+++ b/src/oci/database_migration/models/object_store_bucket.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class ObjectStoreBucket(object):
     """
-    In lieu of a network database link, OCI Object Storage bucket will be used to store Datapump dump files for the migration.
+    In lieu of a network database link, OCI Object Storage bucket will be used to store Data Pump dump files for the migration.
     """
 
     def __init__(self, **kwargs):

--- a/src/oci/database_migration/models/replicat.py
+++ b/src/oci/database_migration/models/replicat.py
@@ -75,7 +75,7 @@ class Replicat(object):
     def min_apply_parallelism(self):
         """
         Gets the min_apply_parallelism of this Replicat.
-        Defines the range in which the Replicat automatically adjusts its apply parallelism (valid for Parallel Replicat)
+        Defines the range in which Replicat automatically adjusts its apply parallelism (valid for Parallel Replicat)
 
 
         :return: The min_apply_parallelism of this Replicat.
@@ -87,7 +87,7 @@ class Replicat(object):
     def min_apply_parallelism(self, min_apply_parallelism):
         """
         Sets the min_apply_parallelism of this Replicat.
-        Defines the range in which the Replicat automatically adjusts its apply parallelism (valid for Parallel Replicat)
+        Defines the range in which Replicat automatically adjusts its apply parallelism (valid for Parallel Replicat)
 
 
         :param min_apply_parallelism: The min_apply_parallelism of this Replicat.
@@ -99,7 +99,7 @@ class Replicat(object):
     def max_apply_parallelism(self):
         """
         Gets the max_apply_parallelism of this Replicat.
-        Defines the range in which the Replicat automatically adjusts its apply parallelism (valid for Parallel Replicat)
+        Defines the range in which Replicat automatically adjusts its apply parallelism (valid for Parallel Replicat)
 
 
         :return: The max_apply_parallelism of this Replicat.
@@ -111,7 +111,7 @@ class Replicat(object):
     def max_apply_parallelism(self, max_apply_parallelism):
         """
         Sets the max_apply_parallelism of this Replicat.
-        Defines the range in which the Replicat automatically adjusts its apply parallelism (valid for Parallel Replicat)
+        Defines the range in which Replicat automatically adjusts its apply parallelism (valid for Parallel Replicat)
 
 
         :param max_apply_parallelism: The max_apply_parallelism of this Replicat.

--- a/src/oci/database_migration/models/ssh_details.py
+++ b/src/oci/database_migration/models/ssh_details.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class SshDetails(object):
     """
-    Details of the ssh key that will be used.
+    Details of the SSH key that will be used.
     """
 
     def __init__(self, **kwargs):
@@ -51,7 +51,7 @@ class SshDetails(object):
     def host(self):
         """
         **[Required]** Gets the host of this SshDetails.
-        Name of the host the sshkey is valid for.
+        Name of the host the SSH key is valid for.
 
 
         :return: The host of this SshDetails.
@@ -63,7 +63,7 @@ class SshDetails(object):
     def host(self, host):
         """
         Sets the host of this SshDetails.
-        Name of the host the sshkey is valid for.
+        Name of the host the SSH key is valid for.
 
 
         :param host: The host of this SshDetails.

--- a/src/oci/database_migration/models/update_admin_credentials.py
+++ b/src/oci/database_migration/models/update_admin_credentials.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class UpdateAdminCredentials(object):
     """
-    Database Admin Credentials details. An empty object would result in the removal of the stored details.
+    Database Administrator Credentials details. An empty object would result in the removal of the stored details.
     """
 
     def __init__(self, **kwargs):
@@ -44,7 +44,7 @@ class UpdateAdminCredentials(object):
     def username(self):
         """
         Gets the username of this UpdateAdminCredentials.
-        Admin username
+        Administrator username
 
 
         :return: The username of this UpdateAdminCredentials.
@@ -56,7 +56,7 @@ class UpdateAdminCredentials(object):
     def username(self, username):
         """
         Sets the username of this UpdateAdminCredentials.
-        Admin username
+        Administrator username
 
 
         :param username: The username of this UpdateAdminCredentials.
@@ -68,7 +68,7 @@ class UpdateAdminCredentials(object):
     def password(self):
         """
         Gets the password of this UpdateAdminCredentials.
-        Admin password
+        Administrator password
 
 
         :return: The password of this UpdateAdminCredentials.
@@ -80,7 +80,7 @@ class UpdateAdminCredentials(object):
     def password(self, password):
         """
         Sets the password of this UpdateAdminCredentials.
-        Admin password
+        Administrator password
 
 
         :param password: The password of this UpdateAdminCredentials.

--- a/src/oci/database_migration/models/update_data_pump_parameters.py
+++ b/src/oci/database_migration/models/update_data_pump_parameters.py
@@ -10,8 +10,10 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class UpdateDataPumpParameters(object):
     """
-    Optional parameters for Datapump Export and Import. Refer to https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/ODMS_DATAPUMP.html#GUID-62324358-2F26-4A94-B69F-1075D53FA96D__BABDECJE
+    Optional parameters for Data Pump Export and Import. Refer to `Configuring Optional Initial Load Advanced Settings`__
     If an empty object is specified, the stored Data Pump Parameter details will be removed.
+
+    __ https://docs-uat.us.oracle.com/en/cloud/paas/database-migration/dmsus/working-migration-resources.html#GUID-24BD3054-FDF8-48FF-8492-636C1D4B71ED
     """
 
     #: A constant which can be used with the estimate property of a UpdateDataPumpParameters.
@@ -99,7 +101,7 @@ class UpdateDataPumpParameters(object):
     def is_cluster(self):
         """
         Gets the is_cluster of this UpdateDataPumpParameters.
-        False to force datapump worker process to run on one instance.
+        Set to false to force Data Pump worker processes to run on one instance.
 
 
         :return: The is_cluster of this UpdateDataPumpParameters.
@@ -111,7 +113,7 @@ class UpdateDataPumpParameters(object):
     def is_cluster(self, is_cluster):
         """
         Sets the is_cluster of this UpdateDataPumpParameters.
-        False to force datapump worker process to run on one instance.
+        Set to false to force Data Pump worker processes to run on one instance.
 
 
         :param is_cluster: The is_cluster of this UpdateDataPumpParameters.
@@ -187,7 +189,7 @@ class UpdateDataPumpParameters(object):
     def exclude_parameters(self):
         """
         Gets the exclude_parameters of this UpdateDataPumpParameters.
-        Exclude paratemers for export and import. If specified, the stored list will be replaced.
+        Exclude paratemers for Export and Import. If specified, the stored list will be replaced.
 
 
         :return: The exclude_parameters of this UpdateDataPumpParameters.
@@ -199,7 +201,7 @@ class UpdateDataPumpParameters(object):
     def exclude_parameters(self, exclude_parameters):
         """
         Sets the exclude_parameters of this UpdateDataPumpParameters.
-        Exclude paratemers for export and import. If specified, the stored list will be replaced.
+        Exclude paratemers for Export and Import. If specified, the stored list will be replaced.
 
 
         :param exclude_parameters: The exclude_parameters of this UpdateDataPumpParameters.
@@ -211,7 +213,7 @@ class UpdateDataPumpParameters(object):
     def import_parallelism_degree(self):
         """
         Gets the import_parallelism_degree of this UpdateDataPumpParameters.
-        Maximum number of worker processes that can be used for a Datapump Import job.
+        Maximum number of worker processes that can be used for a Data Pump Import job.
         For an Autonomous Database, ODMS will automatically query its CPU core count and set this property.
 
 
@@ -224,7 +226,7 @@ class UpdateDataPumpParameters(object):
     def import_parallelism_degree(self, import_parallelism_degree):
         """
         Sets the import_parallelism_degree of this UpdateDataPumpParameters.
-        Maximum number of worker processes that can be used for a Datapump Import job.
+        Maximum number of worker processes that can be used for a Data Pump Import job.
         For an Autonomous Database, ODMS will automatically query its CPU core count and set this property.
 
 
@@ -237,7 +239,7 @@ class UpdateDataPumpParameters(object):
     def export_parallelism_degree(self):
         """
         Gets the export_parallelism_degree of this UpdateDataPumpParameters.
-        Maximum number of worker processes that can be used for a Datapump Export job.
+        Maximum number of worker processes that can be used for a Data Pump Export job.
 
 
         :return: The export_parallelism_degree of this UpdateDataPumpParameters.
@@ -249,7 +251,7 @@ class UpdateDataPumpParameters(object):
     def export_parallelism_degree(self, export_parallelism_degree):
         """
         Sets the export_parallelism_degree of this UpdateDataPumpParameters.
-        Maximum number of worker processes that can be used for a Datapump Export job.
+        Maximum number of worker processes that can be used for a Data Pump Export job.
 
 
         :param export_parallelism_degree: The export_parallelism_degree of this UpdateDataPumpParameters.

--- a/src/oci/database_migration/models/update_data_pump_settings.py
+++ b/src/oci/database_migration/models/update_data_pump_settings.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class UpdateDataPumpSettings(object):
     """
-    Optional settings for Datapump Export and Import jobs
+    Optional settings for Data Pump Export and Import jobs
     """
 
     #: A constant which can be used with the job_mode property of a UpdateDataPumpSettings.
@@ -86,8 +86,10 @@ class UpdateDataPumpSettings(object):
     def job_mode(self):
         """
         Gets the job_mode of this UpdateDataPumpSettings.
-        DataPump job mode.
-        Refer to docs.oracle.com/en/database/oracle/oracle-database/19/arpls/ODMS_DATAPUMP.html#GUID-92C2CB46-8BC9-414D-B62E-79CD788C1E62__BABBDEHD
+        Data Pump job mode.
+        Refer to `Data Pump Export Modes `__
+
+        __ https://docs.oracle.com/en/database/oracle/oracle-database/19/sutil/oracle-data-pump-export-utility.html#GUID-8E497131-6B9B-4CC8-AA50-35F480CAC2C4
 
         Allowed values for this property are: "FULL", "SCHEMA", "TABLE", "TABLESPACE", "TRANSPORTABLE"
 
@@ -101,8 +103,10 @@ class UpdateDataPumpSettings(object):
     def job_mode(self, job_mode):
         """
         Sets the job_mode of this UpdateDataPumpSettings.
-        DataPump job mode.
-        Refer to docs.oracle.com/en/database/oracle/oracle-database/19/arpls/ODMS_DATAPUMP.html#GUID-92C2CB46-8BC9-414D-B62E-79CD788C1E62__BABBDEHD
+        Data Pump job mode.
+        Refer to `Data Pump Export Modes `__
+
+        __ https://docs.oracle.com/en/database/oracle/oracle-database/19/sutil/oracle-data-pump-export-utility.html#GUID-8E497131-6B9B-4CC8-AA50-35F480CAC2C4
 
 
         :param job_mode: The job_mode of this UpdateDataPumpSettings.
@@ -140,9 +144,11 @@ class UpdateDataPumpSettings(object):
     def metadata_remaps(self):
         """
         Gets the metadata_remaps of this UpdateDataPumpSettings.
-        Defines remapping to be applied to objects as they are processed.
-        Refer to https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/ODMS_DATAPUMP.html#GUID-0FC32790-91E6-4781-87A3-229DE024CB3D.
+        Defines remappings to be applied to objects as they are processed.
+        Refer to `METADATA_REMAP Procedure `__
         If specified, the list will be replaced entirely. Empty list will remove stored Metadata Remap details.
+
+        __ https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/DBMS_DATAPUMP.html#GUID-0FC32790-91E6-4781-87A3-229DE024CB3D
 
 
         :return: The metadata_remaps of this UpdateDataPumpSettings.
@@ -154,9 +160,11 @@ class UpdateDataPumpSettings(object):
     def metadata_remaps(self, metadata_remaps):
         """
         Sets the metadata_remaps of this UpdateDataPumpSettings.
-        Defines remapping to be applied to objects as they are processed.
-        Refer to https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/ODMS_DATAPUMP.html#GUID-0FC32790-91E6-4781-87A3-229DE024CB3D.
+        Defines remappings to be applied to objects as they are processed.
+        Refer to `METADATA_REMAP Procedure `__
         If specified, the list will be replaced entirely. Empty list will remove stored Metadata Remap details.
+
+        __ https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/DBMS_DATAPUMP.html#GUID-0FC32790-91E6-4781-87A3-229DE024CB3D
 
 
         :param metadata_remaps: The metadata_remaps of this UpdateDataPumpSettings.

--- a/src/oci/database_migration/models/update_data_transfer_medium_details.py
+++ b/src/oci/database_migration/models/update_data_transfer_medium_details.py
@@ -11,7 +11,7 @@ from oci.decorators import init_model_state_from_kwargs
 class UpdateDataTransferMediumDetails(object):
     """
     Data Transfer Medium details for the Migration.
-    Only one type of medium details can be specified and will replace the stored Data Transfer Medium details.
+    Only one type of data transfer medium can be specified and will replace the stored Data Transfer Medium details.
     If an empty object is specified, the stored Data Transfer Medium details will be removed.
     """
 

--- a/src/oci/database_migration/models/update_golden_gate_hub.py
+++ b/src/oci/database_migration/models/update_golden_gate_hub.py
@@ -192,7 +192,7 @@ class UpdateGoldenGateHub(object):
     def source_microservices_deployment_name(self):
         """
         Gets the source_microservices_deployment_name of this UpdateGoldenGateHub.
-        Name of Microservices deployment to operate on source DB
+        Name of GoldenGate deployment to operate on source database
 
 
         :return: The source_microservices_deployment_name of this UpdateGoldenGateHub.
@@ -204,7 +204,7 @@ class UpdateGoldenGateHub(object):
     def source_microservices_deployment_name(self, source_microservices_deployment_name):
         """
         Sets the source_microservices_deployment_name of this UpdateGoldenGateHub.
-        Name of Microservices deployment to operate on source DB
+        Name of GoldenGate deployment to operate on source database
 
 
         :param source_microservices_deployment_name: The source_microservices_deployment_name of this UpdateGoldenGateHub.
@@ -216,7 +216,7 @@ class UpdateGoldenGateHub(object):
     def target_microservices_deployment_name(self):
         """
         Gets the target_microservices_deployment_name of this UpdateGoldenGateHub.
-        Name of Microservices deployment to operate on target DB
+        Name of GoldenGate deployment to operate on target database
 
 
         :return: The target_microservices_deployment_name of this UpdateGoldenGateHub.
@@ -228,7 +228,7 @@ class UpdateGoldenGateHub(object):
     def target_microservices_deployment_name(self, target_microservices_deployment_name):
         """
         Sets the target_microservices_deployment_name of this UpdateGoldenGateHub.
-        Name of Microservices deployment to operate on target DB
+        Name of GoldenGate deployment to operate on target database
 
 
         :param target_microservices_deployment_name: The target_microservices_deployment_name of this UpdateGoldenGateHub.
@@ -240,7 +240,7 @@ class UpdateGoldenGateHub(object):
     def compute_id(self):
         """
         Gets the compute_id of this UpdateGoldenGateHub.
-        OCID of Golden Gate compute instance. An empty value will remove the stored computeId.
+        OCID of GoldenGate compute instance. An empty value will remove the stored computeId.
 
 
         :return: The compute_id of this UpdateGoldenGateHub.
@@ -252,7 +252,7 @@ class UpdateGoldenGateHub(object):
     def compute_id(self, compute_id):
         """
         Sets the compute_id of this UpdateGoldenGateHub.
-        OCID of Golden Gate compute instance. An empty value will remove the stored computeId.
+        OCID of GoldenGate compute instance. An empty value will remove the stored computeId.
 
 
         :param compute_id: The compute_id of this UpdateGoldenGateHub.

--- a/src/oci/database_migration/models/update_golden_gate_settings.py
+++ b/src/oci/database_migration/models/update_golden_gate_settings.py
@@ -11,7 +11,7 @@ from oci.decorators import init_model_state_from_kwargs
 class UpdateGoldenGateSettings(object):
     """
     Optional settings for Oracle GoldenGate processes
-    If an empty object is specified, the stored Golden Gate Settings details will be removed.
+    If an empty object is specified, the stored GoldenGate Settings details will be removed.
     """
 
     def __init__(self, **kwargs):

--- a/src/oci/database_migration/models/update_migration_details.py
+++ b/src/oci/database_migration/models/update_migration_details.py
@@ -234,9 +234,9 @@ class UpdateMigrationDetails(object):
     def source_container_database_connection_id(self):
         """
         Gets the source_container_database_connection_id of this UpdateMigrationDetails.
-        The OCID of the Source Container Database Connection. Only used for ONLINE migrations.
+        The OCID of the Source Container Database Connection. Only used for Online migrations.
         Only Connections of type Non-Autonomous can be used as source container databases.
-        An empty value would remove the stored Connection Id.
+        An empty value would remove the stored Connection ID.
 
 
         :return: The source_container_database_connection_id of this UpdateMigrationDetails.
@@ -248,9 +248,9 @@ class UpdateMigrationDetails(object):
     def source_container_database_connection_id(self, source_container_database_connection_id):
         """
         Sets the source_container_database_connection_id of this UpdateMigrationDetails.
-        The OCID of the Source Container Database Connection. Only used for ONLINE migrations.
+        The OCID of the Source Container Database Connection. Only used for Online migrations.
         Only Connections of type Non-Autonomous can be used as source container databases.
-        An empty value would remove the stored Connection Id.
+        An empty value would remove the stored Connection ID.
 
 
         :param source_container_database_connection_id: The source_container_database_connection_id of this UpdateMigrationDetails.

--- a/src/oci/database_migration/models/update_replicat.py
+++ b/src/oci/database_migration/models/update_replicat.py
@@ -76,7 +76,7 @@ class UpdateReplicat(object):
     def min_apply_parallelism(self):
         """
         Gets the min_apply_parallelism of this UpdateReplicat.
-        Defines the range in which the Replicat automatically adjusts its apply parallelism (valid for Parallel Replicat)
+        Defines the range in which Replicat automatically adjusts its apply parallelism (valid for Parallel Replicat)
 
 
         :return: The min_apply_parallelism of this UpdateReplicat.
@@ -88,7 +88,7 @@ class UpdateReplicat(object):
     def min_apply_parallelism(self, min_apply_parallelism):
         """
         Sets the min_apply_parallelism of this UpdateReplicat.
-        Defines the range in which the Replicat automatically adjusts its apply parallelism (valid for Parallel Replicat)
+        Defines the range in which Replicat automatically adjusts its apply parallelism (valid for Parallel Replicat)
 
 
         :param min_apply_parallelism: The min_apply_parallelism of this UpdateReplicat.
@@ -100,7 +100,7 @@ class UpdateReplicat(object):
     def max_apply_parallelism(self):
         """
         Gets the max_apply_parallelism of this UpdateReplicat.
-        Defines the range in which the Replicat automatically adjusts its apply parallelism (valid for Parallel Replicat)
+        Defines the range in which Replicat automatically adjusts its apply parallelism (valid for Parallel Replicat)
 
 
         :return: The max_apply_parallelism of this UpdateReplicat.
@@ -112,7 +112,7 @@ class UpdateReplicat(object):
     def max_apply_parallelism(self, max_apply_parallelism):
         """
         Sets the max_apply_parallelism of this UpdateReplicat.
-        Defines the range in which the Replicat automatically adjusts its apply parallelism (valid for Parallel Replicat)
+        Defines the range in which Replicat automatically adjusts its apply parallelism (valid for Parallel Replicat)
 
 
         :param max_apply_parallelism: The max_apply_parallelism of this UpdateReplicat.

--- a/src/oci/database_migration/models/update_ssh_details.py
+++ b/src/oci/database_migration/models/update_ssh_details.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class UpdateSshDetails(object):
     """
-    Details of the ssh key that will be used.
+    Details of the SSH key that will be used.
     """
 
     def __init__(self, **kwargs):
@@ -58,7 +58,7 @@ class UpdateSshDetails(object):
     def host(self):
         """
         Gets the host of this UpdateSshDetails.
-        Name of the host the sshkey is valid for.
+        Name of the host the SSH key is valid for.
 
 
         :return: The host of this UpdateSshDetails.
@@ -70,7 +70,7 @@ class UpdateSshDetails(object):
     def host(self, host):
         """
         Sets the host of this UpdateSshDetails.
-        Name of the host the sshkey is valid for.
+        Name of the host the SSH key is valid for.
 
 
         :param host: The host of this UpdateSshDetails.
@@ -82,7 +82,7 @@ class UpdateSshDetails(object):
     def sshkey(self):
         """
         Gets the sshkey of this UpdateSshDetails.
-        Private ssh key string.
+        Private SSH key string.
 
 
         :return: The sshkey of this UpdateSshDetails.
@@ -94,7 +94,7 @@ class UpdateSshDetails(object):
     def sshkey(self, sshkey):
         """
         Sets the sshkey of this UpdateSshDetails.
-        Private ssh key string.
+        Private SSH key string.
 
 
         :param sshkey: The sshkey of this UpdateSshDetails.

--- a/src/oci/database_migration/models/work_request_error.py
+++ b/src/oci/database_migration/models/work_request_error.py
@@ -52,7 +52,9 @@ class WorkRequestError(object):
         """
         **[Required]** Gets the code of this WorkRequestError.
         A machine-usable code for the error that occured. Error codes are listed on
-        (https://docs.cloud.oracle.com/Content/API/References/apierrors.htm)
+        `API Errors`__
+
+        __ https://docs.cloud.oracle.com/Content/API/References/apierrors.htm
 
 
         :return: The code of this WorkRequestError.
@@ -65,7 +67,9 @@ class WorkRequestError(object):
         """
         Sets the code of this WorkRequestError.
         A machine-usable code for the error that occured. Error codes are listed on
-        (https://docs.cloud.oracle.com/Content/API/References/apierrors.htm)
+        `API Errors`__
+
+        __ https://docs.cloud.oracle.com/Content/API/References/apierrors.htm
 
 
         :param code: The code of this WorkRequestError.

--- a/src/oci/object_storage/models/bucket.py
+++ b/src/oci/object_storage/models/bucket.py
@@ -54,6 +54,14 @@ class Bucket(object):
     #: This constant has a value of "Disabled"
     VERSIONING_DISABLED = "Disabled"
 
+    #: A constant which can be used with the auto_tiering property of a Bucket.
+    #: This constant has a value of "Disabled"
+    AUTO_TIERING_DISABLED = "Disabled"
+
+    #: A constant which can be used with the auto_tiering property of a Bucket.
+    #: This constant has a value of "InfrequentAccess"
+    AUTO_TIERING_INFREQUENT_ACCESS = "InfrequentAccess"
+
     def __init__(self, **kwargs):
         """
         Initializes a new Bucket object with values from keyword arguments.
@@ -145,6 +153,12 @@ class Bucket(object):
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type versioning: str
 
+        :param auto_tiering:
+            The value to assign to the auto_tiering property of this Bucket.
+            Allowed values for this property are: "Disabled", "InfrequentAccess", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type auto_tiering: str
+
         """
         self.swagger_types = {
             'namespace': 'str',
@@ -166,7 +180,8 @@ class Bucket(object):
             'replication_enabled': 'bool',
             'is_read_only': 'bool',
             'id': 'str',
-            'versioning': 'str'
+            'versioning': 'str',
+            'auto_tiering': 'str'
         }
 
         self.attribute_map = {
@@ -189,7 +204,8 @@ class Bucket(object):
             'replication_enabled': 'replicationEnabled',
             'is_read_only': 'isReadOnly',
             'id': 'id',
-            'versioning': 'versioning'
+            'versioning': 'versioning',
+            'auto_tiering': 'autoTiering'
         }
 
         self._namespace = None
@@ -212,6 +228,7 @@ class Bucket(object):
         self._is_read_only = None
         self._id = None
         self._versioning = None
+        self._auto_tiering = None
 
     @property
     def namespace(self):
@@ -778,6 +795,40 @@ class Bucket(object):
         if not value_allowed_none_or_none_sentinel(versioning, allowed_values):
             versioning = 'UNKNOWN_ENUM_VALUE'
         self._versioning = versioning
+
+    @property
+    def auto_tiering(self):
+        """
+        Gets the auto_tiering of this Bucket.
+        The auto tiering status on the bucket. A bucket is created with auto tiering `Disabled` by default.
+        For auto tiering `InfrequentAccess`, objects are transitioned automatically between the 'Standard'
+        and 'InfrequentAccess' tiers based on the access pattern of the objects.
+
+        Allowed values for this property are: "Disabled", "InfrequentAccess", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The auto_tiering of this Bucket.
+        :rtype: str
+        """
+        return self._auto_tiering
+
+    @auto_tiering.setter
+    def auto_tiering(self, auto_tiering):
+        """
+        Sets the auto_tiering of this Bucket.
+        The auto tiering status on the bucket. A bucket is created with auto tiering `Disabled` by default.
+        For auto tiering `InfrequentAccess`, objects are transitioned automatically between the 'Standard'
+        and 'InfrequentAccess' tiers based on the access pattern of the objects.
+
+
+        :param auto_tiering: The auto_tiering of this Bucket.
+        :type: str
+        """
+        allowed_values = ["Disabled", "InfrequentAccess"]
+        if not value_allowed_none_or_none_sentinel(auto_tiering, allowed_values):
+            auto_tiering = 'UNKNOWN_ENUM_VALUE'
+        self._auto_tiering = auto_tiering
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/object_storage/models/create_bucket_details.py
+++ b/src/oci/object_storage/models/create_bucket_details.py
@@ -93,6 +93,10 @@ class CreateBucketDetails(object):
             Allowed values for this property are: "Enabled", "Disabled"
         :type versioning: str
 
+        :param auto_tiering:
+            The value to assign to the auto_tiering property of this CreateBucketDetails.
+        :type auto_tiering: str
+
         """
         self.swagger_types = {
             'name': 'str',
@@ -104,7 +108,8 @@ class CreateBucketDetails(object):
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
             'kms_key_id': 'str',
-            'versioning': 'str'
+            'versioning': 'str',
+            'auto_tiering': 'str'
         }
 
         self.attribute_map = {
@@ -117,7 +122,8 @@ class CreateBucketDetails(object):
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
             'kms_key_id': 'kmsKeyId',
-            'versioning': 'versioning'
+            'versioning': 'versioning',
+            'auto_tiering': 'autoTiering'
         }
 
         self._name = None
@@ -130,6 +136,7 @@ class CreateBucketDetails(object):
         self._defined_tags = None
         self._kms_key_id = None
         self._versioning = None
+        self._auto_tiering = None
 
     @property
     def name(self):
@@ -442,6 +449,36 @@ class CreateBucketDetails(object):
                 .format(allowed_values)
             )
         self._versioning = versioning
+
+    @property
+    def auto_tiering(self):
+        """
+        Gets the auto_tiering of this CreateBucketDetails.
+        Set the auto tiering status on the bucket. By default, a bucket is created with auto tiering `Disabled`.
+        Use this option to enable auto tiering during bucket creation. Objects in a bucket with auto tiering set to
+        `InfrequentAccess` are transitioned automatically between the 'Standard' and 'InfrequentAccess'
+        tiers based on the access pattern of the objects.
+
+
+        :return: The auto_tiering of this CreateBucketDetails.
+        :rtype: str
+        """
+        return self._auto_tiering
+
+    @auto_tiering.setter
+    def auto_tiering(self, auto_tiering):
+        """
+        Sets the auto_tiering of this CreateBucketDetails.
+        Set the auto tiering status on the bucket. By default, a bucket is created with auto tiering `Disabled`.
+        Use this option to enable auto tiering during bucket creation. Objects in a bucket with auto tiering set to
+        `InfrequentAccess` are transitioned automatically between the 'Standard' and 'InfrequentAccess'
+        tiers based on the access pattern of the objects.
+
+
+        :param auto_tiering: The auto_tiering of this CreateBucketDetails.
+        :type: str
+        """
+        self._auto_tiering = auto_tiering
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/object_storage/models/update_bucket_details.py
+++ b/src/oci/object_storage/models/update_bucket_details.py
@@ -84,6 +84,10 @@ class UpdateBucketDetails(object):
             Allowed values for this property are: "Enabled", "Suspended"
         :type versioning: str
 
+        :param auto_tiering:
+            The value to assign to the auto_tiering property of this UpdateBucketDetails.
+        :type auto_tiering: str
+
         """
         self.swagger_types = {
             'namespace': 'str',
@@ -95,7 +99,8 @@ class UpdateBucketDetails(object):
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
             'kms_key_id': 'str',
-            'versioning': 'str'
+            'versioning': 'str',
+            'auto_tiering': 'str'
         }
 
         self.attribute_map = {
@@ -108,7 +113,8 @@ class UpdateBucketDetails(object):
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
             'kms_key_id': 'kmsKeyId',
-            'versioning': 'versioning'
+            'versioning': 'versioning',
+            'auto_tiering': 'autoTiering'
         }
 
         self._namespace = None
@@ -121,6 +127,7 @@ class UpdateBucketDetails(object):
         self._defined_tags = None
         self._kms_key_id = None
         self._versioning = None
+        self._auto_tiering = None
 
     @property
     def namespace(self):
@@ -425,6 +432,34 @@ class UpdateBucketDetails(object):
                 .format(allowed_values)
             )
         self._versioning = versioning
+
+    @property
+    def auto_tiering(self):
+        """
+        Gets the auto_tiering of this UpdateBucketDetails.
+        The auto tiering status on the bucket. If in state `InfrequentAccess`, objects are transitioned
+        automatically between the 'Standard' and 'InfrequentAccess' tiers based on the access pattern of the objects.
+        When auto tiering is `Disabled`, there will be no automatic transitions between storage tiers.
+
+
+        :return: The auto_tiering of this UpdateBucketDetails.
+        :rtype: str
+        """
+        return self._auto_tiering
+
+    @auto_tiering.setter
+    def auto_tiering(self, auto_tiering):
+        """
+        Sets the auto_tiering of this UpdateBucketDetails.
+        The auto tiering status on the bucket. If in state `InfrequentAccess`, objects are transitioned
+        automatically between the 'Standard' and 'InfrequentAccess' tiers based on the access pattern of the objects.
+        When auto tiering is `Disabled`, there will be no automatic transitions between storage tiers.
+
+
+        :param auto_tiering: The auto_tiering of this UpdateBucketDetails.
+        :type: str
+        """
+        self._auto_tiering = auto_tiering
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/object_storage/object_storage_client.py
+++ b/src/oci/object_storage/object_storage_client.py
@@ -1517,10 +1517,11 @@ class ObjectStorageClient(object):
 
         :param list[str] fields: (optional)
             Bucket summary includes the 'namespace', 'name', 'compartmentId', 'createdBy', 'timeCreated',
-            and 'etag' fields. This parameter can also include 'approximateCount' (approximate number of objects) and 'approximateSize'
-            (total approximate size in bytes of all objects). For example 'approximateCount,approximateSize'.
+            and 'etag' fields. This parameter can also include 'approximateCount' (approximate number of objects), 'approximateSize'
+            (total approximate size in bytes of all objects) and 'autoTiering' (state of auto tiering on the bucket).
+            For example 'approximateCount,approximateSize,autoTiering'.
 
-            Allowed values are: "approximateCount", "approximateSize"
+            Allowed values are: "approximateCount", "approximateSize", "autoTiering"
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -1564,7 +1565,7 @@ class ObjectStorageClient(object):
                 raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
 
         if 'fields' in kwargs:
-            fields_allowed_values = ["approximateCount", "approximateSize"]
+            fields_allowed_values = ["approximateCount", "approximateSize", "autoTiering"]
             for fields_item in kwargs['fields']:
                 if fields_item not in fields_allowed_values:
                     raise ValueError(

--- a/src/oci/version.py
+++ b/src/oci/version.py
@@ -2,4 +2,4 @@
 # Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
 # This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 
-__version__ = "2.37.0"
+__version__ = "2.38.0"


### PR DESCRIPTION
## Added

* Support for RACs (real application clusters) for external container, non-container, and pluggable databases in the Database service

* Support for data masking in the Cloud Guard service

* Support for opting out of DNS records during instance launch, as well as attaching secondary VNICs, in the Compute service

* Support for mutable sizes on cluster networks in the Autoscaling service

* Support for auto-tiering on buckets in the Object Storage service

## Breaking

* VCN id parameters were moved from being required to being optional on all list operations in the Networking service
