### PR TITLE
Fix dns_label documentation

### DIFF
--- a/src/oci/core/models/create_vcn_details.py
+++ b/src/oci/core/models/create_vcn_details.py
@@ -232,7 +232,7 @@ class CreateVcnDetails(object):
         Gets the dns_label of this CreateVcnDetails.
         A DNS label for the VCN, used in conjunction with the VNIC's hostname and
         subnet's DNS label to form a fully qualified domain name (FQDN) for each VNIC
-        within this subnet (for example, `bminstance-1.subnet123.vcn1.oraclevcn.com`).
+        within this subnet (for example, `bminstance1.subnet123.vcn1.oraclevcn.com`).
         Not required to be unique, but it's a best practice to set unique DNS labels
         for VCNs in your tenancy. Must be an alphanumeric string that begins with a letter.
         The value cannot be changed.


### PR DESCRIPTION
Fix example which contained a dash (`-`) which is not an alphanumeric character.