### PR TITLE
Releasing version 2.38.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 ====================
+2.38.2 - 2021-05-11
+====================
+
+Added
+-----
+* Support for creating notebook sessions with larger block volumes in the Data Science service
+* Support for database maintenance run patch modes in the Database service
+
+Fixed
+-----
+* Fixed a bug where `timeout=None` was not respected when passed to clients. The older versions of the SDK still use the default connection timeout(10s) and read timeout(60s) when initialized with `timeout=None`
+
+Changed
+-------
+* Improvement in the performance of Upload Manager for parallel uploads. This is achieved by overriding the default read size of Python HTTP client from 8192 bytes to 64 kb.
+
+====================
 2.38.1 - 2021-05-04
 ====================
 

--- a/docs/known-issues.rst
+++ b/docs/known-issues.rst
@@ -64,3 +64,13 @@ Potential data corruption with Python SDK on binary upload (versions 2.8.0 and b
 Default timeout not getting set in the clients (versions 2.17.2 and below)
 ==========================================================================
 The default timeout values (connect timeout = 10 secs and read timeout = 60 secs) we not getting set in the clients and remained None (infinite timeout). This has been fixed in v2.18.0.
+
+Some BlockStorage composite operations throw a 404/NotAuthorizedOrNotFound for Cross Region operations
+======================================================================================================
+**Details:** The copy_boot_volume_backup_and_wait_for_state() and copy_volume_backup_and_wait_for_state() from the BlockStorage Client Composite operations throw a 404/NotAuthorizedOrNotFound when copying a backup from one region to another even though the operation succeeds eventually.
+
+**Impacted Versions:** All
+
+**Workaround:** Instead of using the composite operations, use two different clients for this operation; one client in the Source Region to send the request for copying the backup from Region A to Region B, and a second client in Destination region to wait for the backup to become available. See `this <https://github.com/oracle/oci-python-sdk/blob/master/examples/copy_volume_backup_example.py>`_ for an example.
+
+**Direct link to this issue:** `Some BlockStorage composite operations throw a 404/NotAuthorizedOrNotFound for Cross Region operations <https://github.com/oracle/oci-python-sdk/issues/344>`_

--- a/examples/copy_boot_volume_backup_example.py
+++ b/examples/copy_boot_volume_backup_example.py
@@ -2,27 +2,27 @@
 # Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
 # This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 
-# This example demonstrates how to copy volume backups to a different region and wait on the copy status.
+# This example demonstrates how to copy boot volume backups to a different region and wait on the copy status.
 #
 # # USAGE:
-# `python examples/copy_volume_backup_example.py  \
+# `python examples/copy_boot_volume_backup_example.py  \
 #        --volume-backup-id 'foo' \
 #        --destination-region '<destination_region>' \
 #        --display_name 'bar' \
 #        --kms-key-id 'baz'`
 #
 # Example (copying from us-phoenix-1 to eu-frankfurt-1 :
-# `python examples/copy_volume_backup_example.py  \
-#        --volume-backup-id 'ocid1.volumebackup.oc1.phx.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' \
-#        --destination-region 'eu-frankfurt-1'
+# `python examples/copy_boot_volume_backup_example.py  \
+#        --boot-volume-backup-id 'ocid1.bootvolumebackup.oc1.phx.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' \
+#        --destination-region 'us-ashburn-1'
 #        --display-name 'copied backup from phoenix' \
-#        --kms-key-id 'ocid1.key.oc1.fra.aaaaaaaaaaaaa.bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'`
+#        --kms-key-id 'ocid1.key.oc1.iad.aaaaaaaaaaaaa.bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'`
 #
 # This script accepts up to for arguments:
-#   - volume-backup-id: is the OCID of the volume backup to copy.
-#   - destination-region: is the name of the region to copy the volume backup to.
-#   - display_name (optional): is the new display name of the copied volume backup. If omitted, the copied volume backup
-# will have the same display name as the source backup.
+#   - boot-volume-backup-id: is the OCID of the boot volume backup to copy.
+#   - destination-region: is the name of the region to copy the boot volume backup to.
+#   - display_name (optional): is the new display name of the copied boot volume backup.
+#     If omitted, the copied boot volume backup will have the same display name as the source backup.
 #   - kms-key-id (optional): is the OCID of the kms key to use in the destination region to encrypt
 # the copied backup with. If not specified, a platform ad-master key will be used.
 
@@ -32,28 +32,28 @@ import argparse
 
 # parse arguments
 parser = argparse.ArgumentParser()
-parser.add_argument('--volume-backup-id',
-                    help='the OCID of the volume backup to copy',
+parser.add_argument('--boot-volume-backup-id',
+                    help='the OCID of the boot volume backup to copy',
                     required=True
                     )
 parser.add_argument('--destination-region',
-                    help='the name of the destination region',
+                    help='the name of the destination region to copy the backup to',
                     required=True
                     )
 
 parser.add_argument('--display-name',
-                    help='the display name of the copied backup. If not specified, '
+                    help='the display name of the copied boot volume backup. If not specified, '
                          'defaults to the same as the original backup\'s display name',
                     required=False
                     )
 
 parser.add_argument('--kms-key-id',
-                    help='the OCID of the kms key in the destination region to encrypt the copied backup',
+                    help='the OCID of the kms key in the destination region to encrypt the copied boot volume backup',
                     required=False
                     )
 args = parser.parse_args()
 
-source_backup_id = args.volume_backup_id
+source_backup_id = args.boot_volume_backup_id
 destination_region = args.destination_region
 kms_key_id = args.kms_key_id
 display_name = args.display_name
@@ -65,24 +65,24 @@ destination_config["region"] = destination_region
 source_blockstorage_client = oci.core.BlockstorageClient(source_config)
 destination_blockstorage_client = oci.core.BlockstorageClient(destination_config)
 
-print('Copying backup with ID {} from {} to {} using new display name: {} and kms key id: {} \n'.format(
+print('Copying boot volume backup with ID {} from {} to {} using new display name: {} and kms key id: {} \n'.format(
     source_backup_id, source_config["region"], destination_region, display_name, kms_key_id))
-result = source_blockstorage_client.copy_volume_backup(
+result = source_blockstorage_client.copy_boot_volume_backup(
     source_backup_id,
-    oci.core.models.CopyVolumeBackupDetails(
+    oci.core.models.CopyBootVolumeBackupDetails(
         destination_region=destination_region,
         display_name=display_name,
         kms_key_id=kms_key_id
     )
 )
 
-print('Copy backup response status: {}, copied backup: {}\n'.format(result.status, result.data))
+print('Copy boot volume backup response status: {}, copied backup: {}\n'.format(result.status, result.data))
 print('Waiting for the copied backup to be in available state...')
 
 # query the destination region for the copied' backup's status and wait for it to be available.
 copied_backup = oci.wait_until(
     destination_blockstorage_client,
-    destination_blockstorage_client.get_volume_backup(result.data.id),
+    destination_blockstorage_client.get_boot_volume_backup(result.data.id),
     'lifecycle_state',
     'AVAILABLE'
 ).data

--- a/src/oci/ai_language/ai_service_language_client.py
+++ b/src/oci/ai_language/ai_service_language_client.py
@@ -79,11 +79,12 @@ class AIServiceLanguageClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20210101',
             'service_endpoint_template': 'https://language.aiservice.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("ai_service_language", config, signer, ai_language_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/analytics/analytics_client.py
+++ b/src/oci/analytics/analytics_client.py
@@ -77,11 +77,12 @@ class AnalyticsClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20190331',
             'service_endpoint_template': 'https://analytics.{region}.ocp.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("analytics", config, signer, analytics_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/announcements_service/announcement_client.py
+++ b/src/oci/announcements_service/announcement_client.py
@@ -77,11 +77,12 @@ class AnnouncementClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20180904',
             'service_endpoint_template': 'https://announcements.{region}.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("announcement", config, signer, announcements_service_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/announcements_service/announcements_preferences_client.py
+++ b/src/oci/announcements_service/announcements_preferences_client.py
@@ -77,11 +77,12 @@ class AnnouncementsPreferencesClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20180904',
             'service_endpoint_template': 'https://announcements.{region}.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("announcements_preferences", config, signer, announcements_service_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/apigateway/api_gateway_client.py
+++ b/src/oci/apigateway/api_gateway_client.py
@@ -79,11 +79,12 @@ class ApiGatewayClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20190501',
             'service_endpoint_template': 'https://apigateway.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("api_gateway", config, signer, apigateway_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/apigateway/deployment_client.py
+++ b/src/oci/apigateway/deployment_client.py
@@ -79,11 +79,12 @@ class DeploymentClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20190501',
             'service_endpoint_template': 'https://apigateway.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("deployment", config, signer, apigateway_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/apigateway/gateway_client.py
+++ b/src/oci/apigateway/gateway_client.py
@@ -79,11 +79,12 @@ class GatewayClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20190501',
             'service_endpoint_template': 'https://apigateway.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("gateway", config, signer, apigateway_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/apigateway/work_requests_client.py
+++ b/src/oci/apigateway/work_requests_client.py
@@ -79,11 +79,12 @@ class WorkRequestsClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20190501',
             'service_endpoint_template': 'https://apigateway.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("work_requests", config, signer, apigateway_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/apm_control_plane/apm_domain_client.py
+++ b/src/oci/apm_control_plane/apm_domain_client.py
@@ -78,11 +78,12 @@ class ApmDomainClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20200630',
             'service_endpoint_template': 'https://apm-cp.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("apm_domain", config, signer, apm_control_plane_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/apm_synthetics/apm_synthetic_client.py
+++ b/src/oci/apm_synthetics/apm_synthetic_client.py
@@ -77,11 +77,12 @@ class ApmSyntheticClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20200630',
             'service_endpoint_template': 'https://apm-synthetic.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("apm_synthetic", config, signer, apm_synthetics_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/apm_traces/query_client.py
+++ b/src/oci/apm_traces/query_client.py
@@ -77,11 +77,12 @@ class QueryClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20200630',
             'service_endpoint_template': 'https://apm-trace.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("query", config, signer, apm_traces_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/apm_traces/trace_client.py
+++ b/src/oci/apm_traces/trace_client.py
@@ -77,11 +77,12 @@ class TraceClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20200630',
             'service_endpoint_template': 'https://apm-trace.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("trace", config, signer, apm_traces_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/application_migration/application_migration_client.py
+++ b/src/oci/application_migration/application_migration_client.py
@@ -80,11 +80,12 @@ class ApplicationMigrationClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20191031',
             'service_endpoint_template': 'https://applicationmigration.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("application_migration", config, signer, application_migration_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/artifacts/artifacts_client.py
+++ b/src/oci/artifacts/artifacts_client.py
@@ -78,11 +78,12 @@ class ArtifactsClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20160918',
             'service_endpoint_template': 'https://artifacts.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("artifacts", config, signer, artifacts_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/audit/audit_client.py
+++ b/src/oci/audit/audit_client.py
@@ -80,11 +80,12 @@ class AuditClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20190901',
             'service_endpoint_template': 'https://audit.{region}.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("audit", config, signer, audit_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/autoscaling/auto_scaling_client.py
+++ b/src/oci/autoscaling/auto_scaling_client.py
@@ -82,11 +82,12 @@ class AutoScalingClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20181001',
             'service_endpoint_template': 'https://autoscaling.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("auto_scaling", config, signer, autoscaling_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/base_client.py
+++ b/src/oci/base_client.py
@@ -151,8 +151,8 @@ class BaseClient(object):
         self.type_mappings = merge_type_mappings(self.primitive_type_map, type_mapping)
         self.session = requests.Session()
 
-        timeout_value_in_kwargs = kwargs.get('timeout')
-        self.timeout = timeout_value_in_kwargs if timeout_value_in_kwargs else (DEFAULT_CONNECTION_TIMEOUT, DEFAULT_READ_TIMEOUT)
+        # If the user doesn't specify timeout explicitly we would use default timeout.
+        self.timeout = kwargs.get('timeout') if 'timeout' in kwargs else (DEFAULT_CONNECTION_TIMEOUT, DEFAULT_READ_TIMEOUT)
 
         self.user_agent = build_user_agent(get_config_value_or_default(config, "additional_user_agent"))
 

--- a/src/oci/bds/bds_client.py
+++ b/src/oci/bds/bds_client.py
@@ -79,11 +79,12 @@ class BdsClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20190531',
             'service_endpoint_template': 'https://bigdataservice.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("bds", config, signer, bds_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/blockchain/blockchain_platform_client.py
+++ b/src/oci/blockchain/blockchain_platform_client.py
@@ -77,11 +77,12 @@ class BlockchainPlatformClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20191010',
             'service_endpoint_template': 'https://blockchain.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("blockchain_platform", config, signer, blockchain_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/budget/budget_client.py
+++ b/src/oci/budget/budget_client.py
@@ -77,11 +77,12 @@ class BudgetClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20190111',
             'service_endpoint_template': 'https://usage.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("budget", config, signer, budget_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/cims/incident_client.py
+++ b/src/oci/cims/incident_client.py
@@ -77,11 +77,12 @@ class IncidentClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20181231',
             'service_endpoint_template': 'https://incidentmanagement.{region}.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("incident", config, signer, cims_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/cims/user_client.py
+++ b/src/oci/cims/user_client.py
@@ -77,11 +77,12 @@ class UserClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20181231',
             'service_endpoint_template': 'https://incidentmanagement.{region}.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("user", config, signer, cims_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/cloud_guard/cloud_guard_client.py
+++ b/src/oci/cloud_guard/cloud_guard_client.py
@@ -77,11 +77,12 @@ class CloudGuardClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20200131',
             'service_endpoint_template': 'https://cloudguard-cp-api.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("cloud_guard", config, signer, cloud_guard_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/compute_instance_agent/compute_instance_agent_client.py
+++ b/src/oci/compute_instance_agent/compute_instance_agent_client.py
@@ -78,11 +78,12 @@ class ComputeInstanceAgentClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20180530',
             'service_endpoint_template': 'https://iaas.{region}.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("compute_instance_agent", config, signer, compute_instance_agent_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/compute_instance_agent/plugin_client.py
+++ b/src/oci/compute_instance_agent/plugin_client.py
@@ -78,11 +78,12 @@ class PluginClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20180530',
             'service_endpoint_template': 'https://iaas.{region}.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("plugin", config, signer, compute_instance_agent_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/compute_instance_agent/pluginconfig_client.py
+++ b/src/oci/compute_instance_agent/pluginconfig_client.py
@@ -78,11 +78,12 @@ class PluginconfigClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20180530',
             'service_endpoint_template': 'https://iaas.{region}.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("pluginconfig", config, signer, compute_instance_agent_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/container_engine/container_engine_client.py
+++ b/src/oci/container_engine/container_engine_client.py
@@ -79,11 +79,12 @@ class ContainerEngineClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20180222',
             'service_endpoint_template': 'https://containerengine.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("container_engine", config, signer, container_engine_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/core/blockstorage_client.py
+++ b/src/oci/core/blockstorage_client.py
@@ -81,11 +81,12 @@ class BlockstorageClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20160918',
             'service_endpoint_template': 'https://iaas.{region}.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("blockstorage", config, signer, core_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
         self._config = config

--- a/src/oci/core/compute_client.py
+++ b/src/oci/core/compute_client.py
@@ -81,11 +81,12 @@ class ComputeClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20160918',
             'service_endpoint_template': 'https://iaas.{region}.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("compute", config, signer, core_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
         self._config = config

--- a/src/oci/core/compute_management_client.py
+++ b/src/oci/core/compute_management_client.py
@@ -81,11 +81,12 @@ class ComputeManagementClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20160918',
             'service_endpoint_template': 'https://iaas.{region}.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("compute_management", config, signer, core_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
         self._config = config

--- a/src/oci/core/virtual_network_client.py
+++ b/src/oci/core/virtual_network_client.py
@@ -81,11 +81,12 @@ class VirtualNetworkClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20160918',
             'service_endpoint_template': 'https://iaas.{region}.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("virtual_network", config, signer, core_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
         self._config = config

--- a/src/oci/data_catalog/data_catalog_client.py
+++ b/src/oci/data_catalog/data_catalog_client.py
@@ -77,11 +77,12 @@ class DataCatalogClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20190325',
             'service_endpoint_template': 'https://datacatalog.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("data_catalog", config, signer, data_catalog_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/data_flow/data_flow_client.py
+++ b/src/oci/data_flow/data_flow_client.py
@@ -77,11 +77,12 @@ class DataFlowClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20200129',
             'service_endpoint_template': 'https://dataflow.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("data_flow", config, signer, data_flow_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/data_integration/data_integration_client.py
+++ b/src/oci/data_integration/data_integration_client.py
@@ -77,11 +77,12 @@ class DataIntegrationClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20200430',
             'service_endpoint_template': 'https://dataintegration.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("data_integration", config, signer, data_integration_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/data_safe/data_safe_client.py
+++ b/src/oci/data_safe/data_safe_client.py
@@ -77,11 +77,12 @@ class DataSafeClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20181201',
             'service_endpoint_template': 'https://datasafe.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("data_safe", config, signer, data_safe_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/data_science/data_science_client.py
+++ b/src/oci/data_science/data_science_client.py
@@ -78,11 +78,12 @@ class DataScienceClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20190101',
             'service_endpoint_template': 'https://datascience.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("data_science", config, signer, data_science_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 
@@ -3772,10 +3773,10 @@ class DataScienceClient(object):
 
     def update_model_deployment(self, model_deployment_id, update_model_deployment_details, **kwargs):
         """
-        Updates the properties of a model deployment. You can update the `displayName`.
-        When the model deployment is in the ACTIVE lifecycle state, you can update `modelDeploymentConfigurationDetails` and  change `instanceShapeName` and `modelId`. Any update to
-        `bandwidthMbps` or `instanceCount` can be done when the model deployment is in the INACTIVE lifecycle state. Changes to the `bandwidthMbps` or `instanceCount` will take effect
-        the next time the `ActivateModelDeployment` action is invoked on the model deployment resource.
+        Updates the properties of a model deployment. Some of the properties of `modelDeploymentConfigurationDetails` or `CategoryLogDetails` can also be updated with zero down time when
+        the model deployment's lifecycle state is ACTIVE i.e `instanceShapeName` can be updated along with `modelId`, similarly `logId` can be updated along with `logGroupId`. But
+        `instanceShapeName` or `modelId` cannot be updated along with `logId` or `logGroupId`. All of the fields can be updated when the deployment is in the INACTIVE lifecycle state.
+        Changes will take effect the next time the model deployment is activated.
 
 
         :param str model_deployment_id: (required)
@@ -3784,9 +3785,10 @@ class DataScienceClient(object):
             __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param oci.data_science.models.UpdateModelDeploymentDetails update_model_deployment_details: (required)
-            Details for updating a model deployment. You can update `modelDeploymentConfigurationDetails` and change `instanceShapeName` and `modelId` when the model deployment is in
-            the ACTIVE lifecycle state. The `bandwidthMbps` or `instanceCount` can only be updated while the model deployment is in the `INACTIVE` state. Changes to the `bandwidthMbps`
-            or `instanceCount` will take effect the next time the `ActivateModelDeployment` action is invoked on the model deployment resource.
+            Details for updating a model deployment. Some of the properties of `modelDeploymentConfigurationDetails` or `CategoryLogDetails` can also be updated with zero down time when
+            the model deployment's lifecycle state is ACTIVE i.e `instanceShapeName` can be updated along with `modelId`, similarly `logId` can be updated along with `logGroupId`. But
+            `instanceShapeName` or `modelId` cannot be updated along with `logId` or `logGroupId`. All of the fields can be updated when the deployment is in the INACTIVE lifecycle state.
+            Changes will take effect the next time the model deployment is activated.
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call

--- a/src/oci/data_science/data_science_client_composite_operations.py
+++ b/src/oci/data_science/data_science_client_composite_operations.py
@@ -662,9 +662,10 @@ class DataScienceClientCompositeOperations(object):
             __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param oci.data_science.models.UpdateModelDeploymentDetails update_model_deployment_details: (required)
-            Details for updating a model deployment. You can update `modelDeploymentConfigurationDetails` and change `instanceShapeName` and `modelId` when the model deployment is in
-            the ACTIVE lifecycle state. The `bandwidthMbps` or `instanceCount` can only be updated while the model deployment is in the `INACTIVE` state. Changes to the `bandwidthMbps`
-            or `instanceCount` will take effect the next time the `ActivateModelDeployment` action is invoked on the model deployment resource.
+            Details for updating a model deployment. Some of the properties of `modelDeploymentConfigurationDetails` or `CategoryLogDetails` can also be updated with zero down time when
+            the model deployment's lifecycle state is ACTIVE i.e `instanceShapeName` can be updated along with `modelId`, similarly `logId` can be updated along with `logGroupId`. But
+            `instanceShapeName` or `modelId` cannot be updated along with `logId` or `logGroupId`. All of the fields can be updated when the deployment is in the INACTIVE lifecycle state.
+            Changes will take effect the next time the model deployment is activated.
 
         :param list[str] wait_for_states:
             An array of states to wait on. These should be valid values for :py:attr:`~oci.data_science.models.WorkRequest.status`

--- a/src/oci/database/database_client.py
+++ b/src/oci/database/database_client.py
@@ -77,11 +77,12 @@ class DatabaseClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20160918',
             'service_endpoint_template': 'https://database.{region}.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("database", config, signer, database_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
         self._config = config

--- a/src/oci/database/models/maintenance_run.py
+++ b/src/oci/database/models/maintenance_run.py
@@ -105,6 +105,14 @@ class MaintenanceRun(object):
     #: This constant has a value of "ONEOFF"
     MAINTENANCE_SUBTYPE_ONEOFF = "ONEOFF"
 
+    #: A constant which can be used with the patching_mode property of a MaintenanceRun.
+    #: This constant has a value of "ROLLING"
+    PATCHING_MODE_ROLLING = "ROLLING"
+
+    #: A constant which can be used with the patching_mode property of a MaintenanceRun.
+    #: This constant has a value of "NONROLLING"
+    PATCHING_MODE_NONROLLING = "NONROLLING"
+
     def __init__(self, **kwargs):
         """
         Initializes a new MaintenanceRun object with values from keyword arguments.
@@ -178,6 +186,16 @@ class MaintenanceRun(object):
             The value to assign to the peer_maintenance_run_id property of this MaintenanceRun.
         :type peer_maintenance_run_id: str
 
+        :param patching_mode:
+            The value to assign to the patching_mode property of this MaintenanceRun.
+            Allowed values for this property are: "ROLLING", "NONROLLING", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type patching_mode: str
+
+        :param patch_failure_count:
+            The value to assign to the patch_failure_count property of this MaintenanceRun.
+        :type patch_failure_count: int
+
         """
         self.swagger_types = {
             'id': 'str',
@@ -194,7 +212,9 @@ class MaintenanceRun(object):
             'maintenance_type': 'str',
             'patch_id': 'str',
             'maintenance_subtype': 'str',
-            'peer_maintenance_run_id': 'str'
+            'peer_maintenance_run_id': 'str',
+            'patching_mode': 'str',
+            'patch_failure_count': 'int'
         }
 
         self.attribute_map = {
@@ -212,7 +232,9 @@ class MaintenanceRun(object):
             'maintenance_type': 'maintenanceType',
             'patch_id': 'patchId',
             'maintenance_subtype': 'maintenanceSubtype',
-            'peer_maintenance_run_id': 'peerMaintenanceRunId'
+            'peer_maintenance_run_id': 'peerMaintenanceRunId',
+            'patching_mode': 'patchingMode',
+            'patch_failure_count': 'patchFailureCount'
         }
 
         self._id = None
@@ -230,6 +252,8 @@ class MaintenanceRun(object):
         self._patch_id = None
         self._maintenance_subtype = None
         self._peer_maintenance_run_id = None
+        self._patching_mode = None
+        self._patch_failure_count = None
 
     @property
     def id(self):
@@ -618,6 +642,60 @@ class MaintenanceRun(object):
         :type: str
         """
         self._peer_maintenance_run_id = peer_maintenance_run_id
+
+    @property
+    def patching_mode(self):
+        """
+        Gets the patching_mode of this MaintenanceRun.
+        Maintenance method, it will be either \"ROLLING\" or \"NONROLLING\". Default value is ROLLING.
+
+        Allowed values for this property are: "ROLLING", "NONROLLING", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The patching_mode of this MaintenanceRun.
+        :rtype: str
+        """
+        return self._patching_mode
+
+    @patching_mode.setter
+    def patching_mode(self, patching_mode):
+        """
+        Sets the patching_mode of this MaintenanceRun.
+        Maintenance method, it will be either \"ROLLING\" or \"NONROLLING\". Default value is ROLLING.
+
+
+        :param patching_mode: The patching_mode of this MaintenanceRun.
+        :type: str
+        """
+        allowed_values = ["ROLLING", "NONROLLING"]
+        if not value_allowed_none_or_none_sentinel(patching_mode, allowed_values):
+            patching_mode = 'UNKNOWN_ENUM_VALUE'
+        self._patching_mode = patching_mode
+
+    @property
+    def patch_failure_count(self):
+        """
+        Gets the patch_failure_count of this MaintenanceRun.
+        Contain the patch failure count.
+
+
+        :return: The patch_failure_count of this MaintenanceRun.
+        :rtype: int
+        """
+        return self._patch_failure_count
+
+    @patch_failure_count.setter
+    def patch_failure_count(self, patch_failure_count):
+        """
+        Sets the patch_failure_count of this MaintenanceRun.
+        Contain the patch failure count.
+
+
+        :param patch_failure_count: The patch_failure_count of this MaintenanceRun.
+        :type: int
+        """
+        self._patch_failure_count = patch_failure_count
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/database/models/maintenance_run_summary.py
+++ b/src/oci/database/models/maintenance_run_summary.py
@@ -105,6 +105,14 @@ class MaintenanceRunSummary(object):
     #: This constant has a value of "ONEOFF"
     MAINTENANCE_SUBTYPE_ONEOFF = "ONEOFF"
 
+    #: A constant which can be used with the patching_mode property of a MaintenanceRunSummary.
+    #: This constant has a value of "ROLLING"
+    PATCHING_MODE_ROLLING = "ROLLING"
+
+    #: A constant which can be used with the patching_mode property of a MaintenanceRunSummary.
+    #: This constant has a value of "NONROLLING"
+    PATCHING_MODE_NONROLLING = "NONROLLING"
+
     def __init__(self, **kwargs):
         """
         Initializes a new MaintenanceRunSummary object with values from keyword arguments.
@@ -178,6 +186,16 @@ class MaintenanceRunSummary(object):
             The value to assign to the peer_maintenance_run_id property of this MaintenanceRunSummary.
         :type peer_maintenance_run_id: str
 
+        :param patching_mode:
+            The value to assign to the patching_mode property of this MaintenanceRunSummary.
+            Allowed values for this property are: "ROLLING", "NONROLLING", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type patching_mode: str
+
+        :param patch_failure_count:
+            The value to assign to the patch_failure_count property of this MaintenanceRunSummary.
+        :type patch_failure_count: int
+
         """
         self.swagger_types = {
             'id': 'str',
@@ -194,7 +212,9 @@ class MaintenanceRunSummary(object):
             'maintenance_type': 'str',
             'patch_id': 'str',
             'maintenance_subtype': 'str',
-            'peer_maintenance_run_id': 'str'
+            'peer_maintenance_run_id': 'str',
+            'patching_mode': 'str',
+            'patch_failure_count': 'int'
         }
 
         self.attribute_map = {
@@ -212,7 +232,9 @@ class MaintenanceRunSummary(object):
             'maintenance_type': 'maintenanceType',
             'patch_id': 'patchId',
             'maintenance_subtype': 'maintenanceSubtype',
-            'peer_maintenance_run_id': 'peerMaintenanceRunId'
+            'peer_maintenance_run_id': 'peerMaintenanceRunId',
+            'patching_mode': 'patchingMode',
+            'patch_failure_count': 'patchFailureCount'
         }
 
         self._id = None
@@ -230,6 +252,8 @@ class MaintenanceRunSummary(object):
         self._patch_id = None
         self._maintenance_subtype = None
         self._peer_maintenance_run_id = None
+        self._patching_mode = None
+        self._patch_failure_count = None
 
     @property
     def id(self):
@@ -618,6 +642,60 @@ class MaintenanceRunSummary(object):
         :type: str
         """
         self._peer_maintenance_run_id = peer_maintenance_run_id
+
+    @property
+    def patching_mode(self):
+        """
+        Gets the patching_mode of this MaintenanceRunSummary.
+        Maintenance method, it will be either \"ROLLING\" or \"NONROLLING\". Default value is ROLLING.
+
+        Allowed values for this property are: "ROLLING", "NONROLLING", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The patching_mode of this MaintenanceRunSummary.
+        :rtype: str
+        """
+        return self._patching_mode
+
+    @patching_mode.setter
+    def patching_mode(self, patching_mode):
+        """
+        Sets the patching_mode of this MaintenanceRunSummary.
+        Maintenance method, it will be either \"ROLLING\" or \"NONROLLING\". Default value is ROLLING.
+
+
+        :param patching_mode: The patching_mode of this MaintenanceRunSummary.
+        :type: str
+        """
+        allowed_values = ["ROLLING", "NONROLLING"]
+        if not value_allowed_none_or_none_sentinel(patching_mode, allowed_values):
+            patching_mode = 'UNKNOWN_ENUM_VALUE'
+        self._patching_mode = patching_mode
+
+    @property
+    def patch_failure_count(self):
+        """
+        Gets the patch_failure_count of this MaintenanceRunSummary.
+        Contain the patch failure count.
+
+
+        :return: The patch_failure_count of this MaintenanceRunSummary.
+        :rtype: int
+        """
+        return self._patch_failure_count
+
+    @patch_failure_count.setter
+    def patch_failure_count(self, patch_failure_count):
+        """
+        Sets the patch_failure_count of this MaintenanceRunSummary.
+        Contain the patch failure count.
+
+
+        :param patch_failure_count: The patch_failure_count of this MaintenanceRunSummary.
+        :type: int
+        """
+        self._patch_failure_count = patch_failure_count
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/database/models/update_maintenance_run_details.py
+++ b/src/oci/database/models/update_maintenance_run_details.py
@@ -13,6 +13,14 @@ class UpdateMaintenanceRunDetails(object):
     Describes the modification parameters for the maintenance run.
     """
 
+    #: A constant which can be used with the patching_mode property of a UpdateMaintenanceRunDetails.
+    #: This constant has a value of "ROLLING"
+    PATCHING_MODE_ROLLING = "ROLLING"
+
+    #: A constant which can be used with the patching_mode property of a UpdateMaintenanceRunDetails.
+    #: This constant has a value of "NONROLLING"
+    PATCHING_MODE_NONROLLING = "NONROLLING"
+
     def __init__(self, **kwargs):
         """
         Initializes a new UpdateMaintenanceRunDetails object with values from keyword arguments.
@@ -34,25 +42,33 @@ class UpdateMaintenanceRunDetails(object):
             The value to assign to the patch_id property of this UpdateMaintenanceRunDetails.
         :type patch_id: str
 
+        :param patching_mode:
+            The value to assign to the patching_mode property of this UpdateMaintenanceRunDetails.
+            Allowed values for this property are: "ROLLING", "NONROLLING"
+        :type patching_mode: str
+
         """
         self.swagger_types = {
             'is_enabled': 'bool',
             'time_scheduled': 'datetime',
             'is_patch_now_enabled': 'bool',
-            'patch_id': 'str'
+            'patch_id': 'str',
+            'patching_mode': 'str'
         }
 
         self.attribute_map = {
             'is_enabled': 'isEnabled',
             'time_scheduled': 'timeScheduled',
             'is_patch_now_enabled': 'isPatchNowEnabled',
-            'patch_id': 'patchId'
+            'patch_id': 'patchId',
+            'patching_mode': 'patchingMode'
         }
 
         self._is_enabled = None
         self._time_scheduled = None
         self._is_patch_now_enabled = None
         self._patch_id = None
+        self._patching_mode = None
 
     @property
     def is_enabled(self):
@@ -153,6 +169,38 @@ class UpdateMaintenanceRunDetails(object):
         :type: str
         """
         self._patch_id = patch_id
+
+    @property
+    def patching_mode(self):
+        """
+        Gets the patching_mode of this UpdateMaintenanceRunDetails.
+        Maintenance method, it will be either \"ROLLING\" or \"NONROLLING\". Default value is ROLLING.
+
+        Allowed values for this property are: "ROLLING", "NONROLLING"
+
+
+        :return: The patching_mode of this UpdateMaintenanceRunDetails.
+        :rtype: str
+        """
+        return self._patching_mode
+
+    @patching_mode.setter
+    def patching_mode(self, patching_mode):
+        """
+        Sets the patching_mode of this UpdateMaintenanceRunDetails.
+        Maintenance method, it will be either \"ROLLING\" or \"NONROLLING\". Default value is ROLLING.
+
+
+        :param patching_mode: The patching_mode of this UpdateMaintenanceRunDetails.
+        :type: str
+        """
+        allowed_values = ["ROLLING", "NONROLLING"]
+        if not value_allowed_none_or_none_sentinel(patching_mode, allowed_values):
+            raise ValueError(
+                "Invalid value for `patching_mode`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._patching_mode = patching_mode
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/database_management/db_management_client.py
+++ b/src/oci/database_management/db_management_client.py
@@ -79,11 +79,12 @@ class DbManagementClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20201101',
             'service_endpoint_template': 'https://dbmgmt.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("db_management", config, signer, database_management_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/database_migration/database_migration_client.py
+++ b/src/oci/database_migration/database_migration_client.py
@@ -77,11 +77,12 @@ class DatabaseMigrationClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20200720',
             'service_endpoint_template': 'https://odms.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("database_migration", config, signer, database_migration_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/dns/dns_client.py
+++ b/src/oci/dns/dns_client.py
@@ -78,11 +78,12 @@ class DnsClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20180115',
             'service_endpoint_template': 'https://dns.{region}.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("dns", config, signer, dns_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/dts/appliance_export_job_client.py
+++ b/src/oci/dts/appliance_export_job_client.py
@@ -77,11 +77,12 @@ class ApplianceExportJobClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20171001',
             'service_endpoint_template': 'https://datatransfer.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("appliance_export_job", config, signer, dts_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/dts/shipping_vendors_client.py
+++ b/src/oci/dts/shipping_vendors_client.py
@@ -77,11 +77,12 @@ class ShippingVendorsClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20171001',
             'service_endpoint_template': 'https://datatransfer.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("shipping_vendors", config, signer, dts_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/dts/transfer_appliance_client.py
+++ b/src/oci/dts/transfer_appliance_client.py
@@ -77,11 +77,12 @@ class TransferApplianceClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20171001',
             'service_endpoint_template': 'https://datatransfer.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("transfer_appliance", config, signer, dts_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/dts/transfer_appliance_entitlement_client.py
+++ b/src/oci/dts/transfer_appliance_entitlement_client.py
@@ -77,11 +77,12 @@ class TransferApplianceEntitlementClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20171001',
             'service_endpoint_template': 'https://datatransfer.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("transfer_appliance_entitlement", config, signer, dts_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/dts/transfer_device_client.py
+++ b/src/oci/dts/transfer_device_client.py
@@ -77,11 +77,12 @@ class TransferDeviceClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20171001',
             'service_endpoint_template': 'https://datatransfer.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("transfer_device", config, signer, dts_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/dts/transfer_job_client.py
+++ b/src/oci/dts/transfer_job_client.py
@@ -77,11 +77,12 @@ class TransferJobClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20171001',
             'service_endpoint_template': 'https://datatransfer.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("transfer_job", config, signer, dts_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/dts/transfer_package_client.py
+++ b/src/oci/dts/transfer_package_client.py
@@ -77,11 +77,12 @@ class TransferPackageClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20171001',
             'service_endpoint_template': 'https://datatransfer.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("transfer_package", config, signer, dts_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/email/email_client.py
+++ b/src/oci/email/email_client.py
@@ -81,11 +81,12 @@ class EmailClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20170907',
             'service_endpoint_template': 'https://email.{region}.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("email", config, signer, email_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/events/events_client.py
+++ b/src/oci/events/events_client.py
@@ -78,11 +78,12 @@ class EventsClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20181201',
             'service_endpoint_template': 'https://events.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("events", config, signer, events_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/file_storage/file_storage_client.py
+++ b/src/oci/file_storage/file_storage_client.py
@@ -77,11 +77,12 @@ class FileStorageClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20171215',
             'service_endpoint_template': 'https://filestorage.{region}.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("file_storage", config, signer, file_storage_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/functions/functions_invoke_client.py
+++ b/src/oci/functions/functions_invoke_client.py
@@ -78,11 +78,12 @@ class FunctionsInvokeClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20181201',
             'service_endpoint_template': 'https://functions.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("functions_invoke", config, signer, functions_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/functions/functions_management_client.py
+++ b/src/oci/functions/functions_management_client.py
@@ -77,11 +77,12 @@ class FunctionsManagementClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20181201',
             'service_endpoint_template': 'https://functions.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("functions_management", config, signer, functions_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/golden_gate/golden_gate_client.py
+++ b/src/oci/golden_gate/golden_gate_client.py
@@ -77,11 +77,12 @@ class GoldenGateClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20200407',
             'service_endpoint_template': 'https://goldengate.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("golden_gate", config, signer, golden_gate_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/healthchecks/health_checks_client.py
+++ b/src/oci/healthchecks/health_checks_client.py
@@ -79,11 +79,12 @@ class HealthChecksClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20180501',
             'service_endpoint_template': 'https://healthchecks.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("health_checks", config, signer, healthchecks_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/identity/identity_client.py
+++ b/src/oci/identity/identity_client.py
@@ -77,10 +77,11 @@ class IdentityClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20160918',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("identity", config, signer, identity_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/integration/integration_instance_client.py
+++ b/src/oci/integration/integration_instance_client.py
@@ -77,11 +77,12 @@ class IntegrationInstanceClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20190131',
             'service_endpoint_template': 'https://integration.{region}.ocp.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("integration_instance", config, signer, integration_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/key_management/kms_crypto_client.py
+++ b/src/oci/key_management/kms_crypto_client.py
@@ -76,11 +76,12 @@ class KmsCryptoClient(object):
         base_client_init_kwargs = {
             'regional_client': False,
             'service_endpoint': service_endpoint,
-            'timeout': kwargs.get('timeout'),
             'base_path': '/',
             'service_endpoint_template': 'https://kms.{region}.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("kms_crypto", config, signer, key_management_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/key_management/kms_management_client.py
+++ b/src/oci/key_management/kms_management_client.py
@@ -77,11 +77,12 @@ class KmsManagementClient(object):
         base_client_init_kwargs = {
             'regional_client': False,
             'service_endpoint': service_endpoint,
-            'timeout': kwargs.get('timeout'),
             'base_path': '/',
             'service_endpoint_template': 'https://kms.{region}.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("kms_management", config, signer, key_management_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/key_management/kms_vault_client.py
+++ b/src/oci/key_management/kms_vault_client.py
@@ -79,11 +79,12 @@ class KmsVaultClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/',
             'service_endpoint_template': 'https://kms.{region}.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("kms_vault", config, signer, key_management_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/limits/limits_client.py
+++ b/src/oci/limits/limits_client.py
@@ -77,11 +77,12 @@ class LimitsClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/',
             'service_endpoint_template': 'https://limits.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("limits", config, signer, limits_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/limits/quotas_client.py
+++ b/src/oci/limits/quotas_client.py
@@ -77,11 +77,12 @@ class QuotasClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/',
             'service_endpoint_template': 'https://limits.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("quotas", config, signer, limits_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/load_balancer/load_balancer_client.py
+++ b/src/oci/load_balancer/load_balancer_client.py
@@ -78,11 +78,12 @@ class LoadBalancerClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20170115',
             'service_endpoint_template': 'https://iaas.{region}.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("load_balancer", config, signer, load_balancer_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/log_analytics/log_analytics_client.py
+++ b/src/oci/log_analytics/log_analytics_client.py
@@ -78,11 +78,12 @@ class LogAnalyticsClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20200601',
             'service_endpoint_template': 'https://loganalytics.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("log_analytics", config, signer, log_analytics_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/logging/logging_management_client.py
+++ b/src/oci/logging/logging_management_client.py
@@ -77,11 +77,12 @@ class LoggingManagementClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20200531',
             'service_endpoint_template': 'https://logging.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("logging_management", config, signer, logging_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/loggingingestion/logging_client.py
+++ b/src/oci/loggingingestion/logging_client.py
@@ -77,11 +77,12 @@ class LoggingClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20200831',
             'service_endpoint_template': 'https://ingestion.logging.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("logging", config, signer, loggingingestion_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/loggingsearch/log_search_client.py
+++ b/src/oci/loggingsearch/log_search_client.py
@@ -77,11 +77,12 @@ class LogSearchClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20190909',
             'service_endpoint_template': 'https://logging.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("log_search", config, signer, loggingsearch_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/management_agent/management_agent_client.py
+++ b/src/oci/management_agent/management_agent_client.py
@@ -77,11 +77,12 @@ class ManagementAgentClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20200202',
             'service_endpoint_template': 'https://management-agent.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("management_agent", config, signer, management_agent_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/management_dashboard/dashx_apis_client.py
+++ b/src/oci/management_dashboard/dashx_apis_client.py
@@ -77,11 +77,12 @@ class DashxApisClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20200901',
             'service_endpoint_template': 'https://managementdashboard.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("dashx_apis", config, signer, management_dashboard_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/marketplace/marketplace_client.py
+++ b/src/oci/marketplace/marketplace_client.py
@@ -77,11 +77,12 @@ class MarketplaceClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20181001',
             'service_endpoint_template': 'https://marketplace.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("marketplace", config, signer, marketplace_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/monitoring/monitoring_client.py
+++ b/src/oci/monitoring/monitoring_client.py
@@ -79,11 +79,12 @@ class MonitoringClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20180401',
             'service_endpoint_template': 'https://telemetry.{region}.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("monitoring", config, signer, monitoring_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/mysql/channels_client.py
+++ b/src/oci/mysql/channels_client.py
@@ -77,11 +77,12 @@ class ChannelsClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20190415',
             'service_endpoint_template': 'https://mysql.{region}.ocp.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("channels", config, signer, mysql_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/mysql/db_backups_client.py
+++ b/src/oci/mysql/db_backups_client.py
@@ -77,11 +77,12 @@ class DbBackupsClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20190415',
             'service_endpoint_template': 'https://mysql.{region}.ocp.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("db_backups", config, signer, mysql_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/mysql/db_system_client.py
+++ b/src/oci/mysql/db_system_client.py
@@ -77,11 +77,12 @@ class DbSystemClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20190415',
             'service_endpoint_template': 'https://mysql.{region}.ocp.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("db_system", config, signer, mysql_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/mysql/mysqlaas_client.py
+++ b/src/oci/mysql/mysqlaas_client.py
@@ -77,11 +77,12 @@ class MysqlaasClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20190415',
             'service_endpoint_template': 'https://mysql.{region}.ocp.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("mysqlaas", config, signer, mysql_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/mysql/work_requests_client.py
+++ b/src/oci/mysql/work_requests_client.py
@@ -77,11 +77,12 @@ class WorkRequestsClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20190415',
             'service_endpoint_template': 'https://mysql.{region}.ocp.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("work_requests", config, signer, mysql_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/network_load_balancer/network_load_balancer_client.py
+++ b/src/oci/network_load_balancer/network_load_balancer_client.py
@@ -77,11 +77,12 @@ class NetworkLoadBalancerClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20200501',
             'service_endpoint_template': 'https://network-load-balancer-api.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("network_load_balancer", config, signer, network_load_balancer_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/nosql/nosql_client.py
+++ b/src/oci/nosql/nosql_client.py
@@ -80,11 +80,12 @@ class NosqlClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20190828',
             'service_endpoint_template': 'https://nosql.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("nosql", config, signer, nosql_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/object_storage/object_storage_client.py
+++ b/src/oci/object_storage/object_storage_client.py
@@ -80,11 +80,12 @@ class ObjectStorageClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/',
             'service_endpoint_template': 'https://objectstorage.{region}.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("object_storage", config, signer, object_storage_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/oce/oce_instance_client.py
+++ b/src/oci/oce/oce_instance_client.py
@@ -77,11 +77,12 @@ class OceInstanceClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20190912',
             'service_endpoint_template': 'https://cp.oce.{region}.ocp.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("oce_instance", config, signer, oce_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/ocvp/esxi_host_client.py
+++ b/src/oci/ocvp/esxi_host_client.py
@@ -77,11 +77,12 @@ class EsxiHostClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20200501',
             'service_endpoint_template': 'https://ocvps.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("esxi_host", config, signer, ocvp_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/ocvp/sddc_client.py
+++ b/src/oci/ocvp/sddc_client.py
@@ -77,11 +77,12 @@ class SddcClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20200501',
             'service_endpoint_template': 'https://ocvps.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("sddc", config, signer, ocvp_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/ocvp/work_request_client.py
+++ b/src/oci/ocvp/work_request_client.py
@@ -77,11 +77,12 @@ class WorkRequestClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20200501',
             'service_endpoint_template': 'https://ocvps.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("work_request", config, signer, ocvp_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/oda/oda_client.py
+++ b/src/oci/oda/oda_client.py
@@ -77,11 +77,12 @@ class OdaClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20190506',
             'service_endpoint_template': 'https://digitalassistant-api.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("oda", config, signer, oda_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/ons/notification_control_plane_client.py
+++ b/src/oci/ons/notification_control_plane_client.py
@@ -78,11 +78,12 @@ class NotificationControlPlaneClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20181201',
             'service_endpoint_template': 'https://notification.{region}.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("notification_control_plane", config, signer, ons_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/ons/notification_data_plane_client.py
+++ b/src/oci/ons/notification_data_plane_client.py
@@ -78,11 +78,12 @@ class NotificationDataPlaneClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20181201',
             'service_endpoint_template': 'https://notification.{region}.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("notification_data_plane", config, signer, ons_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/operator_access_control/access_requests_client.py
+++ b/src/oci/operator_access_control/access_requests_client.py
@@ -80,11 +80,12 @@ class AccessRequestsClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20200630',
             'service_endpoint_template': 'https://operator-access-control.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("access_requests", config, signer, operator_access_control_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/operator_access_control/operator_actions_client.py
+++ b/src/oci/operator_access_control/operator_actions_client.py
@@ -80,11 +80,12 @@ class OperatorActionsClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20200630',
             'service_endpoint_template': 'https://operator-access-control.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("operator_actions", config, signer, operator_access_control_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/operator_access_control/operator_control_assignment_client.py
+++ b/src/oci/operator_access_control/operator_control_assignment_client.py
@@ -80,11 +80,12 @@ class OperatorControlAssignmentClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20200630',
             'service_endpoint_template': 'https://operator-access-control.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("operator_control_assignment", config, signer, operator_access_control_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/operator_access_control/operator_control_client.py
+++ b/src/oci/operator_access_control/operator_control_client.py
@@ -80,11 +80,12 @@ class OperatorControlClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20200630',
             'service_endpoint_template': 'https://operator-access-control.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("operator_control", config, signer, operator_access_control_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/opsi/operations_insights_client.py
+++ b/src/oci/opsi/operations_insights_client.py
@@ -79,11 +79,12 @@ class OperationsInsightsClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20200630',
             'service_endpoint_template': 'https://operationsinsights.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("operations_insights", config, signer, opsi_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/optimizer/optimizer_client.py
+++ b/src/oci/optimizer/optimizer_client.py
@@ -77,11 +77,12 @@ class OptimizerClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20200606',
             'service_endpoint_template': 'https://optimizer.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("optimizer", config, signer, optimizer_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/os_management/os_management_client.py
+++ b/src/oci/os_management/os_management_client.py
@@ -78,11 +78,12 @@ class OsManagementClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20190801',
             'service_endpoint_template': 'https://osms.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("os_management", config, signer, os_management_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/resource_manager/resource_manager_client.py
+++ b/src/oci/resource_manager/resource_manager_client.py
@@ -80,11 +80,12 @@ class ResourceManagerClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20180917',
             'service_endpoint_template': 'https://resourcemanager.{region}.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("resource_manager", config, signer, resource_manager_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/resource_search/resource_search_client.py
+++ b/src/oci/resource_search/resource_search_client.py
@@ -77,11 +77,12 @@ class ResourceSearchClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20180409',
             'service_endpoint_template': 'https://query.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("resource_search", config, signer, resource_search_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/rover/rover_cluster_client.py
+++ b/src/oci/rover/rover_cluster_client.py
@@ -77,11 +77,12 @@ class RoverClusterClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20201210',
             'service_endpoint_template': 'https://rover.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("rover_cluster", config, signer, rover_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/rover/rover_entitlement_client.py
+++ b/src/oci/rover/rover_entitlement_client.py
@@ -77,11 +77,12 @@ class RoverEntitlementClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20201210',
             'service_endpoint_template': 'https://rover.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("rover_entitlement", config, signer, rover_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/rover/rover_node_client.py
+++ b/src/oci/rover/rover_node_client.py
@@ -77,11 +77,12 @@ class RoverNodeClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20201210',
             'service_endpoint_template': 'https://rover.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("rover_node", config, signer, rover_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/sch/service_connector_client.py
+++ b/src/oci/sch/service_connector_client.py
@@ -79,11 +79,12 @@ class ServiceConnectorClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20200909',
             'service_endpoint_template': 'https://service-connector-hub.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("service_connector", config, signer, sch_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/secrets/secrets_client.py
+++ b/src/oci/secrets/secrets_client.py
@@ -77,11 +77,12 @@ class SecretsClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20190301',
             'service_endpoint_template': 'https://secrets.vaults.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("secrets", config, signer, secrets_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/service_catalog/service_catalog_client.py
+++ b/src/oci/service_catalog/service_catalog_client.py
@@ -77,11 +77,12 @@ class ServiceCatalogClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20210527',
             'service_endpoint_template': 'https://service-catalog.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("service_catalog", config, signer, service_catalog_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/streaming/stream_admin_client.py
+++ b/src/oci/streaming/stream_admin_client.py
@@ -77,11 +77,12 @@ class StreamAdminClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20180418',
             'service_endpoint_template': 'https://streaming.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("stream_admin", config, signer, streaming_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/streaming/stream_client.py
+++ b/src/oci/streaming/stream_client.py
@@ -75,11 +75,12 @@ class StreamClient(object):
         base_client_init_kwargs = {
             'regional_client': False,
             'service_endpoint': service_endpoint,
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20180418',
             'service_endpoint_template': 'https://streaming.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("stream", config, signer, streaming_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/tenant_manager_control_plane/domain_client.py
+++ b/src/oci/tenant_manager_control_plane/domain_client.py
@@ -77,11 +77,12 @@ class DomainClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20200801',
             'service_endpoint_template': 'https://organizations.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("domain", config, signer, tenant_manager_control_plane_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/tenant_manager_control_plane/domain_governance_client.py
+++ b/src/oci/tenant_manager_control_plane/domain_governance_client.py
@@ -77,11 +77,12 @@ class DomainGovernanceClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20200801',
             'service_endpoint_template': 'https://organizations.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("domain_governance", config, signer, tenant_manager_control_plane_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/tenant_manager_control_plane/link_client.py
+++ b/src/oci/tenant_manager_control_plane/link_client.py
@@ -77,11 +77,12 @@ class LinkClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20200801',
             'service_endpoint_template': 'https://organizations.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("link", config, signer, tenant_manager_control_plane_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/tenant_manager_control_plane/recipient_invitation_client.py
+++ b/src/oci/tenant_manager_control_plane/recipient_invitation_client.py
@@ -77,11 +77,12 @@ class RecipientInvitationClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20200801',
             'service_endpoint_template': 'https://organizations.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("recipient_invitation", config, signer, tenant_manager_control_plane_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/tenant_manager_control_plane/sender_invitation_client.py
+++ b/src/oci/tenant_manager_control_plane/sender_invitation_client.py
@@ -77,11 +77,12 @@ class SenderInvitationClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20200801',
             'service_endpoint_template': 'https://organizations.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("sender_invitation", config, signer, tenant_manager_control_plane_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/tenant_manager_control_plane/work_request_client.py
+++ b/src/oci/tenant_manager_control_plane/work_request_client.py
@@ -77,11 +77,12 @@ class WorkRequestClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20200801',
             'service_endpoint_template': 'https://organizations.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("work_request", config, signer, tenant_manager_control_plane_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/usage_api/usageapi_client.py
+++ b/src/oci/usage_api/usageapi_client.py
@@ -77,11 +77,12 @@ class UsageapiClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20200107',
             'service_endpoint_template': 'https://usageapi.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("usageapi", config, signer, usage_api_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/vault/vaults_client.py
+++ b/src/oci/vault/vaults_client.py
@@ -77,11 +77,12 @@ class VaultsClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20180608',
             'service_endpoint_template': 'https://vaults.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("vaults", config, signer, vault_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/version.py
+++ b/src/oci/version.py
@@ -2,4 +2,4 @@
 # Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
 # This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 
-__version__ = "2.38.1"
+__version__ = "2.38.2"

--- a/src/oci/vulnerability_scanning/vulnerability_scanning_client.py
+++ b/src/oci/vulnerability_scanning/vulnerability_scanning_client.py
@@ -77,11 +77,12 @@ class VulnerabilityScanningClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20210215',
             'service_endpoint_template': 'https://vss-cp-api.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("vulnerability_scanning", config, signer, vulnerability_scanning_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/waas/redirect_client.py
+++ b/src/oci/waas/redirect_client.py
@@ -77,11 +77,12 @@ class RedirectClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20181116',
             'service_endpoint_template': 'https://waas.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("redirect", config, signer, waas_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/waas/waas_client.py
+++ b/src/oci/waas/waas_client.py
@@ -77,11 +77,12 @@ class WaasClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20181116',
             'service_endpoint_template': 'https://waas.{region}.oci.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("waas", config, signer, waas_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 

--- a/src/oci/work_requests/work_request_client.py
+++ b/src/oci/work_requests/work_request_client.py
@@ -82,11 +82,12 @@ class WorkRequestClient(object):
         base_client_init_kwargs = {
             'regional_client': True,
             'service_endpoint': kwargs.get('service_endpoint'),
-            'timeout': kwargs.get('timeout'),
             'base_path': '/20160918',
             'service_endpoint_template': 'https://iaas.{region}.{secondLevelDomain}',
             'skip_deserialization': kwargs.get('skip_deserialization', False)
         }
+        if 'timeout' in kwargs:
+            base_client_init_kwargs['timeout'] = kwargs.get('timeout')
         self.base_client = BaseClient("work_request", config, signer, work_requests_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 


### PR DESCRIPTION
## Added

* Support for creating notebook sessions with larger block volumes in the Data Science service

* Support for database maintenance run patch modes in the Database service

##Fixed

* Fixed a bug where `timeout=None` was not respected when passed to clients. The older versions of the SDK still use the default connection timeout(10s) and read timeout(60s) when initialized with `timeout=None`

## Changed

* Improvement in the performance of Upload Manager for parallel uploads. This is achieved by overriding the default read size of Python HTTP client from 8192 bytes to 64 kb.
