### PR TITLE
Releasing version 2.39.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 ====================
+2.39.0 - 2021-06-01
+====================
+
+Added
+-----
+* Support for configuration of autonomous database KMS keys in the Database service
+* Support for creating database software images with any supported RUs in the Database service
+* Support for creating database software images from an existing database home in the Database service
+* Support for listing all NSGs associated with a given VLAN in the Networking service
+* Support for a duration windows, task failure reasons, and next execution times on scheduled tasks in the Logging Analytics service
+* Support for calling Oracle Cloud Infrastructure services in the sa-vinhedo-1 region
+
+Breaking
+-----
+* `compartment_id` is now optional in operation `list_network_security_groups` in the Networking service
+
+====================
 2.38.4 - 2021-05-25
 ====================
 

--- a/docs/api/database.rst
+++ b/docs/api/database.rst
@@ -37,6 +37,7 @@ Database
     oci.database.models.AutonomousDatabaseConnectionUrls
     oci.database.models.AutonomousDatabaseConsoleTokenDetails
     oci.database.models.AutonomousDatabaseDataguardAssociation
+    oci.database.models.AutonomousDatabaseKeyHistoryEntry
     oci.database.models.AutonomousDatabaseManualRefreshDetails
     oci.database.models.AutonomousDatabaseStandbySummary
     oci.database.models.AutonomousDatabaseSummary
@@ -67,6 +68,7 @@ Database
     oci.database.models.CloudVmCluster
     oci.database.models.CloudVmClusterSummary
     oci.database.models.CompleteExternalBackupJobDetails
+    oci.database.models.ConfigureAutonomousDatabaseVaultKeyDetails
     oci.database.models.ConsoleConnection
     oci.database.models.ConsoleConnectionSummary
     oci.database.models.CreateAutonomousContainerDatabaseDetails

--- a/docs/api/database/models/oci.database.models.AutonomousDatabaseKeyHistoryEntry.rst
+++ b/docs/api/database/models/oci.database.models.AutonomousDatabaseKeyHistoryEntry.rst
@@ -1,0 +1,11 @@
+AutonomousDatabaseKeyHistoryEntry
+=================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: AutonomousDatabaseKeyHistoryEntry
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/database/models/oci.database.models.ConfigureAutonomousDatabaseVaultKeyDetails.rst
+++ b/docs/api/database/models/oci.database.models.ConfigureAutonomousDatabaseVaultKeyDetails.rst
@@ -1,0 +1,11 @@
+ConfigureAutonomousDatabaseVaultKeyDetails
+==========================================
+
+.. currentmodule:: oci.database.models
+
+.. autoclass:: ConfigureAutonomousDatabaseVaultKeyDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/log_analytics.rst
+++ b/docs/api/log_analytics.rst
@@ -55,6 +55,7 @@ Log Analytics
     oci.log_analytics.models.ColumnName
     oci.log_analytics.models.ColumnNameCollection
     oci.log_analytics.models.CommandDescriptor
+    oci.log_analytics.models.CompareCommandDescriptor
     oci.log_analytics.models.CreateAccelerationTaskDetails
     oci.log_analytics.models.CreateLogAnalyticsEmBridgeDetails
     oci.log_analytics.models.CreateLogAnalyticsEntityDetails

--- a/docs/api/log_analytics/models/oci.log_analytics.models.CompareCommandDescriptor.rst
+++ b/docs/api/log_analytics/models/oci.log_analytics.models.CompareCommandDescriptor.rst
@@ -1,0 +1,11 @@
+CompareCommandDescriptor
+========================
+
+.. currentmodule:: oci.log_analytics.models
+
+.. autoclass:: CompareCommandDescriptor
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/src/oci/core/virtual_network_client.py
+++ b/src/oci/core/virtual_network_client.py
@@ -14462,13 +14462,19 @@ class VirtualNetworkClient(object):
                 header_params=header_params,
                 response_type="list[NetworkSecurityGroupVnic]")
 
-    def list_network_security_groups(self, compartment_id, **kwargs):
+    def list_network_security_groups(self, **kwargs):
         """
-        Lists the network security groups in the specified compartment.
+        Lists either the network security groups in the specified compartment, or those associated with the specified VLAN.
+        You must specify either a `vlanId` or a `compartmentId`, but not both. If you specify a `vlanId`, all other parameters are ignored.
 
 
-        :param str compartment_id: (required)
+        :param str compartment_id: (optional)
             The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+        :param str vlan_id: (optional)
+            The `OCID`__ of the VLAN.
 
             __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
@@ -14540,6 +14546,8 @@ class VirtualNetworkClient(object):
         # Don't accept unknown kwargs
         expected_kwargs = [
             "retry_strategy",
+            "compartment_id",
+            "vlan_id",
             "vcn_id",
             "limit",
             "page",
@@ -14575,7 +14583,8 @@ class VirtualNetworkClient(object):
                 )
 
         query_params = {
-            "compartmentId": compartment_id,
+            "compartmentId": kwargs.get("compartment_id", missing),
+            "vlanId": kwargs.get("vlan_id", missing),
             "vcnId": kwargs.get("vcn_id", missing),
             "limit": kwargs.get("limit", missing),
             "page": kwargs.get("page", missing),

--- a/src/oci/database/database_client.py
+++ b/src/oci/database/database_client.py
@@ -2001,6 +2001,108 @@ class DatabaseClient(object):
                 body=complete_external_backup_job_details,
                 response_type="ExternalBackupJob")
 
+    def configure_autonomous_database_vault_key(self, autonomous_database_id, configure_autonomous_database_vault_key_details, **kwargs):
+        """
+        Configures the Autonomous Database Vault service `key`__.
+
+        __ https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts
+
+
+        :param str autonomous_database_id: (required)
+            The database `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param oci.database.models.ConfigureAutonomousDatabaseVaultKeyDetails configure_autonomous_database_vault_key_details: (required)
+            Configuration details for the Autonomous Database Vault service `key`__.
+
+            __ https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+            parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+            will be updated or deleted only if the etag you provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://docs.oracle.com/en-us/iaas/tools/python/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/database/configure_autonomous_database_vault_key.py.html>`__ to see an example of how to use configure_autonomous_database_vault_key API.
+        """
+        resource_path = "/autonomousDatabases/{autonomousDatabaseId}/actions/configureAutonomousDatabaseVaultKey"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "configure_autonomous_database_vault_key got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "autonomousDatabaseId": autonomous_database_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=configure_autonomous_database_vault_key_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=configure_autonomous_database_vault_key_details)
+
     def create_autonomous_container_database(self, create_autonomous_container_database_details, **kwargs):
         """
         Creates an Autonomous Container Database in the specified Autonomous Exadata Infrastructure.
@@ -11005,7 +11107,7 @@ class DatabaseClient(object):
         :param str lifecycle_state: (optional)
             A filter to return only resources that match the given lifecycle state exactly.
 
-            Allowed values are: "PROVISIONING", "AVAILABLE", "STOPPING", "STOPPED", "STARTING", "TERMINATING", "TERMINATED", "UNAVAILABLE", "RESTORE_IN_PROGRESS", "RESTORE_FAILED", "BACKUP_IN_PROGRESS", "SCALE_IN_PROGRESS", "AVAILABLE_NEEDS_ATTENTION", "UPDATING", "MAINTENANCE_IN_PROGRESS", "RESTARTING", "RECREATING", "ROLE_CHANGE_IN_PROGRESS", "UPGRADING"
+            Allowed values are: "PROVISIONING", "AVAILABLE", "STOPPING", "STOPPED", "STARTING", "TERMINATING", "TERMINATED", "UNAVAILABLE", "RESTORE_IN_PROGRESS", "RESTORE_FAILED", "BACKUP_IN_PROGRESS", "SCALE_IN_PROGRESS", "AVAILABLE_NEEDS_ATTENTION", "UPDATING", "MAINTENANCE_IN_PROGRESS", "RESTARTING", "RECREATING", "ROLE_CHANGE_IN_PROGRESS", "UPGRADING", "INACCESSIBLE"
 
         :param str sort_by: (optional)
             The field to sort by.  You can provide one sort order (`sortOrder`).  Default order for TIMECREATED is descending.  Default order for DISPLAYNAME is ascending. The DISPLAYNAME sort order is case sensitive.
@@ -11071,7 +11173,7 @@ class DatabaseClient(object):
                 )
 
         if 'lifecycle_state' in kwargs:
-            lifecycle_state_allowed_values = ["PROVISIONING", "AVAILABLE", "STOPPING", "STOPPED", "STARTING", "TERMINATING", "TERMINATED", "UNAVAILABLE", "RESTORE_IN_PROGRESS", "RESTORE_FAILED", "BACKUP_IN_PROGRESS", "SCALE_IN_PROGRESS", "AVAILABLE_NEEDS_ATTENTION", "UPDATING", "MAINTENANCE_IN_PROGRESS", "RESTARTING", "RECREATING", "ROLE_CHANGE_IN_PROGRESS", "UPGRADING"]
+            lifecycle_state_allowed_values = ["PROVISIONING", "AVAILABLE", "STOPPING", "STOPPED", "STARTING", "TERMINATING", "TERMINATED", "UNAVAILABLE", "RESTORE_IN_PROGRESS", "RESTORE_FAILED", "BACKUP_IN_PROGRESS", "SCALE_IN_PROGRESS", "AVAILABLE_NEEDS_ATTENTION", "UPDATING", "MAINTENANCE_IN_PROGRESS", "RESTARTING", "RECREATING", "ROLE_CHANGE_IN_PROGRESS", "UPGRADING", "INACCESSIBLE"]
             if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
                 raise ValueError(
                     "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
@@ -11260,7 +11362,7 @@ class DatabaseClient(object):
         :param str lifecycle_state: (optional)
             A filter to return only resources that match the given lifecycle state exactly.
 
-            Allowed values are: "PROVISIONING", "AVAILABLE", "STOPPING", "STOPPED", "STARTING", "TERMINATING", "TERMINATED", "UNAVAILABLE", "RESTORE_IN_PROGRESS", "RESTORE_FAILED", "BACKUP_IN_PROGRESS", "SCALE_IN_PROGRESS", "AVAILABLE_NEEDS_ATTENTION", "UPDATING", "MAINTENANCE_IN_PROGRESS", "RESTARTING", "RECREATING", "ROLE_CHANGE_IN_PROGRESS", "UPGRADING"
+            Allowed values are: "PROVISIONING", "AVAILABLE", "STOPPING", "STOPPED", "STARTING", "TERMINATING", "TERMINATED", "UNAVAILABLE", "RESTORE_IN_PROGRESS", "RESTORE_FAILED", "BACKUP_IN_PROGRESS", "SCALE_IN_PROGRESS", "AVAILABLE_NEEDS_ATTENTION", "UPDATING", "MAINTENANCE_IN_PROGRESS", "RESTARTING", "RECREATING", "ROLE_CHANGE_IN_PROGRESS", "UPGRADING", "INACCESSIBLE"
 
         :param str db_workload: (optional)
             A filter to return only autonomous database resources that match the specified workload type.
@@ -11349,7 +11451,7 @@ class DatabaseClient(object):
                 )
 
         if 'lifecycle_state' in kwargs:
-            lifecycle_state_allowed_values = ["PROVISIONING", "AVAILABLE", "STOPPING", "STOPPED", "STARTING", "TERMINATING", "TERMINATED", "UNAVAILABLE", "RESTORE_IN_PROGRESS", "RESTORE_FAILED", "BACKUP_IN_PROGRESS", "SCALE_IN_PROGRESS", "AVAILABLE_NEEDS_ATTENTION", "UPDATING", "MAINTENANCE_IN_PROGRESS", "RESTARTING", "RECREATING", "ROLE_CHANGE_IN_PROGRESS", "UPGRADING"]
+            lifecycle_state_allowed_values = ["PROVISIONING", "AVAILABLE", "STOPPING", "STOPPED", "STARTING", "TERMINATING", "TERMINATED", "UNAVAILABLE", "RESTORE_IN_PROGRESS", "RESTORE_FAILED", "BACKUP_IN_PROGRESS", "SCALE_IN_PROGRESS", "AVAILABLE_NEEDS_ATTENTION", "UPDATING", "MAINTENANCE_IN_PROGRESS", "RESTARTING", "RECREATING", "ROLE_CHANGE_IN_PROGRESS", "UPGRADING", "INACCESSIBLE"]
             if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
                 raise ValueError(
                     "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
@@ -14208,6 +14310,9 @@ class DatabaseClient(object):
         :param bool is_upgrade_supported: (optional)
             If provided, filters the results to the set of database versions which are supported for Upgrade.
 
+        :param bool is_database_software_image_supported: (optional)
+            If true, filters the results to the set of Oracle Database versions that are supported for OCI database software images.
+
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
 
@@ -14233,7 +14338,8 @@ class DatabaseClient(object):
             "db_system_shape",
             "db_system_id",
             "storage_management",
-            "is_upgrade_supported"
+            "is_upgrade_supported",
+            "is_database_software_image_supported"
         ]
         extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
         if extra_kwargs:
@@ -14254,7 +14360,8 @@ class DatabaseClient(object):
             "dbSystemShape": kwargs.get("db_system_shape", missing),
             "dbSystemId": kwargs.get("db_system_id", missing),
             "storageManagement": kwargs.get("storage_management", missing),
-            "isUpgradeSupported": kwargs.get("is_upgrade_supported", missing)
+            "isUpgradeSupported": kwargs.get("is_upgrade_supported", missing),
+            "isDatabaseSoftwareImageSupported": kwargs.get("is_database_software_image_supported", missing)
         }
         query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
 

--- a/src/oci/database/database_client_composite_operations.py
+++ b/src/oci/database/database_client_composite_operations.py
@@ -880,6 +880,48 @@ class DatabaseClientCompositeOperations(object):
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
+    def configure_autonomous_database_vault_key_and_wait_for_work_request(self, autonomous_database_id, configure_autonomous_database_vault_key_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.database.DatabaseClient.configure_autonomous_database_vault_key` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str autonomous_database_id: (required)
+            The database `OCID`__.
+
+            __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+        :param oci.database.models.ConfigureAutonomousDatabaseVaultKeyDetails configure_autonomous_database_vault_key_details: (required)
+            Configuration details for the Autonomous Database Vault service `key`__.
+
+            __ https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.database.DatabaseClient.configure_autonomous_database_vault_key`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.configure_autonomous_database_vault_key(autonomous_database_id, configure_autonomous_database_vault_key_details, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def create_autonomous_container_database_and_wait_for_work_request(self, create_autonomous_container_database_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.database.DatabaseClient.create_autonomous_container_database` and waits for the oci.work_requests.models.WorkRequest

--- a/src/oci/database/models/__init__.py
+++ b/src/oci/database/models/__init__.py
@@ -23,6 +23,7 @@ from .autonomous_database_connection_strings import AutonomousDatabaseConnection
 from .autonomous_database_connection_urls import AutonomousDatabaseConnectionUrls
 from .autonomous_database_console_token_details import AutonomousDatabaseConsoleTokenDetails
 from .autonomous_database_dataguard_association import AutonomousDatabaseDataguardAssociation
+from .autonomous_database_key_history_entry import AutonomousDatabaseKeyHistoryEntry
 from .autonomous_database_manual_refresh_details import AutonomousDatabaseManualRefreshDetails
 from .autonomous_database_standby_summary import AutonomousDatabaseStandbySummary
 from .autonomous_database_summary import AutonomousDatabaseSummary
@@ -53,6 +54,7 @@ from .cloud_exadata_infrastructure_summary import CloudExadataInfrastructureSumm
 from .cloud_vm_cluster import CloudVmCluster
 from .cloud_vm_cluster_summary import CloudVmClusterSummary
 from .complete_external_backup_job_details import CompleteExternalBackupJobDetails
+from .configure_autonomous_database_vault_key_details import ConfigureAutonomousDatabaseVaultKeyDetails
 from .console_connection import ConsoleConnection
 from .console_connection_summary import ConsoleConnectionSummary
 from .create_autonomous_container_database_details import CreateAutonomousContainerDatabaseDetails
@@ -260,6 +262,7 @@ database_type_mapping = {
     "AutonomousDatabaseConnectionUrls": AutonomousDatabaseConnectionUrls,
     "AutonomousDatabaseConsoleTokenDetails": AutonomousDatabaseConsoleTokenDetails,
     "AutonomousDatabaseDataguardAssociation": AutonomousDatabaseDataguardAssociation,
+    "AutonomousDatabaseKeyHistoryEntry": AutonomousDatabaseKeyHistoryEntry,
     "AutonomousDatabaseManualRefreshDetails": AutonomousDatabaseManualRefreshDetails,
     "AutonomousDatabaseStandbySummary": AutonomousDatabaseStandbySummary,
     "AutonomousDatabaseSummary": AutonomousDatabaseSummary,
@@ -290,6 +293,7 @@ database_type_mapping = {
     "CloudVmCluster": CloudVmCluster,
     "CloudVmClusterSummary": CloudVmClusterSummary,
     "CompleteExternalBackupJobDetails": CompleteExternalBackupJobDetails,
+    "ConfigureAutonomousDatabaseVaultKeyDetails": ConfigureAutonomousDatabaseVaultKeyDetails,
     "ConsoleConnection": ConsoleConnection,
     "ConsoleConnectionSummary": ConsoleConnectionSummary,
     "CreateAutonomousContainerDatabaseDetails": CreateAutonomousContainerDatabaseDetails,

--- a/src/oci/database/models/autonomous_database.py
+++ b/src/oci/database/models/autonomous_database.py
@@ -89,6 +89,10 @@ class AutonomousDatabase(object):
     #: This constant has a value of "UPGRADING"
     LIFECYCLE_STATE_UPGRADING = "UPGRADING"
 
+    #: A constant which can be used with the lifecycle_state property of a AutonomousDatabase.
+    #: This constant has a value of "INACCESSIBLE"
+    LIFECYCLE_STATE_INACCESSIBLE = "INACCESSIBLE"
+
     #: A constant which can be used with the infrastructure_type property of a AutonomousDatabase.
     #: This constant has a value of "CLOUD"
     INFRASTRUCTURE_TYPE_CLOUD = "CLOUD"
@@ -224,13 +228,25 @@ class AutonomousDatabase(object):
 
         :param lifecycle_state:
             The value to assign to the lifecycle_state property of this AutonomousDatabase.
-            Allowed values for this property are: "PROVISIONING", "AVAILABLE", "STOPPING", "STOPPED", "STARTING", "TERMINATING", "TERMINATED", "UNAVAILABLE", "RESTORE_IN_PROGRESS", "RESTORE_FAILED", "BACKUP_IN_PROGRESS", "SCALE_IN_PROGRESS", "AVAILABLE_NEEDS_ATTENTION", "UPDATING", "MAINTENANCE_IN_PROGRESS", "RESTARTING", "RECREATING", "ROLE_CHANGE_IN_PROGRESS", "UPGRADING", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "PROVISIONING", "AVAILABLE", "STOPPING", "STOPPED", "STARTING", "TERMINATING", "TERMINATED", "UNAVAILABLE", "RESTORE_IN_PROGRESS", "RESTORE_FAILED", "BACKUP_IN_PROGRESS", "SCALE_IN_PROGRESS", "AVAILABLE_NEEDS_ATTENTION", "UPDATING", "MAINTENANCE_IN_PROGRESS", "RESTARTING", "RECREATING", "ROLE_CHANGE_IN_PROGRESS", "UPGRADING", "INACCESSIBLE", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type lifecycle_state: str
 
         :param lifecycle_details:
             The value to assign to the lifecycle_details property of this AutonomousDatabase.
         :type lifecycle_details: str
+
+        :param kms_key_id:
+            The value to assign to the kms_key_id property of this AutonomousDatabase.
+        :type kms_key_id: str
+
+        :param vault_id:
+            The value to assign to the vault_id property of this AutonomousDatabase.
+        :type vault_id: str
+
+        :param kms_key_lifecycle_details:
+            The value to assign to the kms_key_lifecycle_details property of this AutonomousDatabase.
+        :type kms_key_lifecycle_details: str
 
         :param db_name:
             The value to assign to the db_name property of this AutonomousDatabase.
@@ -255,6 +271,10 @@ class AutonomousDatabase(object):
         :param backup_config:
             The value to assign to the backup_config property of this AutonomousDatabase.
         :type backup_config: oci.database.models.AutonomousDatabaseBackupConfig
+
+        :param key_history_entry:
+            The value to assign to the key_history_entry property of this AutonomousDatabase.
+        :type key_history_entry: list[oci.database.models.AutonomousDatabaseKeyHistoryEntry]
 
         :param cpu_core_count:
             The value to assign to the cpu_core_count property of this AutonomousDatabase.
@@ -490,12 +510,16 @@ class AutonomousDatabase(object):
             'compartment_id': 'str',
             'lifecycle_state': 'str',
             'lifecycle_details': 'str',
+            'kms_key_id': 'str',
+            'vault_id': 'str',
+            'kms_key_lifecycle_details': 'str',
             'db_name': 'str',
             'is_free_tier': 'bool',
             'system_tags': 'dict(str, dict(str, object))',
             'time_reclamation_of_free_autonomous_database': 'datetime',
             'time_deletion_of_free_autonomous_database': 'datetime',
             'backup_config': 'AutonomousDatabaseBackupConfig',
+            'key_history_entry': 'list[AutonomousDatabaseKeyHistoryEntry]',
             'cpu_core_count': 'int',
             'data_storage_size_in_tbs': 'int',
             'data_storage_size_in_gbs': 'int',
@@ -555,12 +579,16 @@ class AutonomousDatabase(object):
             'compartment_id': 'compartmentId',
             'lifecycle_state': 'lifecycleState',
             'lifecycle_details': 'lifecycleDetails',
+            'kms_key_id': 'kmsKeyId',
+            'vault_id': 'vaultId',
+            'kms_key_lifecycle_details': 'kmsKeyLifecycleDetails',
             'db_name': 'dbName',
             'is_free_tier': 'isFreeTier',
             'system_tags': 'systemTags',
             'time_reclamation_of_free_autonomous_database': 'timeReclamationOfFreeAutonomousDatabase',
             'time_deletion_of_free_autonomous_database': 'timeDeletionOfFreeAutonomousDatabase',
             'backup_config': 'backupConfig',
+            'key_history_entry': 'keyHistoryEntry',
             'cpu_core_count': 'cpuCoreCount',
             'data_storage_size_in_tbs': 'dataStorageSizeInTBs',
             'data_storage_size_in_gbs': 'dataStorageSizeInGBs',
@@ -619,12 +647,16 @@ class AutonomousDatabase(object):
         self._compartment_id = None
         self._lifecycle_state = None
         self._lifecycle_details = None
+        self._kms_key_id = None
+        self._vault_id = None
+        self._kms_key_lifecycle_details = None
         self._db_name = None
         self._is_free_tier = None
         self._system_tags = None
         self._time_reclamation_of_free_autonomous_database = None
         self._time_deletion_of_free_autonomous_database = None
         self._backup_config = None
+        self._key_history_entry = None
         self._cpu_core_count = None
         self._data_storage_size_in_tbs = None
         self._data_storage_size_in_gbs = None
@@ -740,7 +772,7 @@ class AutonomousDatabase(object):
         **[Required]** Gets the lifecycle_state of this AutonomousDatabase.
         The current state of the Autonomous Database.
 
-        Allowed values for this property are: "PROVISIONING", "AVAILABLE", "STOPPING", "STOPPED", "STARTING", "TERMINATING", "TERMINATED", "UNAVAILABLE", "RESTORE_IN_PROGRESS", "RESTORE_FAILED", "BACKUP_IN_PROGRESS", "SCALE_IN_PROGRESS", "AVAILABLE_NEEDS_ATTENTION", "UPDATING", "MAINTENANCE_IN_PROGRESS", "RESTARTING", "RECREATING", "ROLE_CHANGE_IN_PROGRESS", "UPGRADING", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "PROVISIONING", "AVAILABLE", "STOPPING", "STOPPED", "STARTING", "TERMINATING", "TERMINATED", "UNAVAILABLE", "RESTORE_IN_PROGRESS", "RESTORE_FAILED", "BACKUP_IN_PROGRESS", "SCALE_IN_PROGRESS", "AVAILABLE_NEEDS_ATTENTION", "UPDATING", "MAINTENANCE_IN_PROGRESS", "RESTARTING", "RECREATING", "ROLE_CHANGE_IN_PROGRESS", "UPGRADING", "INACCESSIBLE", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -759,7 +791,7 @@ class AutonomousDatabase(object):
         :param lifecycle_state: The lifecycle_state of this AutonomousDatabase.
         :type: str
         """
-        allowed_values = ["PROVISIONING", "AVAILABLE", "STOPPING", "STOPPED", "STARTING", "TERMINATING", "TERMINATED", "UNAVAILABLE", "RESTORE_IN_PROGRESS", "RESTORE_FAILED", "BACKUP_IN_PROGRESS", "SCALE_IN_PROGRESS", "AVAILABLE_NEEDS_ATTENTION", "UPDATING", "MAINTENANCE_IN_PROGRESS", "RESTARTING", "RECREATING", "ROLE_CHANGE_IN_PROGRESS", "UPGRADING"]
+        allowed_values = ["PROVISIONING", "AVAILABLE", "STOPPING", "STOPPED", "STARTING", "TERMINATING", "TERMINATED", "UNAVAILABLE", "RESTORE_IN_PROGRESS", "RESTORE_FAILED", "BACKUP_IN_PROGRESS", "SCALE_IN_PROGRESS", "AVAILABLE_NEEDS_ATTENTION", "UPDATING", "MAINTENANCE_IN_PROGRESS", "RESTARTING", "RECREATING", "ROLE_CHANGE_IN_PROGRESS", "UPGRADING", "INACCESSIBLE"]
         if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
             lifecycle_state = 'UNKNOWN_ENUM_VALUE'
         self._lifecycle_state = lifecycle_state
@@ -787,6 +819,84 @@ class AutonomousDatabase(object):
         :type: str
         """
         self._lifecycle_details = lifecycle_details
+
+    @property
+    def kms_key_id(self):
+        """
+        Gets the kms_key_id of this AutonomousDatabase.
+        The OCID of the key container that is used as the master encryption key in database transparent data encryption (TDE) operations.
+
+
+        :return: The kms_key_id of this AutonomousDatabase.
+        :rtype: str
+        """
+        return self._kms_key_id
+
+    @kms_key_id.setter
+    def kms_key_id(self, kms_key_id):
+        """
+        Sets the kms_key_id of this AutonomousDatabase.
+        The OCID of the key container that is used as the master encryption key in database transparent data encryption (TDE) operations.
+
+
+        :param kms_key_id: The kms_key_id of this AutonomousDatabase.
+        :type: str
+        """
+        self._kms_key_id = kms_key_id
+
+    @property
+    def vault_id(self):
+        """
+        Gets the vault_id of this AutonomousDatabase.
+        The `OCID`__ of the Oracle Cloud Infrastructure `vault`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts
+
+
+        :return: The vault_id of this AutonomousDatabase.
+        :rtype: str
+        """
+        return self._vault_id
+
+    @vault_id.setter
+    def vault_id(self, vault_id):
+        """
+        Sets the vault_id of this AutonomousDatabase.
+        The `OCID`__ of the Oracle Cloud Infrastructure `vault`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts
+
+
+        :param vault_id: The vault_id of this AutonomousDatabase.
+        :type: str
+        """
+        self._vault_id = vault_id
+
+    @property
+    def kms_key_lifecycle_details(self):
+        """
+        Gets the kms_key_lifecycle_details of this AutonomousDatabase.
+        KMS key lifecycle details.
+
+
+        :return: The kms_key_lifecycle_details of this AutonomousDatabase.
+        :rtype: str
+        """
+        return self._kms_key_lifecycle_details
+
+    @kms_key_lifecycle_details.setter
+    def kms_key_lifecycle_details(self, kms_key_lifecycle_details):
+        """
+        Sets the kms_key_lifecycle_details of this AutonomousDatabase.
+        KMS key lifecycle details.
+
+
+        :param kms_key_lifecycle_details: The kms_key_lifecycle_details of this AutonomousDatabase.
+        :type: str
+        """
+        self._kms_key_lifecycle_details = kms_key_lifecycle_details
 
     @property
     def db_name(self):
@@ -933,6 +1043,30 @@ class AutonomousDatabase(object):
         :type: oci.database.models.AutonomousDatabaseBackupConfig
         """
         self._backup_config = backup_config
+
+    @property
+    def key_history_entry(self):
+        """
+        Gets the key_history_entry of this AutonomousDatabase.
+        Key History Entry.
+
+
+        :return: The key_history_entry of this AutonomousDatabase.
+        :rtype: list[oci.database.models.AutonomousDatabaseKeyHistoryEntry]
+        """
+        return self._key_history_entry
+
+    @key_history_entry.setter
+    def key_history_entry(self, key_history_entry):
+        """
+        Sets the key_history_entry of this AutonomousDatabase.
+        Key History Entry.
+
+
+        :param key_history_entry: The key_history_entry of this AutonomousDatabase.
+        :type: list[oci.database.models.AutonomousDatabaseKeyHistoryEntry]
+        """
+        self._key_history_entry = key_history_entry
 
     @property
     def cpu_core_count(self):

--- a/src/oci/database/models/autonomous_database_backup.py
+++ b/src/oci/database/models/autonomous_database_backup.py
@@ -106,6 +106,14 @@ class AutonomousDatabaseBackup(object):
             The value to assign to the key_store_wallet_name property of this AutonomousDatabaseBackup.
         :type key_store_wallet_name: str
 
+        :param kms_key_id:
+            The value to assign to the kms_key_id property of this AutonomousDatabaseBackup.
+        :type kms_key_id: str
+
+        :param vault_id:
+            The value to assign to the vault_id property of this AutonomousDatabaseBackup.
+        :type vault_id: str
+
         """
         self.swagger_types = {
             'id': 'str',
@@ -121,7 +129,9 @@ class AutonomousDatabaseBackup(object):
             'lifecycle_state': 'str',
             'is_restorable': 'bool',
             'key_store_id': 'str',
-            'key_store_wallet_name': 'str'
+            'key_store_wallet_name': 'str',
+            'kms_key_id': 'str',
+            'vault_id': 'str'
         }
 
         self.attribute_map = {
@@ -138,7 +148,9 @@ class AutonomousDatabaseBackup(object):
             'lifecycle_state': 'lifecycleState',
             'is_restorable': 'isRestorable',
             'key_store_id': 'keyStoreId',
-            'key_store_wallet_name': 'keyStoreWalletName'
+            'key_store_wallet_name': 'keyStoreWalletName',
+            'kms_key_id': 'kmsKeyId',
+            'vault_id': 'vaultId'
         }
 
         self._id = None
@@ -155,6 +167,8 @@ class AutonomousDatabaseBackup(object):
         self._is_restorable = None
         self._key_store_id = None
         self._key_store_wallet_name = None
+        self._kms_key_id = None
+        self._vault_id = None
 
     @property
     def id(self):
@@ -519,6 +533,60 @@ class AutonomousDatabaseBackup(object):
         :type: str
         """
         self._key_store_wallet_name = key_store_wallet_name
+
+    @property
+    def kms_key_id(self):
+        """
+        Gets the kms_key_id of this AutonomousDatabaseBackup.
+        The OCID of the key container that is used as the master encryption key in database transparent data encryption (TDE) operations.
+
+
+        :return: The kms_key_id of this AutonomousDatabaseBackup.
+        :rtype: str
+        """
+        return self._kms_key_id
+
+    @kms_key_id.setter
+    def kms_key_id(self, kms_key_id):
+        """
+        Sets the kms_key_id of this AutonomousDatabaseBackup.
+        The OCID of the key container that is used as the master encryption key in database transparent data encryption (TDE) operations.
+
+
+        :param kms_key_id: The kms_key_id of this AutonomousDatabaseBackup.
+        :type: str
+        """
+        self._kms_key_id = kms_key_id
+
+    @property
+    def vault_id(self):
+        """
+        Gets the vault_id of this AutonomousDatabaseBackup.
+        The `OCID`__ of the Oracle Cloud Infrastructure `vault`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts
+
+
+        :return: The vault_id of this AutonomousDatabaseBackup.
+        :rtype: str
+        """
+        return self._vault_id
+
+    @vault_id.setter
+    def vault_id(self, vault_id):
+        """
+        Sets the vault_id of this AutonomousDatabaseBackup.
+        The `OCID`__ of the Oracle Cloud Infrastructure `vault`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts
+
+
+        :param vault_id: The vault_id of this AutonomousDatabaseBackup.
+        :type: str
+        """
+        self._vault_id = vault_id
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/database/models/autonomous_database_backup_summary.py
+++ b/src/oci/database/models/autonomous_database_backup_summary.py
@@ -111,6 +111,14 @@ class AutonomousDatabaseBackupSummary(object):
             The value to assign to the key_store_wallet_name property of this AutonomousDatabaseBackupSummary.
         :type key_store_wallet_name: str
 
+        :param kms_key_id:
+            The value to assign to the kms_key_id property of this AutonomousDatabaseBackupSummary.
+        :type kms_key_id: str
+
+        :param vault_id:
+            The value to assign to the vault_id property of this AutonomousDatabaseBackupSummary.
+        :type vault_id: str
+
         """
         self.swagger_types = {
             'id': 'str',
@@ -126,7 +134,9 @@ class AutonomousDatabaseBackupSummary(object):
             'lifecycle_state': 'str',
             'is_restorable': 'bool',
             'key_store_id': 'str',
-            'key_store_wallet_name': 'str'
+            'key_store_wallet_name': 'str',
+            'kms_key_id': 'str',
+            'vault_id': 'str'
         }
 
         self.attribute_map = {
@@ -143,7 +153,9 @@ class AutonomousDatabaseBackupSummary(object):
             'lifecycle_state': 'lifecycleState',
             'is_restorable': 'isRestorable',
             'key_store_id': 'keyStoreId',
-            'key_store_wallet_name': 'keyStoreWalletName'
+            'key_store_wallet_name': 'keyStoreWalletName',
+            'kms_key_id': 'kmsKeyId',
+            'vault_id': 'vaultId'
         }
 
         self._id = None
@@ -160,6 +172,8 @@ class AutonomousDatabaseBackupSummary(object):
         self._is_restorable = None
         self._key_store_id = None
         self._key_store_wallet_name = None
+        self._kms_key_id = None
+        self._vault_id = None
 
     @property
     def id(self):
@@ -524,6 +538,60 @@ class AutonomousDatabaseBackupSummary(object):
         :type: str
         """
         self._key_store_wallet_name = key_store_wallet_name
+
+    @property
+    def kms_key_id(self):
+        """
+        Gets the kms_key_id of this AutonomousDatabaseBackupSummary.
+        The OCID of the key container that is used as the master encryption key in database transparent data encryption (TDE) operations.
+
+
+        :return: The kms_key_id of this AutonomousDatabaseBackupSummary.
+        :rtype: str
+        """
+        return self._kms_key_id
+
+    @kms_key_id.setter
+    def kms_key_id(self, kms_key_id):
+        """
+        Sets the kms_key_id of this AutonomousDatabaseBackupSummary.
+        The OCID of the key container that is used as the master encryption key in database transparent data encryption (TDE) operations.
+
+
+        :param kms_key_id: The kms_key_id of this AutonomousDatabaseBackupSummary.
+        :type: str
+        """
+        self._kms_key_id = kms_key_id
+
+    @property
+    def vault_id(self):
+        """
+        Gets the vault_id of this AutonomousDatabaseBackupSummary.
+        The `OCID`__ of the Oracle Cloud Infrastructure `vault`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts
+
+
+        :return: The vault_id of this AutonomousDatabaseBackupSummary.
+        :rtype: str
+        """
+        return self._vault_id
+
+    @vault_id.setter
+    def vault_id(self, vault_id):
+        """
+        Sets the vault_id of this AutonomousDatabaseBackupSummary.
+        The `OCID`__ of the Oracle Cloud Infrastructure `vault`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts
+
+
+        :param vault_id: The vault_id of this AutonomousDatabaseBackupSummary.
+        :type: str
+        """
+        self._vault_id = vault_id
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/database/models/autonomous_database_key_history_entry.py
+++ b/src/oci/database/models/autonomous_database_key_history_entry.py
@@ -1,0 +1,144 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class AutonomousDatabaseKeyHistoryEntry(object):
+    """
+    The Autonomous Database `Vault`__ service key management history entry.
+
+    __ https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new AutonomousDatabaseKeyHistoryEntry object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param id:
+            The value to assign to the id property of this AutonomousDatabaseKeyHistoryEntry.
+        :type id: str
+
+        :param vault_id:
+            The value to assign to the vault_id property of this AutonomousDatabaseKeyHistoryEntry.
+        :type vault_id: str
+
+        :param time_activated:
+            The value to assign to the time_activated property of this AutonomousDatabaseKeyHistoryEntry.
+        :type time_activated: datetime
+
+        """
+        self.swagger_types = {
+            'id': 'str',
+            'vault_id': 'str',
+            'time_activated': 'datetime'
+        }
+
+        self.attribute_map = {
+            'id': 'id',
+            'vault_id': 'vaultId',
+            'time_activated': 'timeActivated'
+        }
+
+        self._id = None
+        self._vault_id = None
+        self._time_activated = None
+
+    @property
+    def id(self):
+        """
+        **[Required]** Gets the id of this AutonomousDatabaseKeyHistoryEntry.
+        The id of the Autonomous Database `Vault`__ service key management history entry.
+
+        __ https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts
+
+
+        :return: The id of this AutonomousDatabaseKeyHistoryEntry.
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """
+        Sets the id of this AutonomousDatabaseKeyHistoryEntry.
+        The id of the Autonomous Database `Vault`__ service key management history entry.
+
+        __ https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts
+
+
+        :param id: The id of this AutonomousDatabaseKeyHistoryEntry.
+        :type: str
+        """
+        self._id = id
+
+    @property
+    def vault_id(self):
+        """
+        Gets the vault_id of this AutonomousDatabaseKeyHistoryEntry.
+        The `OCID`__ of the Oracle Cloud Infrastructure `vault`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts
+
+
+        :return: The vault_id of this AutonomousDatabaseKeyHistoryEntry.
+        :rtype: str
+        """
+        return self._vault_id
+
+    @vault_id.setter
+    def vault_id(self, vault_id):
+        """
+        Sets the vault_id of this AutonomousDatabaseKeyHistoryEntry.
+        The `OCID`__ of the Oracle Cloud Infrastructure `vault`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts
+
+
+        :param vault_id: The vault_id of this AutonomousDatabaseKeyHistoryEntry.
+        :type: str
+        """
+        self._vault_id = vault_id
+
+    @property
+    def time_activated(self):
+        """
+        Gets the time_activated of this AutonomousDatabaseKeyHistoryEntry.
+        The date and time the kms key activated.
+
+
+        :return: The time_activated of this AutonomousDatabaseKeyHistoryEntry.
+        :rtype: datetime
+        """
+        return self._time_activated
+
+    @time_activated.setter
+    def time_activated(self, time_activated):
+        """
+        Sets the time_activated of this AutonomousDatabaseKeyHistoryEntry.
+        The date and time the kms key activated.
+
+
+        :param time_activated: The time_activated of this AutonomousDatabaseKeyHistoryEntry.
+        :type: datetime
+        """
+        self._time_activated = time_activated
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/autonomous_database_standby_summary.py
+++ b/src/oci/database/models/autonomous_database_standby_summary.py
@@ -89,6 +89,10 @@ class AutonomousDatabaseStandbySummary(object):
     #: This constant has a value of "UPGRADING"
     LIFECYCLE_STATE_UPGRADING = "UPGRADING"
 
+    #: A constant which can be used with the lifecycle_state property of a AutonomousDatabaseStandbySummary.
+    #: This constant has a value of "INACCESSIBLE"
+    LIFECYCLE_STATE_INACCESSIBLE = "INACCESSIBLE"
+
     def __init__(self, **kwargs):
         """
         Initializes a new AutonomousDatabaseStandbySummary object with values from keyword arguments.
@@ -100,7 +104,7 @@ class AutonomousDatabaseStandbySummary(object):
 
         :param lifecycle_state:
             The value to assign to the lifecycle_state property of this AutonomousDatabaseStandbySummary.
-            Allowed values for this property are: "PROVISIONING", "AVAILABLE", "STOPPING", "STOPPED", "STARTING", "TERMINATING", "TERMINATED", "UNAVAILABLE", "RESTORE_IN_PROGRESS", "RESTORE_FAILED", "BACKUP_IN_PROGRESS", "SCALE_IN_PROGRESS", "AVAILABLE_NEEDS_ATTENTION", "UPDATING", "MAINTENANCE_IN_PROGRESS", "RESTARTING", "RECREATING", "ROLE_CHANGE_IN_PROGRESS", "UPGRADING", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "PROVISIONING", "AVAILABLE", "STOPPING", "STOPPED", "STARTING", "TERMINATING", "TERMINATED", "UNAVAILABLE", "RESTORE_IN_PROGRESS", "RESTORE_FAILED", "BACKUP_IN_PROGRESS", "SCALE_IN_PROGRESS", "AVAILABLE_NEEDS_ATTENTION", "UPDATING", "MAINTENANCE_IN_PROGRESS", "RESTARTING", "RECREATING", "ROLE_CHANGE_IN_PROGRESS", "UPGRADING", "INACCESSIBLE", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type lifecycle_state: str
 
@@ -155,7 +159,7 @@ class AutonomousDatabaseStandbySummary(object):
         Gets the lifecycle_state of this AutonomousDatabaseStandbySummary.
         The current state of the Autonomous Database.
 
-        Allowed values for this property are: "PROVISIONING", "AVAILABLE", "STOPPING", "STOPPED", "STARTING", "TERMINATING", "TERMINATED", "UNAVAILABLE", "RESTORE_IN_PROGRESS", "RESTORE_FAILED", "BACKUP_IN_PROGRESS", "SCALE_IN_PROGRESS", "AVAILABLE_NEEDS_ATTENTION", "UPDATING", "MAINTENANCE_IN_PROGRESS", "RESTARTING", "RECREATING", "ROLE_CHANGE_IN_PROGRESS", "UPGRADING", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "PROVISIONING", "AVAILABLE", "STOPPING", "STOPPED", "STARTING", "TERMINATING", "TERMINATED", "UNAVAILABLE", "RESTORE_IN_PROGRESS", "RESTORE_FAILED", "BACKUP_IN_PROGRESS", "SCALE_IN_PROGRESS", "AVAILABLE_NEEDS_ATTENTION", "UPDATING", "MAINTENANCE_IN_PROGRESS", "RESTARTING", "RECREATING", "ROLE_CHANGE_IN_PROGRESS", "UPGRADING", "INACCESSIBLE", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -174,7 +178,7 @@ class AutonomousDatabaseStandbySummary(object):
         :param lifecycle_state: The lifecycle_state of this AutonomousDatabaseStandbySummary.
         :type: str
         """
-        allowed_values = ["PROVISIONING", "AVAILABLE", "STOPPING", "STOPPED", "STARTING", "TERMINATING", "TERMINATED", "UNAVAILABLE", "RESTORE_IN_PROGRESS", "RESTORE_FAILED", "BACKUP_IN_PROGRESS", "SCALE_IN_PROGRESS", "AVAILABLE_NEEDS_ATTENTION", "UPDATING", "MAINTENANCE_IN_PROGRESS", "RESTARTING", "RECREATING", "ROLE_CHANGE_IN_PROGRESS", "UPGRADING"]
+        allowed_values = ["PROVISIONING", "AVAILABLE", "STOPPING", "STOPPED", "STARTING", "TERMINATING", "TERMINATED", "UNAVAILABLE", "RESTORE_IN_PROGRESS", "RESTORE_FAILED", "BACKUP_IN_PROGRESS", "SCALE_IN_PROGRESS", "AVAILABLE_NEEDS_ATTENTION", "UPDATING", "MAINTENANCE_IN_PROGRESS", "RESTARTING", "RECREATING", "ROLE_CHANGE_IN_PROGRESS", "UPGRADING", "INACCESSIBLE"]
         if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
             lifecycle_state = 'UNKNOWN_ENUM_VALUE'
         self._lifecycle_state = lifecycle_state

--- a/src/oci/database/models/autonomous_database_summary.py
+++ b/src/oci/database/models/autonomous_database_summary.py
@@ -91,6 +91,10 @@ class AutonomousDatabaseSummary(object):
     #: This constant has a value of "UPGRADING"
     LIFECYCLE_STATE_UPGRADING = "UPGRADING"
 
+    #: A constant which can be used with the lifecycle_state property of a AutonomousDatabaseSummary.
+    #: This constant has a value of "INACCESSIBLE"
+    LIFECYCLE_STATE_INACCESSIBLE = "INACCESSIBLE"
+
     #: A constant which can be used with the infrastructure_type property of a AutonomousDatabaseSummary.
     #: This constant has a value of "CLOUD"
     INFRASTRUCTURE_TYPE_CLOUD = "CLOUD"
@@ -226,13 +230,25 @@ class AutonomousDatabaseSummary(object):
 
         :param lifecycle_state:
             The value to assign to the lifecycle_state property of this AutonomousDatabaseSummary.
-            Allowed values for this property are: "PROVISIONING", "AVAILABLE", "STOPPING", "STOPPED", "STARTING", "TERMINATING", "TERMINATED", "UNAVAILABLE", "RESTORE_IN_PROGRESS", "RESTORE_FAILED", "BACKUP_IN_PROGRESS", "SCALE_IN_PROGRESS", "AVAILABLE_NEEDS_ATTENTION", "UPDATING", "MAINTENANCE_IN_PROGRESS", "RESTARTING", "RECREATING", "ROLE_CHANGE_IN_PROGRESS", "UPGRADING", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "PROVISIONING", "AVAILABLE", "STOPPING", "STOPPED", "STARTING", "TERMINATING", "TERMINATED", "UNAVAILABLE", "RESTORE_IN_PROGRESS", "RESTORE_FAILED", "BACKUP_IN_PROGRESS", "SCALE_IN_PROGRESS", "AVAILABLE_NEEDS_ATTENTION", "UPDATING", "MAINTENANCE_IN_PROGRESS", "RESTARTING", "RECREATING", "ROLE_CHANGE_IN_PROGRESS", "UPGRADING", "INACCESSIBLE", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type lifecycle_state: str
 
         :param lifecycle_details:
             The value to assign to the lifecycle_details property of this AutonomousDatabaseSummary.
         :type lifecycle_details: str
+
+        :param kms_key_id:
+            The value to assign to the kms_key_id property of this AutonomousDatabaseSummary.
+        :type kms_key_id: str
+
+        :param vault_id:
+            The value to assign to the vault_id property of this AutonomousDatabaseSummary.
+        :type vault_id: str
+
+        :param kms_key_lifecycle_details:
+            The value to assign to the kms_key_lifecycle_details property of this AutonomousDatabaseSummary.
+        :type kms_key_lifecycle_details: str
 
         :param db_name:
             The value to assign to the db_name property of this AutonomousDatabaseSummary.
@@ -257,6 +273,10 @@ class AutonomousDatabaseSummary(object):
         :param backup_config:
             The value to assign to the backup_config property of this AutonomousDatabaseSummary.
         :type backup_config: oci.database.models.AutonomousDatabaseBackupConfig
+
+        :param key_history_entry:
+            The value to assign to the key_history_entry property of this AutonomousDatabaseSummary.
+        :type key_history_entry: list[oci.database.models.AutonomousDatabaseKeyHistoryEntry]
 
         :param cpu_core_count:
             The value to assign to the cpu_core_count property of this AutonomousDatabaseSummary.
@@ -492,12 +512,16 @@ class AutonomousDatabaseSummary(object):
             'compartment_id': 'str',
             'lifecycle_state': 'str',
             'lifecycle_details': 'str',
+            'kms_key_id': 'str',
+            'vault_id': 'str',
+            'kms_key_lifecycle_details': 'str',
             'db_name': 'str',
             'is_free_tier': 'bool',
             'system_tags': 'dict(str, dict(str, object))',
             'time_reclamation_of_free_autonomous_database': 'datetime',
             'time_deletion_of_free_autonomous_database': 'datetime',
             'backup_config': 'AutonomousDatabaseBackupConfig',
+            'key_history_entry': 'list[AutonomousDatabaseKeyHistoryEntry]',
             'cpu_core_count': 'int',
             'data_storage_size_in_tbs': 'int',
             'data_storage_size_in_gbs': 'int',
@@ -557,12 +581,16 @@ class AutonomousDatabaseSummary(object):
             'compartment_id': 'compartmentId',
             'lifecycle_state': 'lifecycleState',
             'lifecycle_details': 'lifecycleDetails',
+            'kms_key_id': 'kmsKeyId',
+            'vault_id': 'vaultId',
+            'kms_key_lifecycle_details': 'kmsKeyLifecycleDetails',
             'db_name': 'dbName',
             'is_free_tier': 'isFreeTier',
             'system_tags': 'systemTags',
             'time_reclamation_of_free_autonomous_database': 'timeReclamationOfFreeAutonomousDatabase',
             'time_deletion_of_free_autonomous_database': 'timeDeletionOfFreeAutonomousDatabase',
             'backup_config': 'backupConfig',
+            'key_history_entry': 'keyHistoryEntry',
             'cpu_core_count': 'cpuCoreCount',
             'data_storage_size_in_tbs': 'dataStorageSizeInTBs',
             'data_storage_size_in_gbs': 'dataStorageSizeInGBs',
@@ -621,12 +649,16 @@ class AutonomousDatabaseSummary(object):
         self._compartment_id = None
         self._lifecycle_state = None
         self._lifecycle_details = None
+        self._kms_key_id = None
+        self._vault_id = None
+        self._kms_key_lifecycle_details = None
         self._db_name = None
         self._is_free_tier = None
         self._system_tags = None
         self._time_reclamation_of_free_autonomous_database = None
         self._time_deletion_of_free_autonomous_database = None
         self._backup_config = None
+        self._key_history_entry = None
         self._cpu_core_count = None
         self._data_storage_size_in_tbs = None
         self._data_storage_size_in_gbs = None
@@ -742,7 +774,7 @@ class AutonomousDatabaseSummary(object):
         **[Required]** Gets the lifecycle_state of this AutonomousDatabaseSummary.
         The current state of the Autonomous Database.
 
-        Allowed values for this property are: "PROVISIONING", "AVAILABLE", "STOPPING", "STOPPED", "STARTING", "TERMINATING", "TERMINATED", "UNAVAILABLE", "RESTORE_IN_PROGRESS", "RESTORE_FAILED", "BACKUP_IN_PROGRESS", "SCALE_IN_PROGRESS", "AVAILABLE_NEEDS_ATTENTION", "UPDATING", "MAINTENANCE_IN_PROGRESS", "RESTARTING", "RECREATING", "ROLE_CHANGE_IN_PROGRESS", "UPGRADING", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "PROVISIONING", "AVAILABLE", "STOPPING", "STOPPED", "STARTING", "TERMINATING", "TERMINATED", "UNAVAILABLE", "RESTORE_IN_PROGRESS", "RESTORE_FAILED", "BACKUP_IN_PROGRESS", "SCALE_IN_PROGRESS", "AVAILABLE_NEEDS_ATTENTION", "UPDATING", "MAINTENANCE_IN_PROGRESS", "RESTARTING", "RECREATING", "ROLE_CHANGE_IN_PROGRESS", "UPGRADING", "INACCESSIBLE", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -761,7 +793,7 @@ class AutonomousDatabaseSummary(object):
         :param lifecycle_state: The lifecycle_state of this AutonomousDatabaseSummary.
         :type: str
         """
-        allowed_values = ["PROVISIONING", "AVAILABLE", "STOPPING", "STOPPED", "STARTING", "TERMINATING", "TERMINATED", "UNAVAILABLE", "RESTORE_IN_PROGRESS", "RESTORE_FAILED", "BACKUP_IN_PROGRESS", "SCALE_IN_PROGRESS", "AVAILABLE_NEEDS_ATTENTION", "UPDATING", "MAINTENANCE_IN_PROGRESS", "RESTARTING", "RECREATING", "ROLE_CHANGE_IN_PROGRESS", "UPGRADING"]
+        allowed_values = ["PROVISIONING", "AVAILABLE", "STOPPING", "STOPPED", "STARTING", "TERMINATING", "TERMINATED", "UNAVAILABLE", "RESTORE_IN_PROGRESS", "RESTORE_FAILED", "BACKUP_IN_PROGRESS", "SCALE_IN_PROGRESS", "AVAILABLE_NEEDS_ATTENTION", "UPDATING", "MAINTENANCE_IN_PROGRESS", "RESTARTING", "RECREATING", "ROLE_CHANGE_IN_PROGRESS", "UPGRADING", "INACCESSIBLE"]
         if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
             lifecycle_state = 'UNKNOWN_ENUM_VALUE'
         self._lifecycle_state = lifecycle_state
@@ -789,6 +821,84 @@ class AutonomousDatabaseSummary(object):
         :type: str
         """
         self._lifecycle_details = lifecycle_details
+
+    @property
+    def kms_key_id(self):
+        """
+        Gets the kms_key_id of this AutonomousDatabaseSummary.
+        The OCID of the key container that is used as the master encryption key in database transparent data encryption (TDE) operations.
+
+
+        :return: The kms_key_id of this AutonomousDatabaseSummary.
+        :rtype: str
+        """
+        return self._kms_key_id
+
+    @kms_key_id.setter
+    def kms_key_id(self, kms_key_id):
+        """
+        Sets the kms_key_id of this AutonomousDatabaseSummary.
+        The OCID of the key container that is used as the master encryption key in database transparent data encryption (TDE) operations.
+
+
+        :param kms_key_id: The kms_key_id of this AutonomousDatabaseSummary.
+        :type: str
+        """
+        self._kms_key_id = kms_key_id
+
+    @property
+    def vault_id(self):
+        """
+        Gets the vault_id of this AutonomousDatabaseSummary.
+        The `OCID`__ of the Oracle Cloud Infrastructure `vault`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts
+
+
+        :return: The vault_id of this AutonomousDatabaseSummary.
+        :rtype: str
+        """
+        return self._vault_id
+
+    @vault_id.setter
+    def vault_id(self, vault_id):
+        """
+        Sets the vault_id of this AutonomousDatabaseSummary.
+        The `OCID`__ of the Oracle Cloud Infrastructure `vault`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts
+
+
+        :param vault_id: The vault_id of this AutonomousDatabaseSummary.
+        :type: str
+        """
+        self._vault_id = vault_id
+
+    @property
+    def kms_key_lifecycle_details(self):
+        """
+        Gets the kms_key_lifecycle_details of this AutonomousDatabaseSummary.
+        KMS key lifecycle details.
+
+
+        :return: The kms_key_lifecycle_details of this AutonomousDatabaseSummary.
+        :rtype: str
+        """
+        return self._kms_key_lifecycle_details
+
+    @kms_key_lifecycle_details.setter
+    def kms_key_lifecycle_details(self, kms_key_lifecycle_details):
+        """
+        Sets the kms_key_lifecycle_details of this AutonomousDatabaseSummary.
+        KMS key lifecycle details.
+
+
+        :param kms_key_lifecycle_details: The kms_key_lifecycle_details of this AutonomousDatabaseSummary.
+        :type: str
+        """
+        self._kms_key_lifecycle_details = kms_key_lifecycle_details
 
     @property
     def db_name(self):
@@ -935,6 +1045,30 @@ class AutonomousDatabaseSummary(object):
         :type: oci.database.models.AutonomousDatabaseBackupConfig
         """
         self._backup_config = backup_config
+
+    @property
+    def key_history_entry(self):
+        """
+        Gets the key_history_entry of this AutonomousDatabaseSummary.
+        Key History Entry.
+
+
+        :return: The key_history_entry of this AutonomousDatabaseSummary.
+        :rtype: list[oci.database.models.AutonomousDatabaseKeyHistoryEntry]
+        """
+        return self._key_history_entry
+
+    @key_history_entry.setter
+    def key_history_entry(self, key_history_entry):
+        """
+        Sets the key_history_entry of this AutonomousDatabaseSummary.
+        Key History Entry.
+
+
+        :param key_history_entry: The key_history_entry of this AutonomousDatabaseSummary.
+        :type: list[oci.database.models.AutonomousDatabaseKeyHistoryEntry]
+        """
+        self._key_history_entry = key_history_entry
 
     @property
     def cpu_core_count(self):

--- a/src/oci/database/models/configure_autonomous_database_vault_key_details.py
+++ b/src/oci/database/models/configure_autonomous_database_vault_key_details.py
@@ -1,0 +1,140 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ConfigureAutonomousDatabaseVaultKeyDetails(object):
+    """
+    Configuration details for the Autonomous Database `vault`__ key.
+
+    __ https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ConfigureAutonomousDatabaseVaultKeyDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param kms_key_id:
+            The value to assign to the kms_key_id property of this ConfigureAutonomousDatabaseVaultKeyDetails.
+        :type kms_key_id: str
+
+        :param vault_id:
+            The value to assign to the vault_id property of this ConfigureAutonomousDatabaseVaultKeyDetails.
+        :type vault_id: str
+
+        :param is_using_oracle_managed_keys:
+            The value to assign to the is_using_oracle_managed_keys property of this ConfigureAutonomousDatabaseVaultKeyDetails.
+        :type is_using_oracle_managed_keys: bool
+
+        """
+        self.swagger_types = {
+            'kms_key_id': 'str',
+            'vault_id': 'str',
+            'is_using_oracle_managed_keys': 'bool'
+        }
+
+        self.attribute_map = {
+            'kms_key_id': 'kmsKeyId',
+            'vault_id': 'vaultId',
+            'is_using_oracle_managed_keys': 'isUsingOracleManagedKeys'
+        }
+
+        self._kms_key_id = None
+        self._vault_id = None
+        self._is_using_oracle_managed_keys = None
+
+    @property
+    def kms_key_id(self):
+        """
+        Gets the kms_key_id of this ConfigureAutonomousDatabaseVaultKeyDetails.
+        The OCID of the key container that is used as the master encryption key in database transparent data encryption (TDE) operations.
+
+
+        :return: The kms_key_id of this ConfigureAutonomousDatabaseVaultKeyDetails.
+        :rtype: str
+        """
+        return self._kms_key_id
+
+    @kms_key_id.setter
+    def kms_key_id(self, kms_key_id):
+        """
+        Sets the kms_key_id of this ConfigureAutonomousDatabaseVaultKeyDetails.
+        The OCID of the key container that is used as the master encryption key in database transparent data encryption (TDE) operations.
+
+
+        :param kms_key_id: The kms_key_id of this ConfigureAutonomousDatabaseVaultKeyDetails.
+        :type: str
+        """
+        self._kms_key_id = kms_key_id
+
+    @property
+    def vault_id(self):
+        """
+        Gets the vault_id of this ConfigureAutonomousDatabaseVaultKeyDetails.
+        The `OCID`__ of the Oracle Cloud Infrastructure `vault`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts
+
+
+        :return: The vault_id of this ConfigureAutonomousDatabaseVaultKeyDetails.
+        :rtype: str
+        """
+        return self._vault_id
+
+    @vault_id.setter
+    def vault_id(self, vault_id):
+        """
+        Sets the vault_id of this ConfigureAutonomousDatabaseVaultKeyDetails.
+        The `OCID`__ of the Oracle Cloud Infrastructure `vault`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts
+
+
+        :param vault_id: The vault_id of this ConfigureAutonomousDatabaseVaultKeyDetails.
+        :type: str
+        """
+        self._vault_id = vault_id
+
+    @property
+    def is_using_oracle_managed_keys(self):
+        """
+        Gets the is_using_oracle_managed_keys of this ConfigureAutonomousDatabaseVaultKeyDetails.
+        True if disable Customer Managed Keys and use Oracle Managed Keys.
+
+
+        :return: The is_using_oracle_managed_keys of this ConfigureAutonomousDatabaseVaultKeyDetails.
+        :rtype: bool
+        """
+        return self._is_using_oracle_managed_keys
+
+    @is_using_oracle_managed_keys.setter
+    def is_using_oracle_managed_keys(self, is_using_oracle_managed_keys):
+        """
+        Sets the is_using_oracle_managed_keys of this ConfigureAutonomousDatabaseVaultKeyDetails.
+        True if disable Customer Managed Keys and use Oracle Managed Keys.
+
+
+        :param is_using_oracle_managed_keys: The is_using_oracle_managed_keys of this ConfigureAutonomousDatabaseVaultKeyDetails.
+        :type: bool
+        """
+        self._is_using_oracle_managed_keys = is_using_oracle_managed_keys
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/database/models/create_autonomous_database_base.py
+++ b/src/oci/database/models/create_autonomous_database_base.py
@@ -97,6 +97,14 @@ class CreateAutonomousDatabaseBase(object):
             The value to assign to the is_free_tier property of this CreateAutonomousDatabaseBase.
         :type is_free_tier: bool
 
+        :param kms_key_id:
+            The value to assign to the kms_key_id property of this CreateAutonomousDatabaseBase.
+        :type kms_key_id: str
+
+        :param vault_id:
+            The value to assign to the vault_id property of this CreateAutonomousDatabaseBase.
+        :type vault_id: str
+
         :param admin_password:
             The value to assign to the admin_password property of this CreateAutonomousDatabaseBase.
         :type admin_password: str
@@ -187,6 +195,8 @@ class CreateAutonomousDatabaseBase(object):
             'db_workload': 'str',
             'data_storage_size_in_tbs': 'int',
             'is_free_tier': 'bool',
+            'kms_key_id': 'str',
+            'vault_id': 'str',
             'admin_password': 'str',
             'display_name': 'str',
             'license_model': 'str',
@@ -216,6 +226,8 @@ class CreateAutonomousDatabaseBase(object):
             'db_workload': 'dbWorkload',
             'data_storage_size_in_tbs': 'dataStorageSizeInTBs',
             'is_free_tier': 'isFreeTier',
+            'kms_key_id': 'kmsKeyId',
+            'vault_id': 'vaultId',
             'admin_password': 'adminPassword',
             'display_name': 'displayName',
             'license_model': 'licenseModel',
@@ -244,6 +256,8 @@ class CreateAutonomousDatabaseBase(object):
         self._db_workload = None
         self._data_storage_size_in_tbs = None
         self._is_free_tier = None
+        self._kms_key_id = None
+        self._vault_id = None
         self._admin_password = None
         self._display_name = None
         self._license_model = None
@@ -455,6 +469,60 @@ class CreateAutonomousDatabaseBase(object):
         :type: bool
         """
         self._is_free_tier = is_free_tier
+
+    @property
+    def kms_key_id(self):
+        """
+        Gets the kms_key_id of this CreateAutonomousDatabaseBase.
+        The OCID of the key container that is used as the master encryption key in database transparent data encryption (TDE) operations.
+
+
+        :return: The kms_key_id of this CreateAutonomousDatabaseBase.
+        :rtype: str
+        """
+        return self._kms_key_id
+
+    @kms_key_id.setter
+    def kms_key_id(self, kms_key_id):
+        """
+        Sets the kms_key_id of this CreateAutonomousDatabaseBase.
+        The OCID of the key container that is used as the master encryption key in database transparent data encryption (TDE) operations.
+
+
+        :param kms_key_id: The kms_key_id of this CreateAutonomousDatabaseBase.
+        :type: str
+        """
+        self._kms_key_id = kms_key_id
+
+    @property
+    def vault_id(self):
+        """
+        Gets the vault_id of this CreateAutonomousDatabaseBase.
+        The `OCID`__ of the Oracle Cloud Infrastructure `vault`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts
+
+
+        :return: The vault_id of this CreateAutonomousDatabaseBase.
+        :rtype: str
+        """
+        return self._vault_id
+
+    @vault_id.setter
+    def vault_id(self, vault_id):
+        """
+        Sets the vault_id of this CreateAutonomousDatabaseBase.
+        The `OCID`__ of the Oracle Cloud Infrastructure `vault`__.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+        __ https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts
+
+
+        :param vault_id: The vault_id of this CreateAutonomousDatabaseBase.
+        :type: str
+        """
+        self._vault_id = vault_id
 
     @property
     def admin_password(self):

--- a/src/oci/database/models/create_autonomous_database_clone_details.py
+++ b/src/oci/database/models/create_autonomous_database_clone_details.py
@@ -52,6 +52,14 @@ class CreateAutonomousDatabaseCloneDetails(CreateAutonomousDatabaseBase):
             The value to assign to the is_free_tier property of this CreateAutonomousDatabaseCloneDetails.
         :type is_free_tier: bool
 
+        :param kms_key_id:
+            The value to assign to the kms_key_id property of this CreateAutonomousDatabaseCloneDetails.
+        :type kms_key_id: str
+
+        :param vault_id:
+            The value to assign to the vault_id property of this CreateAutonomousDatabaseCloneDetails.
+        :type vault_id: str
+
         :param admin_password:
             The value to assign to the admin_password property of this CreateAutonomousDatabaseCloneDetails.
         :type admin_password: str
@@ -151,6 +159,8 @@ class CreateAutonomousDatabaseCloneDetails(CreateAutonomousDatabaseBase):
             'db_workload': 'str',
             'data_storage_size_in_tbs': 'int',
             'is_free_tier': 'bool',
+            'kms_key_id': 'str',
+            'vault_id': 'str',
             'admin_password': 'str',
             'display_name': 'str',
             'license_model': 'str',
@@ -182,6 +192,8 @@ class CreateAutonomousDatabaseCloneDetails(CreateAutonomousDatabaseBase):
             'db_workload': 'dbWorkload',
             'data_storage_size_in_tbs': 'dataStorageSizeInTBs',
             'is_free_tier': 'isFreeTier',
+            'kms_key_id': 'kmsKeyId',
+            'vault_id': 'vaultId',
             'admin_password': 'adminPassword',
             'display_name': 'displayName',
             'license_model': 'licenseModel',
@@ -212,6 +224,8 @@ class CreateAutonomousDatabaseCloneDetails(CreateAutonomousDatabaseBase):
         self._db_workload = None
         self._data_storage_size_in_tbs = None
         self._is_free_tier = None
+        self._kms_key_id = None
+        self._vault_id = None
         self._admin_password = None
         self._display_name = None
         self._license_model = None

--- a/src/oci/database/models/create_autonomous_database_details.py
+++ b/src/oci/database/models/create_autonomous_database_details.py
@@ -44,6 +44,14 @@ class CreateAutonomousDatabaseDetails(CreateAutonomousDatabaseBase):
             The value to assign to the is_free_tier property of this CreateAutonomousDatabaseDetails.
         :type is_free_tier: bool
 
+        :param kms_key_id:
+            The value to assign to the kms_key_id property of this CreateAutonomousDatabaseDetails.
+        :type kms_key_id: str
+
+        :param vault_id:
+            The value to assign to the vault_id property of this CreateAutonomousDatabaseDetails.
+        :type vault_id: str
+
         :param admin_password:
             The value to assign to the admin_password property of this CreateAutonomousDatabaseDetails.
         :type admin_password: str
@@ -134,6 +142,8 @@ class CreateAutonomousDatabaseDetails(CreateAutonomousDatabaseBase):
             'db_workload': 'str',
             'data_storage_size_in_tbs': 'int',
             'is_free_tier': 'bool',
+            'kms_key_id': 'str',
+            'vault_id': 'str',
             'admin_password': 'str',
             'display_name': 'str',
             'license_model': 'str',
@@ -163,6 +173,8 @@ class CreateAutonomousDatabaseDetails(CreateAutonomousDatabaseBase):
             'db_workload': 'dbWorkload',
             'data_storage_size_in_tbs': 'dataStorageSizeInTBs',
             'is_free_tier': 'isFreeTier',
+            'kms_key_id': 'kmsKeyId',
+            'vault_id': 'vaultId',
             'admin_password': 'adminPassword',
             'display_name': 'displayName',
             'license_model': 'licenseModel',
@@ -191,6 +203,8 @@ class CreateAutonomousDatabaseDetails(CreateAutonomousDatabaseBase):
         self._db_workload = None
         self._data_storage_size_in_tbs = None
         self._is_free_tier = None
+        self._kms_key_id = None
+        self._vault_id = None
         self._admin_password = None
         self._display_name = None
         self._license_model = None

--- a/src/oci/database/models/create_autonomous_database_from_backup_details.py
+++ b/src/oci/database/models/create_autonomous_database_from_backup_details.py
@@ -52,6 +52,14 @@ class CreateAutonomousDatabaseFromBackupDetails(CreateAutonomousDatabaseBase):
             The value to assign to the is_free_tier property of this CreateAutonomousDatabaseFromBackupDetails.
         :type is_free_tier: bool
 
+        :param kms_key_id:
+            The value to assign to the kms_key_id property of this CreateAutonomousDatabaseFromBackupDetails.
+        :type kms_key_id: str
+
+        :param vault_id:
+            The value to assign to the vault_id property of this CreateAutonomousDatabaseFromBackupDetails.
+        :type vault_id: str
+
         :param admin_password:
             The value to assign to the admin_password property of this CreateAutonomousDatabaseFromBackupDetails.
         :type admin_password: str
@@ -151,6 +159,8 @@ class CreateAutonomousDatabaseFromBackupDetails(CreateAutonomousDatabaseBase):
             'db_workload': 'str',
             'data_storage_size_in_tbs': 'int',
             'is_free_tier': 'bool',
+            'kms_key_id': 'str',
+            'vault_id': 'str',
             'admin_password': 'str',
             'display_name': 'str',
             'license_model': 'str',
@@ -182,6 +192,8 @@ class CreateAutonomousDatabaseFromBackupDetails(CreateAutonomousDatabaseBase):
             'db_workload': 'dbWorkload',
             'data_storage_size_in_tbs': 'dataStorageSizeInTBs',
             'is_free_tier': 'isFreeTier',
+            'kms_key_id': 'kmsKeyId',
+            'vault_id': 'vaultId',
             'admin_password': 'adminPassword',
             'display_name': 'displayName',
             'license_model': 'licenseModel',
@@ -212,6 +224,8 @@ class CreateAutonomousDatabaseFromBackupDetails(CreateAutonomousDatabaseBase):
         self._db_workload = None
         self._data_storage_size_in_tbs = None
         self._is_free_tier = None
+        self._kms_key_id = None
+        self._vault_id = None
         self._admin_password = None
         self._display_name = None
         self._license_model = None

--- a/src/oci/database/models/create_autonomous_database_from_backup_timestamp_details.py
+++ b/src/oci/database/models/create_autonomous_database_from_backup_timestamp_details.py
@@ -52,6 +52,14 @@ class CreateAutonomousDatabaseFromBackupTimestampDetails(CreateAutonomousDatabas
             The value to assign to the is_free_tier property of this CreateAutonomousDatabaseFromBackupTimestampDetails.
         :type is_free_tier: bool
 
+        :param kms_key_id:
+            The value to assign to the kms_key_id property of this CreateAutonomousDatabaseFromBackupTimestampDetails.
+        :type kms_key_id: str
+
+        :param vault_id:
+            The value to assign to the vault_id property of this CreateAutonomousDatabaseFromBackupTimestampDetails.
+        :type vault_id: str
+
         :param admin_password:
             The value to assign to the admin_password property of this CreateAutonomousDatabaseFromBackupTimestampDetails.
         :type admin_password: str
@@ -155,6 +163,8 @@ class CreateAutonomousDatabaseFromBackupTimestampDetails(CreateAutonomousDatabas
             'db_workload': 'str',
             'data_storage_size_in_tbs': 'int',
             'is_free_tier': 'bool',
+            'kms_key_id': 'str',
+            'vault_id': 'str',
             'admin_password': 'str',
             'display_name': 'str',
             'license_model': 'str',
@@ -187,6 +197,8 @@ class CreateAutonomousDatabaseFromBackupTimestampDetails(CreateAutonomousDatabas
             'db_workload': 'dbWorkload',
             'data_storage_size_in_tbs': 'dataStorageSizeInTBs',
             'is_free_tier': 'isFreeTier',
+            'kms_key_id': 'kmsKeyId',
+            'vault_id': 'vaultId',
             'admin_password': 'adminPassword',
             'display_name': 'displayName',
             'license_model': 'licenseModel',
@@ -218,6 +230,8 @@ class CreateAutonomousDatabaseFromBackupTimestampDetails(CreateAutonomousDatabas
         self._db_workload = None
         self._data_storage_size_in_tbs = None
         self._is_free_tier = None
+        self._kms_key_id = None
+        self._vault_id = None
         self._admin_password = None
         self._display_name = None
         self._license_model = None

--- a/src/oci/database/models/create_database_software_image_details.py
+++ b/src/oci/database/models/create_database_software_image_details.py
@@ -82,6 +82,10 @@ class CreateDatabaseSoftwareImageDetails(object):
             The value to assign to the defined_tags property of this CreateDatabaseSoftwareImageDetails.
         :type defined_tags: dict(str, dict(str, object))
 
+        :param source_db_home_id:
+            The value to assign to the source_db_home_id property of this CreateDatabaseSoftwareImageDetails.
+        :type source_db_home_id: str
+
         """
         self.swagger_types = {
             'compartment_id': 'str',
@@ -93,7 +97,8 @@ class CreateDatabaseSoftwareImageDetails(object):
             'database_software_image_one_off_patches': 'list[str]',
             'ls_inventory': 'str',
             'freeform_tags': 'dict(str, str)',
-            'defined_tags': 'dict(str, dict(str, object))'
+            'defined_tags': 'dict(str, dict(str, object))',
+            'source_db_home_id': 'str'
         }
 
         self.attribute_map = {
@@ -106,7 +111,8 @@ class CreateDatabaseSoftwareImageDetails(object):
             'database_software_image_one_off_patches': 'databaseSoftwareImageOneOffPatches',
             'ls_inventory': 'lsInventory',
             'freeform_tags': 'freeformTags',
-            'defined_tags': 'definedTags'
+            'defined_tags': 'definedTags',
+            'source_db_home_id': 'sourceDbHomeId'
         }
 
         self._compartment_id = None
@@ -119,6 +125,7 @@ class CreateDatabaseSoftwareImageDetails(object):
         self._ls_inventory = None
         self._freeform_tags = None
         self._defined_tags = None
+        self._source_db_home_id = None
 
     @property
     def compartment_id(self):
@@ -395,6 +402,34 @@ class CreateDatabaseSoftwareImageDetails(object):
         :type: dict(str, dict(str, object))
         """
         self._defined_tags = defined_tags
+
+    @property
+    def source_db_home_id(self):
+        """
+        Gets the source_db_home_id of this CreateDatabaseSoftwareImageDetails.
+        The `OCID`__ of the Database Home.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The source_db_home_id of this CreateDatabaseSoftwareImageDetails.
+        :rtype: str
+        """
+        return self._source_db_home_id
+
+    @source_db_home_id.setter
+    def source_db_home_id(self, source_db_home_id):
+        """
+        Sets the source_db_home_id of this CreateDatabaseSoftwareImageDetails.
+        The `OCID`__ of the Database Home.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param source_db_home_id: The source_db_home_id of this CreateDatabaseSoftwareImageDetails.
+        :type: str
+        """
+        self._source_db_home_id = source_db_home_id
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/database/models/create_db_home_base.py
+++ b/src/oci/database/models/create_db_home_base.py
@@ -77,6 +77,10 @@ class CreateDbHomeBase(object):
             Allowed values for this property are: "NONE", "DB_BACKUP", "DATABASE", "VM_CLUSTER_BACKUP", "VM_CLUSTER_NEW"
         :type source: str
 
+        :param is_desupported_version:
+            The value to assign to the is_desupported_version property of this CreateDbHomeBase.
+        :type is_desupported_version: bool
+
         """
         self.swagger_types = {
             'display_name': 'str',
@@ -85,7 +89,8 @@ class CreateDbHomeBase(object):
             'database_software_image_id': 'str',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
-            'source': 'str'
+            'source': 'str',
+            'is_desupported_version': 'bool'
         }
 
         self.attribute_map = {
@@ -95,7 +100,8 @@ class CreateDbHomeBase(object):
             'database_software_image_id': 'databaseSoftwareImageId',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
-            'source': 'source'
+            'source': 'source',
+            'is_desupported_version': 'isDesupportedVersion'
         }
 
         self._display_name = None
@@ -105,6 +111,7 @@ class CreateDbHomeBase(object):
         self._freeform_tags = None
         self._defined_tags = None
         self._source = None
+        self._is_desupported_version = None
 
     @staticmethod
     def get_subtype(object_dictionary):
@@ -326,6 +333,30 @@ class CreateDbHomeBase(object):
                 .format(allowed_values)
             )
         self._source = source
+
+    @property
+    def is_desupported_version(self):
+        """
+        Gets the is_desupported_version of this CreateDbHomeBase.
+        If true, the customer acknowledges that the specified Oracle Database software is an older release that is not currently supported by OCI.
+
+
+        :return: The is_desupported_version of this CreateDbHomeBase.
+        :rtype: bool
+        """
+        return self._is_desupported_version
+
+    @is_desupported_version.setter
+    def is_desupported_version(self, is_desupported_version):
+        """
+        Sets the is_desupported_version of this CreateDbHomeBase.
+        If true, the customer acknowledges that the specified Oracle Database software is an older release that is not currently supported by OCI.
+
+
+        :param is_desupported_version: The is_desupported_version of this CreateDbHomeBase.
+        :type: bool
+        """
+        self._is_desupported_version = is_desupported_version
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/database/models/create_db_home_with_db_system_id_details.py
+++ b/src/oci/database/models/create_db_home_with_db_system_id_details.py
@@ -48,6 +48,10 @@ class CreateDbHomeWithDbSystemIdDetails(CreateDbHomeBase):
             Allowed values for this property are: "NONE", "DB_BACKUP", "DATABASE", "VM_CLUSTER_BACKUP", "VM_CLUSTER_NEW"
         :type source: str
 
+        :param is_desupported_version:
+            The value to assign to the is_desupported_version property of this CreateDbHomeWithDbSystemIdDetails.
+        :type is_desupported_version: bool
+
         :param db_system_id:
             The value to assign to the db_system_id property of this CreateDbHomeWithDbSystemIdDetails.
         :type db_system_id: str
@@ -69,6 +73,7 @@ class CreateDbHomeWithDbSystemIdDetails(CreateDbHomeBase):
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
             'source': 'str',
+            'is_desupported_version': 'bool',
             'db_system_id': 'str',
             'db_version': 'str',
             'database': 'CreateDatabaseDetails'
@@ -82,6 +87,7 @@ class CreateDbHomeWithDbSystemIdDetails(CreateDbHomeBase):
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
             'source': 'source',
+            'is_desupported_version': 'isDesupportedVersion',
             'db_system_id': 'dbSystemId',
             'db_version': 'dbVersion',
             'database': 'database'
@@ -94,6 +100,7 @@ class CreateDbHomeWithDbSystemIdDetails(CreateDbHomeBase):
         self._freeform_tags = None
         self._defined_tags = None
         self._source = None
+        self._is_desupported_version = None
         self._db_system_id = None
         self._db_version = None
         self._database = None

--- a/src/oci/database/models/create_db_home_with_db_system_id_from_backup_details.py
+++ b/src/oci/database/models/create_db_home_with_db_system_id_from_backup_details.py
@@ -48,6 +48,10 @@ class CreateDbHomeWithDbSystemIdFromBackupDetails(CreateDbHomeBase):
             Allowed values for this property are: "NONE", "DB_BACKUP", "DATABASE", "VM_CLUSTER_BACKUP", "VM_CLUSTER_NEW"
         :type source: str
 
+        :param is_desupported_version:
+            The value to assign to the is_desupported_version property of this CreateDbHomeWithDbSystemIdFromBackupDetails.
+        :type is_desupported_version: bool
+
         :param db_system_id:
             The value to assign to the db_system_id property of this CreateDbHomeWithDbSystemIdFromBackupDetails.
         :type db_system_id: str
@@ -65,6 +69,7 @@ class CreateDbHomeWithDbSystemIdFromBackupDetails(CreateDbHomeBase):
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
             'source': 'str',
+            'is_desupported_version': 'bool',
             'db_system_id': 'str',
             'database': 'CreateDatabaseFromBackupDetails'
         }
@@ -77,6 +82,7 @@ class CreateDbHomeWithDbSystemIdFromBackupDetails(CreateDbHomeBase):
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
             'source': 'source',
+            'is_desupported_version': 'isDesupportedVersion',
             'db_system_id': 'dbSystemId',
             'database': 'database'
         }
@@ -88,6 +94,7 @@ class CreateDbHomeWithDbSystemIdFromBackupDetails(CreateDbHomeBase):
         self._freeform_tags = None
         self._defined_tags = None
         self._source = None
+        self._is_desupported_version = None
         self._db_system_id = None
         self._database = None
         self._source = 'DB_BACKUP'

--- a/src/oci/database/models/create_db_home_with_db_system_id_from_database_details.py
+++ b/src/oci/database/models/create_db_home_with_db_system_id_from_database_details.py
@@ -48,6 +48,10 @@ class CreateDbHomeWithDbSystemIdFromDatabaseDetails(CreateDbHomeBase):
             Allowed values for this property are: "NONE", "DB_BACKUP", "DATABASE", "VM_CLUSTER_BACKUP", "VM_CLUSTER_NEW"
         :type source: str
 
+        :param is_desupported_version:
+            The value to assign to the is_desupported_version property of this CreateDbHomeWithDbSystemIdFromDatabaseDetails.
+        :type is_desupported_version: bool
+
         :param db_system_id:
             The value to assign to the db_system_id property of this CreateDbHomeWithDbSystemIdFromDatabaseDetails.
         :type db_system_id: str
@@ -65,6 +69,7 @@ class CreateDbHomeWithDbSystemIdFromDatabaseDetails(CreateDbHomeBase):
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
             'source': 'str',
+            'is_desupported_version': 'bool',
             'db_system_id': 'str',
             'database': 'CreateDatabaseFromAnotherDatabaseDetails'
         }
@@ -77,6 +82,7 @@ class CreateDbHomeWithDbSystemIdFromDatabaseDetails(CreateDbHomeBase):
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
             'source': 'source',
+            'is_desupported_version': 'isDesupportedVersion',
             'db_system_id': 'dbSystemId',
             'database': 'database'
         }
@@ -88,6 +94,7 @@ class CreateDbHomeWithDbSystemIdFromDatabaseDetails(CreateDbHomeBase):
         self._freeform_tags = None
         self._defined_tags = None
         self._source = None
+        self._is_desupported_version = None
         self._db_system_id = None
         self._database = None
         self._source = 'DATABASE'

--- a/src/oci/database/models/create_db_home_with_vm_cluster_id_details.py
+++ b/src/oci/database/models/create_db_home_with_vm_cluster_id_details.py
@@ -48,6 +48,10 @@ class CreateDbHomeWithVmClusterIdDetails(CreateDbHomeBase):
             Allowed values for this property are: "NONE", "DB_BACKUP", "DATABASE", "VM_CLUSTER_BACKUP", "VM_CLUSTER_NEW"
         :type source: str
 
+        :param is_desupported_version:
+            The value to assign to the is_desupported_version property of this CreateDbHomeWithVmClusterIdDetails.
+        :type is_desupported_version: bool
+
         :param vm_cluster_id:
             The value to assign to the vm_cluster_id property of this CreateDbHomeWithVmClusterIdDetails.
         :type vm_cluster_id: str
@@ -69,6 +73,7 @@ class CreateDbHomeWithVmClusterIdDetails(CreateDbHomeBase):
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
             'source': 'str',
+            'is_desupported_version': 'bool',
             'vm_cluster_id': 'str',
             'db_version': 'str',
             'database': 'CreateDatabaseDetails'
@@ -82,6 +87,7 @@ class CreateDbHomeWithVmClusterIdDetails(CreateDbHomeBase):
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
             'source': 'source',
+            'is_desupported_version': 'isDesupportedVersion',
             'vm_cluster_id': 'vmClusterId',
             'db_version': 'dbVersion',
             'database': 'database'
@@ -94,6 +100,7 @@ class CreateDbHomeWithVmClusterIdDetails(CreateDbHomeBase):
         self._freeform_tags = None
         self._defined_tags = None
         self._source = None
+        self._is_desupported_version = None
         self._vm_cluster_id = None
         self._db_version = None
         self._database = None

--- a/src/oci/database/models/create_db_home_with_vm_cluster_id_from_backup_details.py
+++ b/src/oci/database/models/create_db_home_with_vm_cluster_id_from_backup_details.py
@@ -48,6 +48,10 @@ class CreateDbHomeWithVmClusterIdFromBackupDetails(CreateDbHomeBase):
             Allowed values for this property are: "NONE", "DB_BACKUP", "DATABASE", "VM_CLUSTER_BACKUP", "VM_CLUSTER_NEW"
         :type source: str
 
+        :param is_desupported_version:
+            The value to assign to the is_desupported_version property of this CreateDbHomeWithVmClusterIdFromBackupDetails.
+        :type is_desupported_version: bool
+
         :param vm_cluster_id:
             The value to assign to the vm_cluster_id property of this CreateDbHomeWithVmClusterIdFromBackupDetails.
         :type vm_cluster_id: str
@@ -65,6 +69,7 @@ class CreateDbHomeWithVmClusterIdFromBackupDetails(CreateDbHomeBase):
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
             'source': 'str',
+            'is_desupported_version': 'bool',
             'vm_cluster_id': 'str',
             'database': 'CreateDatabaseFromBackupDetails'
         }
@@ -77,6 +82,7 @@ class CreateDbHomeWithVmClusterIdFromBackupDetails(CreateDbHomeBase):
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
             'source': 'source',
+            'is_desupported_version': 'isDesupportedVersion',
             'vm_cluster_id': 'vmClusterId',
             'database': 'database'
         }
@@ -88,6 +94,7 @@ class CreateDbHomeWithVmClusterIdFromBackupDetails(CreateDbHomeBase):
         self._freeform_tags = None
         self._defined_tags = None
         self._source = None
+        self._is_desupported_version = None
         self._vm_cluster_id = None
         self._database = None
         self._source = 'VM_CLUSTER_BACKUP'

--- a/src/oci/database/models/create_refreshable_autonomous_database_clone_details.py
+++ b/src/oci/database/models/create_refreshable_autonomous_database_clone_details.py
@@ -52,6 +52,14 @@ class CreateRefreshableAutonomousDatabaseCloneDetails(CreateAutonomousDatabaseBa
             The value to assign to the is_free_tier property of this CreateRefreshableAutonomousDatabaseCloneDetails.
         :type is_free_tier: bool
 
+        :param kms_key_id:
+            The value to assign to the kms_key_id property of this CreateRefreshableAutonomousDatabaseCloneDetails.
+        :type kms_key_id: str
+
+        :param vault_id:
+            The value to assign to the vault_id property of this CreateRefreshableAutonomousDatabaseCloneDetails.
+        :type vault_id: str
+
         :param admin_password:
             The value to assign to the admin_password property of this CreateRefreshableAutonomousDatabaseCloneDetails.
         :type admin_password: str
@@ -151,6 +159,8 @@ class CreateRefreshableAutonomousDatabaseCloneDetails(CreateAutonomousDatabaseBa
             'db_workload': 'str',
             'data_storage_size_in_tbs': 'int',
             'is_free_tier': 'bool',
+            'kms_key_id': 'str',
+            'vault_id': 'str',
             'admin_password': 'str',
             'display_name': 'str',
             'license_model': 'str',
@@ -182,6 +192,8 @@ class CreateRefreshableAutonomousDatabaseCloneDetails(CreateAutonomousDatabaseBa
             'db_workload': 'dbWorkload',
             'data_storage_size_in_tbs': 'dataStorageSizeInTBs',
             'is_free_tier': 'isFreeTier',
+            'kms_key_id': 'kmsKeyId',
+            'vault_id': 'vaultId',
             'admin_password': 'adminPassword',
             'display_name': 'displayName',
             'license_model': 'licenseModel',
@@ -212,6 +224,8 @@ class CreateRefreshableAutonomousDatabaseCloneDetails(CreateAutonomousDatabaseBa
         self._db_workload = None
         self._data_storage_size_in_tbs = None
         self._is_free_tier = None
+        self._kms_key_id = None
+        self._vault_id = None
         self._admin_password = None
         self._display_name = None
         self._license_model = None

--- a/src/oci/log_analytics/models/__init__.py
+++ b/src/oci/log_analytics/models/__init__.py
@@ -41,6 +41,7 @@ from .column import Column
 from .column_name import ColumnName
 from .column_name_collection import ColumnNameCollection
 from .command_descriptor import CommandDescriptor
+from .compare_command_descriptor import CompareCommandDescriptor
 from .create_acceleration_task_details import CreateAccelerationTaskDetails
 from .create_log_analytics_em_bridge_details import CreateLogAnalyticsEmBridgeDetails
 from .create_log_analytics_entity_details import CreateLogAnalyticsEntityDetails
@@ -338,6 +339,7 @@ log_analytics_type_mapping = {
     "ColumnName": ColumnName,
     "ColumnNameCollection": ColumnNameCollection,
     "CommandDescriptor": CommandDescriptor,
+    "CompareCommandDescriptor": CompareCommandDescriptor,
     "CreateAccelerationTaskDetails": CreateAccelerationTaskDetails,
     "CreateLogAnalyticsEmBridgeDetails": CreateLogAnalyticsEmBridgeDetails,
     "CreateLogAnalyticsEntityDetails": CreateLogAnalyticsEntityDetails,

--- a/src/oci/log_analytics/models/abstract_command_descriptor.py
+++ b/src/oci/log_analytics/models/abstract_command_descriptor.py
@@ -177,6 +177,10 @@ class AbstractCommandDescriptor(object):
     #: This constant has a value of "NLP"
     NAME_NLP = "NLP"
 
+    #: A constant which can be used with the name property of a AbstractCommandDescriptor.
+    #: This constant has a value of "COMPARE"
+    NAME_COMPARE = "COMPARE"
+
     def __init__(self, **kwargs):
         """
         Initializes a new AbstractCommandDescriptor object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
@@ -185,6 +189,7 @@ class AbstractCommandDescriptor(object):
         * :class:`~oci.log_analytics.models.TopCommandDescriptor`
         * :class:`~oci.log_analytics.models.HighlightCommandDescriptor`
         * :class:`~oci.log_analytics.models.MultiSearchCommandDescriptor`
+        * :class:`~oci.log_analytics.models.CompareCommandDescriptor`
         * :class:`~oci.log_analytics.models.StatsCommandDescriptor`
         * :class:`~oci.log_analytics.models.TimeCompareCommandDescriptor`
         * :class:`~oci.log_analytics.models.TailCommandDescriptor`
@@ -228,7 +233,7 @@ class AbstractCommandDescriptor(object):
 
         :param name:
             The value to assign to the name property of this AbstractCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP", "COMPARE", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type name: str
 
@@ -294,6 +299,9 @@ class AbstractCommandDescriptor(object):
 
         if type == 'MULTI_SEARCH':
             return 'MultiSearchCommandDescriptor'
+
+        if type == 'COMPARE':
+            return 'CompareCommandDescriptor'
 
         if type == 'STATS':
             return 'StatsCommandDescriptor'
@@ -417,7 +425,7 @@ class AbstractCommandDescriptor(object):
         **[Required]** Gets the name of this AbstractCommandDescriptor.
         Name of querylanguage command
 
-        Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP", "COMPARE", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -436,7 +444,7 @@ class AbstractCommandDescriptor(object):
         :param name: The name of this AbstractCommandDescriptor.
         :type: str
         """
-        allowed_values = ["COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"]
+        allowed_values = ["COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP", "COMPARE"]
         if not value_allowed_none_or_none_sentinel(name, allowed_values):
             name = 'UNKNOWN_ENUM_VALUE'
         self._name = name

--- a/src/oci/log_analytics/models/add_fields_command_descriptor.py
+++ b/src/oci/log_analytics/models/add_fields_command_descriptor.py
@@ -21,7 +21,7 @@ class AddFieldsCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this AddFieldsCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP", "COMPARE"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/bottom_command_descriptor.py
+++ b/src/oci/log_analytics/models/bottom_command_descriptor.py
@@ -21,7 +21,7 @@ class BottomCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this BottomCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP", "COMPARE"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/bucket_command_descriptor.py
+++ b/src/oci/log_analytics/models/bucket_command_descriptor.py
@@ -21,7 +21,7 @@ class BucketCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this BucketCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP", "COMPARE"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/classify_command_descriptor.py
+++ b/src/oci/log_analytics/models/classify_command_descriptor.py
@@ -21,7 +21,7 @@ class ClassifyCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this ClassifyCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP", "COMPARE"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/cluster_command_descriptor.py
+++ b/src/oci/log_analytics/models/cluster_command_descriptor.py
@@ -21,7 +21,7 @@ class ClusterCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this ClusterCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP", "COMPARE"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/cluster_compare_command_descriptor.py
+++ b/src/oci/log_analytics/models/cluster_compare_command_descriptor.py
@@ -21,7 +21,7 @@ class ClusterCompareCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this ClusterCompareCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP", "COMPARE"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/cluster_details_command_descriptor.py
+++ b/src/oci/log_analytics/models/cluster_details_command_descriptor.py
@@ -21,7 +21,7 @@ class ClusterDetailsCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this ClusterDetailsCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP", "COMPARE"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/cluster_split_command_descriptor.py
+++ b/src/oci/log_analytics/models/cluster_split_command_descriptor.py
@@ -21,7 +21,7 @@ class ClusterSplitCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this ClusterSplitCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP", "COMPARE"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/command_descriptor.py
+++ b/src/oci/log_analytics/models/command_descriptor.py
@@ -21,7 +21,7 @@ class CommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this CommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP", "COMPARE"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/compare_command_descriptor.py
+++ b/src/oci/log_analytics/models/compare_command_descriptor.py
@@ -8,40 +8,40 @@ from oci.decorators import init_model_state_from_kwargs
 
 
 @init_model_state_from_kwargs
-class EvalCommandDescriptor(AbstractCommandDescriptor):
+class CompareCommandDescriptor(AbstractCommandDescriptor):
     """
-    Command descriptor for querylanguage EVAL command.
+    Command descriptor for querylanguage COMPARE command.
     """
 
     def __init__(self, **kwargs):
         """
-        Initializes a new EvalCommandDescriptor object with values from keyword arguments. The default value of the :py:attr:`~oci.log_analytics.models.EvalCommandDescriptor.name` attribute
-        of this class is ``EVAL`` and it should not be changed.
+        Initializes a new CompareCommandDescriptor object with values from keyword arguments. The default value of the :py:attr:`~oci.log_analytics.models.CompareCommandDescriptor.name` attribute
+        of this class is ``COMPARE`` and it should not be changed.
         The following keyword arguments are supported (corresponding to the getters/setters of this class):
 
         :param name:
-            The value to assign to the name property of this EvalCommandDescriptor.
+            The value to assign to the name property of this CompareCommandDescriptor.
             Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP", "COMPARE"
         :type name: str
 
         :param display_query_string:
-            The value to assign to the display_query_string property of this EvalCommandDescriptor.
+            The value to assign to the display_query_string property of this CompareCommandDescriptor.
         :type display_query_string: str
 
         :param internal_query_string:
-            The value to assign to the internal_query_string property of this EvalCommandDescriptor.
+            The value to assign to the internal_query_string property of this CompareCommandDescriptor.
         :type internal_query_string: str
 
         :param category:
-            The value to assign to the category property of this EvalCommandDescriptor.
+            The value to assign to the category property of this CompareCommandDescriptor.
         :type category: str
 
         :param referenced_fields:
-            The value to assign to the referenced_fields property of this EvalCommandDescriptor.
+            The value to assign to the referenced_fields property of this CompareCommandDescriptor.
         :type referenced_fields: list[oci.log_analytics.models.AbstractField]
 
         :param declared_fields:
-            The value to assign to the declared_fields property of this EvalCommandDescriptor.
+            The value to assign to the declared_fields property of this CompareCommandDescriptor.
         :type declared_fields: list[oci.log_analytics.models.AbstractField]
 
         """
@@ -69,7 +69,7 @@ class EvalCommandDescriptor(AbstractCommandDescriptor):
         self._category = None
         self._referenced_fields = None
         self._declared_fields = None
-        self._name = 'EVAL'
+        self._name = 'COMPARE'
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/log_analytics/models/create_view_command_descriptor.py
+++ b/src/oci/log_analytics/models/create_view_command_descriptor.py
@@ -21,7 +21,7 @@ class CreateViewCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this CreateViewCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP", "COMPARE"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/cron_schedule.py
+++ b/src/oci/log_analytics/models/cron_schedule.py
@@ -29,6 +29,10 @@ class CronSchedule(Schedule):
             Allowed values for this property are: "RETRY_ONCE", "RETRY_INDEFINITELY", "SKIP"
         :type misfire_policy: str
 
+        :param time_of_first_execution:
+            The value to assign to the time_of_first_execution property of this CronSchedule.
+        :type time_of_first_execution: datetime
+
         :param expression:
             The value to assign to the expression property of this CronSchedule.
         :type expression: str
@@ -41,6 +45,7 @@ class CronSchedule(Schedule):
         self.swagger_types = {
             'type': 'str',
             'misfire_policy': 'str',
+            'time_of_first_execution': 'datetime',
             'expression': 'str',
             'time_zone': 'str'
         }
@@ -48,12 +53,14 @@ class CronSchedule(Schedule):
         self.attribute_map = {
             'type': 'type',
             'misfire_policy': 'misfirePolicy',
+            'time_of_first_execution': 'timeOfFirstExecution',
             'expression': 'expression',
             'time_zone': 'timeZone'
         }
 
         self._type = None
         self._misfire_policy = None
+        self._time_of_first_execution = None
         self._expression = None
         self._time_zone = None
         self._type = 'CRON'

--- a/src/oci/log_analytics/models/delete_command_descriptor.py
+++ b/src/oci/log_analytics/models/delete_command_descriptor.py
@@ -21,7 +21,7 @@ class DeleteCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this DeleteCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP", "COMPARE"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/delta_command_descriptor.py
+++ b/src/oci/log_analytics/models/delta_command_descriptor.py
@@ -21,7 +21,7 @@ class DeltaCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this DeltaCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP", "COMPARE"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/demo_mode_command_descriptor.py
+++ b/src/oci/log_analytics/models/demo_mode_command_descriptor.py
@@ -21,7 +21,7 @@ class DemoModeCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this DemoModeCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP", "COMPARE"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/distinct_command_descriptor.py
+++ b/src/oci/log_analytics/models/distinct_command_descriptor.py
@@ -21,7 +21,7 @@ class DistinctCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this DistinctCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP", "COMPARE"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/event_stats_command_descriptor.py
+++ b/src/oci/log_analytics/models/event_stats_command_descriptor.py
@@ -21,7 +21,7 @@ class EventStatsCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this EventStatsCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP", "COMPARE"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/extract_command_descriptor.py
+++ b/src/oci/log_analytics/models/extract_command_descriptor.py
@@ -21,7 +21,7 @@ class ExtractCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this ExtractCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP", "COMPARE"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/field_summary_command_descriptor.py
+++ b/src/oci/log_analytics/models/field_summary_command_descriptor.py
@@ -21,7 +21,7 @@ class FieldSummaryCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this FieldSummaryCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP", "COMPARE"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/fields_command_descriptor.py
+++ b/src/oci/log_analytics/models/fields_command_descriptor.py
@@ -21,7 +21,7 @@ class FieldsCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this FieldsCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP", "COMPARE"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/fixed_frequency_schedule.py
+++ b/src/oci/log_analytics/models/fixed_frequency_schedule.py
@@ -29,6 +29,10 @@ class FixedFrequencySchedule(Schedule):
             Allowed values for this property are: "RETRY_ONCE", "RETRY_INDEFINITELY", "SKIP"
         :type misfire_policy: str
 
+        :param time_of_first_execution:
+            The value to assign to the time_of_first_execution property of this FixedFrequencySchedule.
+        :type time_of_first_execution: datetime
+
         :param recurring_interval:
             The value to assign to the recurring_interval property of this FixedFrequencySchedule.
         :type recurring_interval: str
@@ -41,6 +45,7 @@ class FixedFrequencySchedule(Schedule):
         self.swagger_types = {
             'type': 'str',
             'misfire_policy': 'str',
+            'time_of_first_execution': 'datetime',
             'recurring_interval': 'str',
             'repeat_count': 'int'
         }
@@ -48,12 +53,14 @@ class FixedFrequencySchedule(Schedule):
         self.attribute_map = {
             'type': 'type',
             'misfire_policy': 'misfirePolicy',
+            'time_of_first_execution': 'timeOfFirstExecution',
             'recurring_interval': 'recurringInterval',
             'repeat_count': 'repeatCount'
         }
 
         self._type = None
         self._misfire_policy = None
+        self._time_of_first_execution = None
         self._recurring_interval = None
         self._repeat_count = None
         self._type = 'FIXED_FREQUENCY'

--- a/src/oci/log_analytics/models/head_command_descriptor.py
+++ b/src/oci/log_analytics/models/head_command_descriptor.py
@@ -21,7 +21,7 @@ class HeadCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this HeadCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP", "COMPARE"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/highlight_command_descriptor.py
+++ b/src/oci/log_analytics/models/highlight_command_descriptor.py
@@ -21,7 +21,7 @@ class HighlightCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this HighlightCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP", "COMPARE"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/highlight_groups_command_descriptor.py
+++ b/src/oci/log_analytics/models/highlight_groups_command_descriptor.py
@@ -21,7 +21,7 @@ class HighlightGroupsCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this HighlightGroupsCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP", "COMPARE"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/highlight_rows_command_descriptor.py
+++ b/src/oci/log_analytics/models/highlight_rows_command_descriptor.py
@@ -21,7 +21,7 @@ class HighlightRowsCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this HighlightRowsCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP", "COMPARE"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/link_command_descriptor.py
+++ b/src/oci/log_analytics/models/link_command_descriptor.py
@@ -21,7 +21,7 @@ class LinkCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this LinkCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP", "COMPARE"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/link_details_command_descriptor.py
+++ b/src/oci/log_analytics/models/link_details_command_descriptor.py
@@ -21,7 +21,7 @@ class LinkDetailsCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this LinkDetailsCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP", "COMPARE"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/lookup_command_descriptor.py
+++ b/src/oci/log_analytics/models/lookup_command_descriptor.py
@@ -21,7 +21,7 @@ class LookupCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this LookupCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP", "COMPARE"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/macro_command_descriptor.py
+++ b/src/oci/log_analytics/models/macro_command_descriptor.py
@@ -21,7 +21,7 @@ class MacroCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this MacroCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP", "COMPARE"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/map_command_descriptor.py
+++ b/src/oci/log_analytics/models/map_command_descriptor.py
@@ -21,7 +21,7 @@ class MapCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this MapCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP", "COMPARE"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/multi_search_command_descriptor.py
+++ b/src/oci/log_analytics/models/multi_search_command_descriptor.py
@@ -21,7 +21,7 @@ class MultiSearchCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this MultiSearchCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP", "COMPARE"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/namespace.py
+++ b/src/oci/log_analytics/models/namespace.py
@@ -34,25 +34,32 @@ class Namespace(object):
             The value to assign to the is_log_set_enabled property of this Namespace.
         :type is_log_set_enabled: bool
 
+        :param is_data_ever_ingested:
+            The value to assign to the is_data_ever_ingested property of this Namespace.
+        :type is_data_ever_ingested: bool
+
         """
         self.swagger_types = {
             'namespace_name': 'str',
             'compartment_id': 'str',
             'is_onboarded': 'bool',
-            'is_log_set_enabled': 'bool'
+            'is_log_set_enabled': 'bool',
+            'is_data_ever_ingested': 'bool'
         }
 
         self.attribute_map = {
             'namespace_name': 'namespaceName',
             'compartment_id': 'compartmentId',
             'is_onboarded': 'isOnboarded',
-            'is_log_set_enabled': 'isLogSetEnabled'
+            'is_log_set_enabled': 'isLogSetEnabled',
+            'is_data_ever_ingested': 'isDataEverIngested'
         }
 
         self._namespace_name = None
         self._compartment_id = None
         self._is_onboarded = None
         self._is_log_set_enabled = None
+        self._is_data_ever_ingested = None
 
     @property
     def namespace_name(self):
@@ -149,6 +156,30 @@ class Namespace(object):
         :type: bool
         """
         self._is_log_set_enabled = is_log_set_enabled
+
+    @property
+    def is_data_ever_ingested(self):
+        """
+        Gets the is_data_ever_ingested of this Namespace.
+        This indicates if data has ever been ingested for the tenancy in Logging Analytics
+
+
+        :return: The is_data_ever_ingested of this Namespace.
+        :rtype: bool
+        """
+        return self._is_data_ever_ingested
+
+    @is_data_ever_ingested.setter
+    def is_data_ever_ingested(self, is_data_ever_ingested):
+        """
+        Sets the is_data_ever_ingested of this Namespace.
+        This indicates if data has ever been ingested for the tenancy in Logging Analytics
+
+
+        :param is_data_ever_ingested: The is_data_ever_ingested of this Namespace.
+        :type: bool
+        """
+        self._is_data_ever_ingested = is_data_ever_ingested
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/log_analytics/models/namespace_summary.py
+++ b/src/oci/log_analytics/models/namespace_summary.py
@@ -34,25 +34,32 @@ class NamespaceSummary(object):
             The value to assign to the is_log_set_enabled property of this NamespaceSummary.
         :type is_log_set_enabled: bool
 
+        :param is_data_ever_ingested:
+            The value to assign to the is_data_ever_ingested property of this NamespaceSummary.
+        :type is_data_ever_ingested: bool
+
         """
         self.swagger_types = {
             'namespace_name': 'str',
             'compartment_id': 'str',
             'is_onboarded': 'bool',
-            'is_log_set_enabled': 'bool'
+            'is_log_set_enabled': 'bool',
+            'is_data_ever_ingested': 'bool'
         }
 
         self.attribute_map = {
             'namespace_name': 'namespaceName',
             'compartment_id': 'compartmentId',
             'is_onboarded': 'isOnboarded',
-            'is_log_set_enabled': 'isLogSetEnabled'
+            'is_log_set_enabled': 'isLogSetEnabled',
+            'is_data_ever_ingested': 'isDataEverIngested'
         }
 
         self._namespace_name = None
         self._compartment_id = None
         self._is_onboarded = None
         self._is_log_set_enabled = None
+        self._is_data_ever_ingested = None
 
     @property
     def namespace_name(self):
@@ -149,6 +156,30 @@ class NamespaceSummary(object):
         :type: bool
         """
         self._is_log_set_enabled = is_log_set_enabled
+
+    @property
+    def is_data_ever_ingested(self):
+        """
+        Gets the is_data_ever_ingested of this NamespaceSummary.
+        This indicates if data has ever been ingested for the tenancy in Logging Analytics
+
+
+        :return: The is_data_ever_ingested of this NamespaceSummary.
+        :rtype: bool
+        """
+        return self._is_data_ever_ingested
+
+    @is_data_ever_ingested.setter
+    def is_data_ever_ingested(self, is_data_ever_ingested):
+        """
+        Sets the is_data_ever_ingested of this NamespaceSummary.
+        This indicates if data has ever been ingested for the tenancy in Logging Analytics
+
+
+        :param is_data_ever_ingested: The is_data_ever_ingested of this NamespaceSummary.
+        :type: bool
+        """
+        self._is_data_ever_ingested = is_data_ever_ingested
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/log_analytics/models/nlp_command_descriptor.py
+++ b/src/oci/log_analytics/models/nlp_command_descriptor.py
@@ -21,7 +21,7 @@ class NlpCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this NlpCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP", "COMPARE"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/regex_command_descriptor.py
+++ b/src/oci/log_analytics/models/regex_command_descriptor.py
@@ -21,7 +21,7 @@ class RegexCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this RegexCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP", "COMPARE"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/rename_command_descriptor.py
+++ b/src/oci/log_analytics/models/rename_command_descriptor.py
@@ -21,7 +21,7 @@ class RenameCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this RenameCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP", "COMPARE"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/schedule.py
+++ b/src/oci/log_analytics/models/schedule.py
@@ -55,19 +55,26 @@ class Schedule(object):
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type misfire_policy: str
 
+        :param time_of_first_execution:
+            The value to assign to the time_of_first_execution property of this Schedule.
+        :type time_of_first_execution: datetime
+
         """
         self.swagger_types = {
             'type': 'str',
-            'misfire_policy': 'str'
+            'misfire_policy': 'str',
+            'time_of_first_execution': 'datetime'
         }
 
         self.attribute_map = {
             'type': 'type',
-            'misfire_policy': 'misfirePolicy'
+            'misfire_policy': 'misfirePolicy',
+            'time_of_first_execution': 'timeOfFirstExecution'
         }
 
         self._type = None
         self._misfire_policy = None
+        self._time_of_first_execution = None
 
     @staticmethod
     def get_subtype(object_dictionary):
@@ -144,6 +151,32 @@ class Schedule(object):
         if not value_allowed_none_or_none_sentinel(misfire_policy, allowed_values):
             misfire_policy = 'UNKNOWN_ENUM_VALUE'
         self._misfire_policy = misfire_policy
+
+    @property
+    def time_of_first_execution(self):
+        """
+        Gets the time_of_first_execution of this Schedule.
+        The date and time the scheduled task should execute first time after create or update;
+        thereafter the task will execute as specified in the schedule.
+
+
+        :return: The time_of_first_execution of this Schedule.
+        :rtype: datetime
+        """
+        return self._time_of_first_execution
+
+    @time_of_first_execution.setter
+    def time_of_first_execution(self, time_of_first_execution):
+        """
+        Sets the time_of_first_execution of this Schedule.
+        The date and time the scheduled task should execute first time after create or update;
+        thereafter the task will execute as specified in the schedule.
+
+
+        :param time_of_first_execution: The time_of_first_execution of this Schedule.
+        :type: datetime
+        """
+        self._time_of_first_execution = time_of_first_execution
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/log_analytics/models/scheduled_task.py
+++ b/src/oci/log_analytics/models/scheduled_task.py
@@ -53,6 +53,30 @@ class ScheduledTask(object):
     #: This constant has a value of "BLOCKED"
     TASK_STATUS_BLOCKED = "BLOCKED"
 
+    #: A constant which can be used with the pause_reason property of a ScheduledTask.
+    #: This constant has a value of "METRIC_EXTRACTION_NOT_VALID"
+    PAUSE_REASON_METRIC_EXTRACTION_NOT_VALID = "METRIC_EXTRACTION_NOT_VALID"
+
+    #: A constant which can be used with the pause_reason property of a ScheduledTask.
+    #: This constant has a value of "SAVED_SEARCH_NOT_VALID"
+    PAUSE_REASON_SAVED_SEARCH_NOT_VALID = "SAVED_SEARCH_NOT_VALID"
+
+    #: A constant which can be used with the pause_reason property of a ScheduledTask.
+    #: This constant has a value of "SAVED_SEARCH_NOT_FOUND"
+    PAUSE_REASON_SAVED_SEARCH_NOT_FOUND = "SAVED_SEARCH_NOT_FOUND"
+
+    #: A constant which can be used with the pause_reason property of a ScheduledTask.
+    #: This constant has a value of "QUERY_STRING_NOT_VALID"
+    PAUSE_REASON_QUERY_STRING_NOT_VALID = "QUERY_STRING_NOT_VALID"
+
+    #: A constant which can be used with the pause_reason property of a ScheduledTask.
+    #: This constant has a value of "USER_ACTION"
+    PAUSE_REASON_USER_ACTION = "USER_ACTION"
+
+    #: A constant which can be used with the pause_reason property of a ScheduledTask.
+    #: This constant has a value of "TENANCY_LIFECYCLE"
+    PAUSE_REASON_TENANCY_LIFECYCLE = "TENANCY_LIFECYCLE"
+
     #: A constant which can be used with the lifecycle_state property of a ScheduledTask.
     #: This constant has a value of "ACTIVE"
     LIFECYCLE_STATE_ACTIVE = "ACTIVE"
@@ -104,6 +128,12 @@ class ScheduledTask(object):
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type task_status: str
 
+        :param pause_reason:
+            The value to assign to the pause_reason property of this ScheduledTask.
+            Allowed values for this property are: "METRIC_EXTRACTION_NOT_VALID", "SAVED_SEARCH_NOT_VALID", "SAVED_SEARCH_NOT_FOUND", "QUERY_STRING_NOT_VALID", "USER_ACTION", "TENANCY_LIFECYCLE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type pause_reason: str
+
         :param work_request_id:
             The value to assign to the work_request_id property of this ScheduledTask.
         :type work_request_id: str
@@ -123,6 +153,10 @@ class ScheduledTask(object):
         :param time_updated:
             The value to assign to the time_updated property of this ScheduledTask.
         :type time_updated: datetime
+
+        :param time_of_next_execution:
+            The value to assign to the time_of_next_execution property of this ScheduledTask.
+        :type time_of_next_execution: datetime
 
         :param lifecycle_state:
             The value to assign to the lifecycle_state property of this ScheduledTask.
@@ -147,11 +181,13 @@ class ScheduledTask(object):
             'schedules': 'list[Schedule]',
             'action': 'Action',
             'task_status': 'str',
+            'pause_reason': 'str',
             'work_request_id': 'str',
             'num_occurrences': 'int',
             'compartment_id': 'str',
             'time_created': 'datetime',
             'time_updated': 'datetime',
+            'time_of_next_execution': 'datetime',
             'lifecycle_state': 'str',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))'
@@ -165,11 +201,13 @@ class ScheduledTask(object):
             'schedules': 'schedules',
             'action': 'action',
             'task_status': 'taskStatus',
+            'pause_reason': 'pauseReason',
             'work_request_id': 'workRequestId',
             'num_occurrences': 'numOccurrences',
             'compartment_id': 'compartmentId',
             'time_created': 'timeCreated',
             'time_updated': 'timeUpdated',
+            'time_of_next_execution': 'timeOfNextExecution',
             'lifecycle_state': 'lifecycleState',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags'
@@ -182,11 +220,13 @@ class ScheduledTask(object):
         self._schedules = None
         self._action = None
         self._task_status = None
+        self._pause_reason = None
         self._work_request_id = None
         self._num_occurrences = None
         self._compartment_id = None
         self._time_created = None
         self._time_updated = None
+        self._time_of_next_execution = None
         self._lifecycle_state = None
         self._freeform_tags = None
         self._defined_tags = None
@@ -397,6 +437,36 @@ class ScheduledTask(object):
         self._task_status = task_status
 
     @property
+    def pause_reason(self):
+        """
+        Gets the pause_reason of this ScheduledTask.
+        reason for taskStatus PAUSED.
+
+        Allowed values for this property are: "METRIC_EXTRACTION_NOT_VALID", "SAVED_SEARCH_NOT_VALID", "SAVED_SEARCH_NOT_FOUND", "QUERY_STRING_NOT_VALID", "USER_ACTION", "TENANCY_LIFECYCLE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The pause_reason of this ScheduledTask.
+        :rtype: str
+        """
+        return self._pause_reason
+
+    @pause_reason.setter
+    def pause_reason(self, pause_reason):
+        """
+        Sets the pause_reason of this ScheduledTask.
+        reason for taskStatus PAUSED.
+
+
+        :param pause_reason: The pause_reason of this ScheduledTask.
+        :type: str
+        """
+        allowed_values = ["METRIC_EXTRACTION_NOT_VALID", "SAVED_SEARCH_NOT_VALID", "SAVED_SEARCH_NOT_FOUND", "QUERY_STRING_NOT_VALID", "USER_ACTION", "TENANCY_LIFECYCLE"]
+        if not value_allowed_none_or_none_sentinel(pause_reason, allowed_values):
+            pause_reason = 'UNKNOWN_ENUM_VALUE'
+        self._pause_reason = pause_reason
+
+    @property
     def work_request_id(self):
         """
         Gets the work_request_id of this ScheduledTask.
@@ -523,6 +593,32 @@ class ScheduledTask(object):
         :type: datetime
         """
         self._time_updated = time_updated
+
+    @property
+    def time_of_next_execution(self):
+        """
+        Gets the time_of_next_execution of this ScheduledTask.
+        The date and time the scheduled task will execute next,
+        in the format defined by RFC3339.
+
+
+        :return: The time_of_next_execution of this ScheduledTask.
+        :rtype: datetime
+        """
+        return self._time_of_next_execution
+
+    @time_of_next_execution.setter
+    def time_of_next_execution(self, time_of_next_execution):
+        """
+        Sets the time_of_next_execution of this ScheduledTask.
+        The date and time the scheduled task will execute next,
+        in the format defined by RFC3339.
+
+
+        :param time_of_next_execution: The time_of_next_execution of this ScheduledTask.
+        :type: datetime
+        """
+        self._time_of_next_execution = time_of_next_execution
 
     @property
     def lifecycle_state(self):

--- a/src/oci/log_analytics/models/scheduled_task_summary.py
+++ b/src/oci/log_analytics/models/scheduled_task_summary.py
@@ -90,6 +90,10 @@ class ScheduledTaskSummary(object):
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type task_status: str
 
+        :param pause_reason:
+            The value to assign to the pause_reason property of this ScheduledTaskSummary.
+        :type pause_reason: str
+
         :param work_request_id:
             The value to assign to the work_request_id property of this ScheduledTaskSummary.
         :type work_request_id: str
@@ -125,6 +129,7 @@ class ScheduledTaskSummary(object):
             'time_updated': 'datetime',
             'lifecycle_state': 'str',
             'task_status': 'str',
+            'pause_reason': 'str',
             'work_request_id': 'str',
             'display_name': 'str',
             'freeform_tags': 'dict(str, str)',
@@ -141,6 +146,7 @@ class ScheduledTaskSummary(object):
             'time_updated': 'timeUpdated',
             'lifecycle_state': 'lifecycleState',
             'task_status': 'taskStatus',
+            'pause_reason': 'pauseReason',
             'work_request_id': 'workRequestId',
             'display_name': 'displayName',
             'freeform_tags': 'freeformTags',
@@ -156,6 +162,7 @@ class ScheduledTaskSummary(object):
         self._time_updated = None
         self._lifecycle_state = None
         self._task_status = None
+        self._pause_reason = None
         self._work_request_id = None
         self._display_name = None
         self._freeform_tags = None
@@ -350,6 +357,30 @@ class ScheduledTaskSummary(object):
         if not value_allowed_none_or_none_sentinel(task_status, allowed_values):
             task_status = 'UNKNOWN_ENUM_VALUE'
         self._task_status = task_status
+
+    @property
+    def pause_reason(self):
+        """
+        Gets the pause_reason of this ScheduledTaskSummary.
+        reason for taskStatus PAUSED.
+
+
+        :return: The pause_reason of this ScheduledTaskSummary.
+        :rtype: str
+        """
+        return self._pause_reason
+
+    @pause_reason.setter
+    def pause_reason(self, pause_reason):
+        """
+        Sets the pause_reason of this ScheduledTaskSummary.
+        reason for taskStatus PAUSED.
+
+
+        :param pause_reason: The pause_reason of this ScheduledTaskSummary.
+        :type: str
+        """
+        self._pause_reason = pause_reason
 
     @property
     def work_request_id(self):

--- a/src/oci/log_analytics/models/search_command_descriptor.py
+++ b/src/oci/log_analytics/models/search_command_descriptor.py
@@ -21,7 +21,7 @@ class SearchCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this SearchCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP", "COMPARE"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/search_lookup_command_descriptor.py
+++ b/src/oci/log_analytics/models/search_lookup_command_descriptor.py
@@ -21,7 +21,7 @@ class SearchLookupCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this SearchLookupCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP", "COMPARE"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/sort_command_descriptor.py
+++ b/src/oci/log_analytics/models/sort_command_descriptor.py
@@ -21,7 +21,7 @@ class SortCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this SortCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP", "COMPARE"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/standard_task.py
+++ b/src/oci/log_analytics/models/standard_task.py
@@ -61,6 +61,12 @@ class StandardTask(ScheduledTask):
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type task_status: str
 
+        :param pause_reason:
+            The value to assign to the pause_reason property of this StandardTask.
+            Allowed values for this property are: "METRIC_EXTRACTION_NOT_VALID", "SAVED_SEARCH_NOT_VALID", "SAVED_SEARCH_NOT_FOUND", "QUERY_STRING_NOT_VALID", "USER_ACTION", "TENANCY_LIFECYCLE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type pause_reason: str
+
         :param work_request_id:
             The value to assign to the work_request_id property of this StandardTask.
         :type work_request_id: str
@@ -80,6 +86,10 @@ class StandardTask(ScheduledTask):
         :param time_updated:
             The value to assign to the time_updated property of this StandardTask.
         :type time_updated: datetime
+
+        :param time_of_next_execution:
+            The value to assign to the time_of_next_execution property of this StandardTask.
+        :type time_of_next_execution: datetime
 
         :param lifecycle_state:
             The value to assign to the lifecycle_state property of this StandardTask.
@@ -114,11 +124,13 @@ class StandardTask(ScheduledTask):
             'schedules': 'list[Schedule]',
             'action': 'Action',
             'task_status': 'str',
+            'pause_reason': 'str',
             'work_request_id': 'str',
             'num_occurrences': 'int',
             'compartment_id': 'str',
             'time_created': 'datetime',
             'time_updated': 'datetime',
+            'time_of_next_execution': 'datetime',
             'lifecycle_state': 'str',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
@@ -134,11 +146,13 @@ class StandardTask(ScheduledTask):
             'schedules': 'schedules',
             'action': 'action',
             'task_status': 'taskStatus',
+            'pause_reason': 'pauseReason',
             'work_request_id': 'workRequestId',
             'num_occurrences': 'numOccurrences',
             'compartment_id': 'compartmentId',
             'time_created': 'timeCreated',
             'time_updated': 'timeUpdated',
+            'time_of_next_execution': 'timeOfNextExecution',
             'lifecycle_state': 'lifecycleState',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
@@ -153,11 +167,13 @@ class StandardTask(ScheduledTask):
         self._schedules = None
         self._action = None
         self._task_status = None
+        self._pause_reason = None
         self._work_request_id = None
         self._num_occurrences = None
         self._compartment_id = None
         self._time_created = None
         self._time_updated = None
+        self._time_of_next_execution = None
         self._lifecycle_state = None
         self._freeform_tags = None
         self._defined_tags = None

--- a/src/oci/log_analytics/models/stats_command_descriptor.py
+++ b/src/oci/log_analytics/models/stats_command_descriptor.py
@@ -21,7 +21,7 @@ class StatsCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this StatsCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP", "COMPARE"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/stream_action.py
+++ b/src/oci/log_analytics/models/stream_action.py
@@ -32,22 +32,29 @@ class StreamAction(Action):
             The value to assign to the metric_extraction property of this StreamAction.
         :type metric_extraction: oci.log_analytics.models.MetricExtraction
 
+        :param saved_search_duration:
+            The value to assign to the saved_search_duration property of this StreamAction.
+        :type saved_search_duration: str
+
         """
         self.swagger_types = {
             'type': 'str',
             'saved_search_id': 'str',
-            'metric_extraction': 'MetricExtraction'
+            'metric_extraction': 'MetricExtraction',
+            'saved_search_duration': 'str'
         }
 
         self.attribute_map = {
             'type': 'type',
             'saved_search_id': 'savedSearchId',
-            'metric_extraction': 'metricExtraction'
+            'metric_extraction': 'metricExtraction',
+            'saved_search_duration': 'savedSearchDuration'
         }
 
         self._type = None
         self._saved_search_id = None
         self._metric_extraction = None
+        self._saved_search_duration = None
         self._type = 'STREAM'
 
     @property
@@ -93,6 +100,72 @@ class StreamAction(Action):
         :type: oci.log_analytics.models.MetricExtraction
         """
         self._metric_extraction = metric_extraction
+
+    @property
+    def saved_search_duration(self):
+        """
+        Gets the saved_search_duration of this StreamAction.
+        The duration of data to be searched for SAVED_SEARCH tasks,
+        used when the task fires to calculate the query time range.
+
+        Duration in ISO 8601 extended format as described in
+        https://en.wikipedia.org/wiki/ISO_8601#Durations.
+        The value should be positive.
+        The largest supported unit (as opposed to value) is D, e.g.  P14D (not P2W).
+
+        There are restrictions on the maximum duration value relative to the task schedule
+        value as specified in the following table.
+           Schedule Interval Range          | Maximum Duration
+        ----------------------------------- | -----------------
+          5 Minutes     to 30 Minutes       |   1 hour  \"PT60M\"
+         31 Minutes     to  1 Hour          |  12 hours \"PT720M\"
+         1 Hour+1Minute to  1 Day           |   1 day   \"P1D\"
+         1 Day+1Minute  to  1 Week-1Minute  |   7 days  \"P7D\"
+         1 Week         to  2 Weeks         |  14 days  \"P14D\"
+         greater than 2 Weeks               |  30 days  \"P30D\"
+
+        If not specified, the duration will be based on the schedule. For example,
+        if the schedule is every 5 minutes then the savedSearchDuration will be \"PT5M\";
+        if the schedule is every 3 weeks then the savedSearchDuration will be \"P21D\".
+
+
+        :return: The saved_search_duration of this StreamAction.
+        :rtype: str
+        """
+        return self._saved_search_duration
+
+    @saved_search_duration.setter
+    def saved_search_duration(self, saved_search_duration):
+        """
+        Sets the saved_search_duration of this StreamAction.
+        The duration of data to be searched for SAVED_SEARCH tasks,
+        used when the task fires to calculate the query time range.
+
+        Duration in ISO 8601 extended format as described in
+        https://en.wikipedia.org/wiki/ISO_8601#Durations.
+        The value should be positive.
+        The largest supported unit (as opposed to value) is D, e.g.  P14D (not P2W).
+
+        There are restrictions on the maximum duration value relative to the task schedule
+        value as specified in the following table.
+           Schedule Interval Range          | Maximum Duration
+        ----------------------------------- | -----------------
+          5 Minutes     to 30 Minutes       |   1 hour  \"PT60M\"
+         31 Minutes     to  1 Hour          |  12 hours \"PT720M\"
+         1 Hour+1Minute to  1 Day           |   1 day   \"P1D\"
+         1 Day+1Minute  to  1 Week-1Minute  |   7 days  \"P7D\"
+         1 Week         to  2 Weeks         |  14 days  \"P14D\"
+         greater than 2 Weeks               |  30 days  \"P30D\"
+
+        If not specified, the duration will be based on the schedule. For example,
+        if the schedule is every 5 minutes then the savedSearchDuration will be \"PT5M\";
+        if the schedule is every 3 weeks then the savedSearchDuration will be \"P21D\".
+
+
+        :param saved_search_duration: The saved_search_duration of this StreamAction.
+        :type: str
+        """
+        self._saved_search_duration = saved_search_duration
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/log_analytics/models/tail_command_descriptor.py
+++ b/src/oci/log_analytics/models/tail_command_descriptor.py
@@ -21,7 +21,7 @@ class TailCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this TailCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP", "COMPARE"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/time_compare_command_descriptor.py
+++ b/src/oci/log_analytics/models/time_compare_command_descriptor.py
@@ -21,7 +21,7 @@ class TimeCompareCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this TimeCompareCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP", "COMPARE"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/time_stats_command_descriptor.py
+++ b/src/oci/log_analytics/models/time_stats_command_descriptor.py
@@ -21,7 +21,7 @@ class TimeStatsCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this TimeStatsCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP", "COMPARE"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/top_command_descriptor.py
+++ b/src/oci/log_analytics/models/top_command_descriptor.py
@@ -21,7 +21,7 @@ class TopCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this TopCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP", "COMPARE"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/log_analytics/models/where_command_descriptor.py
+++ b/src/oci/log_analytics/models/where_command_descriptor.py
@@ -21,7 +21,7 @@ class WhereCommandDescriptor(AbstractCommandDescriptor):
 
         :param name:
             The value to assign to the name property of this WhereCommandDescriptor.
-            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP"
+            Allowed values for this property are: "COMMAND", "SEARCH", "STATS", "TIME_STATS", "SORT", "FIELDS", "ADD_FIELDS", "LINK", "LINK_DETAILS", "CLUSTER", "CLUSTER_DETAILS", "CLUSTER_SPLIT", "EVAL", "EXTRACT", "EVENT_STATS", "BUCKET", "CLASSIFY", "TOP", "BOTTOM", "HEAD", "TAIL", "FIELD_SUMMARY", "REGEX", "RENAME", "TIME_COMPARE", "WHERE", "CLUSTER_COMPARE", "DELETE", "DELTA", "DISTINCT", "SEARCH_LOOKUP", "LOOKUP", "DEMO_MODE", "MACRO", "MULTI_SEARCH", "HIGHLIGHT", "HIGHLIGHT_ROWS", "HIGHLIGHT_GROUPS", "CREATE_VIEW", "MAP", "NLP", "COMPARE"
         :type name: str
 
         :param display_query_string:

--- a/src/oci/regions.py
+++ b/src/oci/regions.py
@@ -40,7 +40,8 @@ REGIONS_SHORT_NAMES = {
     'yny': 'ap-chuncheon-1',
     'brs': 'uk-gov-cardiff-1',
     'nja': 'ap-chiyoda-1',
-    'dxb': 'me-dubai-1'
+    'dxb': 'me-dubai-1',
+    'vcp': 'sa-vinhedo-1'
 }
 REGION_REALMS = {
     'ap-melbourne-1': 'oc1',
@@ -65,6 +66,7 @@ REGION_REALMS = {
     'sa-saopaulo-1': 'oc1',
     'sa-santiago-1': 'oc1',
     'ca-montreal-1': 'oc1',
+    'sa-vinhedo-1': 'oc1',
 
     'us-langley-1': 'oc2',
     'us-luke-1': 'oc2',
@@ -115,7 +117,8 @@ REGIONS = [
     "us-gov-phoenix-1",
     "sa-saopaulo-1",
     "sa-santiago-1",
-    "uk-gov-london-1"
+    "uk-gov-london-1",
+    "sa-vinhedo-1"
 ]
 SERVICE_ENDPOINTS = service_endpoints.SERVICE_ENDPOINTS
 SERVICE_ENDPOINTS['auth'] = 'https://auth.{domain}'

--- a/src/oci/version.py
+++ b/src/oci/version.py
@@ -2,4 +2,4 @@
 # Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
 # This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 
-__version__ = "2.38.4"
+__version__ = "2.39.0"


### PR DESCRIPTION
## Added

* Support for configuration of autonomous database KMS keys in the Database service

* Support for creating database software images with any supported RUs in the Database service

* Support for creating database software images from an existing database home in the Database service

* Support for listing all NSGs associated with a given VLAN in the Networking service

* Support for a duration windows, task failure reasons, and next execution times on scheduled tasks in the Logging Analytics service

* Support for calling Oracle Cloud Infrastructure services in the sa-vinhedo-1 region

##Breaking

* `compartment_id` is now optional in operation `list_network_security_groups` in the Networking service