### PR TITLE
Releasing version 2.43.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 ====================
+2.43.2 - 2021-08-03
+====================
+
+Added
+-----
+* Support for manually copying volume group backups across regions in the Block Volume service
+* Support for work requests for the copy volume backup and copy boot volume backup operations in the Block Volume service
+* Support for specifying external Hive metastores during application creation in the Data Flow service
+* Support for changing the compartment of a backup in the MySQL Database service
+* Support for model catalog features including provenance, metadata, schemas, and artifact introspection in the Data Science service
+* Support for Exadata system network bonding in the Database service
+* Support for creating autonomous databases with early patching enabled in the Database service
+
+====================
 2.43.1 - 2021-07-27
 ====================
 

--- a/docs/api/core.rst
+++ b/docs/api/core.rst
@@ -130,6 +130,7 @@ Core Services
     oci.core.models.ConsoleHistory
     oci.core.models.CopyBootVolumeBackupDetails
     oci.core.models.CopyVolumeBackupDetails
+    oci.core.models.CopyVolumeGroupBackupDetails
     oci.core.models.Cpe
     oci.core.models.CpeDeviceConfigAnswer
     oci.core.models.CpeDeviceConfigQuestion

--- a/docs/api/core/models/oci.core.models.CopyVolumeGroupBackupDetails.rst
+++ b/docs/api/core/models/oci.core.models.CopyVolumeGroupBackupDetails.rst
@@ -1,0 +1,11 @@
+CopyVolumeGroupBackupDetails
+============================
+
+.. currentmodule:: oci.core.models
+
+.. autoclass:: CopyVolumeGroupBackupDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/data_science.rst
+++ b/docs/api/data_science.rst
@@ -31,6 +31,7 @@ Data Science
     oci.data_science.models.FixedSizeScalingPolicy
     oci.data_science.models.InstanceConfiguration
     oci.data_science.models.LogDetails
+    oci.data_science.models.Metadata
     oci.data_science.models.Model
     oci.data_science.models.ModelConfigurationDetails
     oci.data_science.models.ModelDeployment

--- a/docs/api/data_science/models/oci.data_science.models.Metadata.rst
+++ b/docs/api/data_science/models/oci.data_science.models.Metadata.rst
@@ -1,0 +1,11 @@
+Metadata
+========
+
+.. currentmodule:: oci.data_science.models
+
+.. autoclass:: Metadata
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/mysql.rst
+++ b/docs/api/mysql.rst
@@ -38,6 +38,7 @@ Mysql
     oci.mysql.models.BackupPolicy
     oci.mysql.models.BackupSummary
     oci.mysql.models.CaCertificate
+    oci.mysql.models.ChangeBackupCompartmentDetails
     oci.mysql.models.Channel
     oci.mysql.models.ChannelSource
     oci.mysql.models.ChannelSourceMysql

--- a/docs/api/mysql/models/oci.mysql.models.ChangeBackupCompartmentDetails.rst
+++ b/docs/api/mysql/models/oci.mysql.models.ChangeBackupCompartmentDetails.rst
@@ -1,0 +1,11 @@
+ChangeBackupCompartmentDetails
+==============================
+
+.. currentmodule:: oci.mysql.models
+
+.. autoclass:: ChangeBackupCompartmentDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/src/oci/core/blockstorage_client.py
+++ b/src/oci/core/blockstorage_client.py
@@ -780,6 +780,101 @@ class BlockstorageClient(object):
                 body=copy_volume_backup_details,
                 response_type="VolumeBackup")
 
+    def copy_volume_group_backup(self, volume_group_backup_id, copy_volume_group_backup_details, **kwargs):
+        """
+        Creates a volume group backup copy in specified region. For general information about volume group backups,
+        see `Overview of Block Volume Service Backups`__
+
+        __ https://docs.cloud.oracle.com/Content/Block/Concepts/blockvolumebackups.htm
+
+
+        :param str volume_group_backup_id: (required)
+            The Oracle Cloud ID (OCID) that uniquely identifies the volume group backup.
+
+        :param oci.core.models.CopyVolumeGroupBackupDetails copy_volume_group_backup_details: (required)
+            Request to create a cross-region copy of given volume group backup.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            may be rejected).
+
+        :param str opc_request_id: (optional)
+            Unique identifier for the request.
+            If you need to contact Oracle about a particular request, please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://docs.oracle.com/en-us/iaas/tools/python/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.core.models.VolumeGroupBackup`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/core/copy_volume_group_backup.py.html>`__ to see an example of how to use copy_volume_group_backup API.
+        """
+        resource_path = "/volumeGroupBackups/{volumeGroupBackupId}/actions/copy"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "copy_volume_group_backup got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "volumeGroupBackupId": volume_group_backup_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=copy_volume_group_backup_details,
+                response_type="VolumeGroupBackup")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=copy_volume_group_backup_details,
+                response_type="VolumeGroupBackup")
+
     def create_boot_volume(self, create_boot_volume_details, **kwargs):
         """
         Creates a new boot volume in the specified compartment from an existing boot volume or a boot volume backup.

--- a/src/oci/core/blockstorage_client_composite_operations.py
+++ b/src/oci/core/blockstorage_client_composite_operations.py
@@ -27,6 +27,44 @@ class BlockstorageClientCompositeOperations(object):
         self.client = client
         self._work_request_client = work_request_client if work_request_client else oci.work_requests.WorkRequestClient(self.client._config, **self.client._kwargs)
 
+    def copy_boot_volume_backup_and_wait_for_work_request(self, boot_volume_backup_id, copy_boot_volume_backup_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.core.BlockstorageClient.copy_boot_volume_backup` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str boot_volume_backup_id: (required)
+            The OCID of the boot volume backup.
+
+        :param oci.core.models.CopyBootVolumeBackupDetails copy_boot_volume_backup_details: (required)
+            Request to create a cross-region copy of given boot volume backup.
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.core.BlockstorageClient.copy_boot_volume_backup`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.copy_boot_volume_backup(boot_volume_backup_id, copy_boot_volume_backup_details, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def copy_boot_volume_backup_and_wait_for_state(self, boot_volume_backup_id, copy_boot_volume_backup_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.core.BlockstorageClient.copy_boot_volume_backup` and waits for the :py:class:`~oci.core.models.BootVolumeBackup` acted upon
@@ -68,6 +106,44 @@ class BlockstorageClientCompositeOperations(object):
         except Exception as e:
             raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
 
+    def copy_volume_backup_and_wait_for_work_request(self, volume_backup_id, copy_volume_backup_details, work_request_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.core.BlockstorageClient.copy_volume_backup` and waits for the oci.work_requests.models.WorkRequest
+        to enter the given state(s).
+
+        :param str volume_backup_id: (required)
+            The OCID of the volume backup.
+
+        :param oci.core.models.CopyVolumeBackupDetails copy_volume_backup_details: (required)
+            Request to create a cross-region copy of given backup.
+
+        :param list[str] work_request_states: (optional)
+            An array of work requests states to wait on. These should be valid values for :py:attr:`~oci.work_requests.models.WorkRequest.status`
+            Default values are termination states: [STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELED]
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.core.BlockstorageClient.copy_volume_backup`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.copy_volume_backup(volume_backup_id, copy_volume_backup_details, **operation_kwargs)
+        work_request_states = work_request_states if work_request_states else oci.waiter._WORK_REQUEST_TERMINATION_STATES
+        lowered_work_request_states = [w.lower() for w in work_request_states]
+        work_request_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self._work_request_client,
+                self._work_request_client.get_work_request(work_request_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_work_request_states,
+                **waiter_kwargs
+            )
+            return waiter_result
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def copy_volume_backup_and_wait_for_state(self, volume_backup_id, copy_volume_backup_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.core.BlockstorageClient.copy_volume_backup` and waits for the :py:class:`~oci.core.models.VolumeBackup` acted upon
@@ -100,6 +176,47 @@ class BlockstorageClientCompositeOperations(object):
             waiter_result = oci.wait_until(
                 self.client,
                 self.client.get_volume_backup(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
+    def copy_volume_group_backup_and_wait_for_state(self, volume_group_backup_id, copy_volume_group_backup_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.core.BlockstorageClient.copy_volume_group_backup` and waits for the :py:class:`~oci.core.models.VolumeGroupBackup` acted upon
+        to enter the given state(s).
+
+        :param str volume_group_backup_id: (required)
+            The Oracle Cloud ID (OCID) that uniquely identifies the volume group backup.
+
+        :param oci.core.models.CopyVolumeGroupBackupDetails copy_volume_group_backup_details: (required)
+            Request to create a cross-region copy of given volume group backup.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.core.models.VolumeGroupBackup.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.core.BlockstorageClient.copy_volume_group_backup`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.copy_volume_group_backup(volume_group_backup_id, copy_volume_group_backup_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_volume_group_backup(wait_for_resource_id),
                 evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
                 **waiter_kwargs
             )

--- a/src/oci/core/models/__init__.py
+++ b/src/oci/core/models/__init__.py
@@ -110,6 +110,7 @@ from .connect_remote_peering_connections_details import ConnectRemotePeeringConn
 from .console_history import ConsoleHistory
 from .copy_boot_volume_backup_details import CopyBootVolumeBackupDetails
 from .copy_volume_backup_details import CopyVolumeBackupDetails
+from .copy_volume_group_backup_details import CopyVolumeGroupBackupDetails
 from .cpe import Cpe
 from .cpe_device_config_answer import CpeDeviceConfigAnswer
 from .cpe_device_config_question import CpeDeviceConfigQuestion
@@ -546,6 +547,7 @@ core_type_mapping = {
     "ConsoleHistory": ConsoleHistory,
     "CopyBootVolumeBackupDetails": CopyBootVolumeBackupDetails,
     "CopyVolumeBackupDetails": CopyVolumeBackupDetails,
+    "CopyVolumeGroupBackupDetails": CopyVolumeGroupBackupDetails,
     "Cpe": Cpe,
     "CpeDeviceConfigAnswer": CpeDeviceConfigAnswer,
     "CpeDeviceConfigQuestion": CpeDeviceConfigQuestion,

--- a/src/oci/core/models/copy_volume_group_backup_details.py
+++ b/src/oci/core/models/copy_volume_group_backup_details.py
@@ -1,0 +1,160 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class CopyVolumeGroupBackupDetails(object):
+    """
+    CopyVolumeGroupBackupDetails model.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new CopyVolumeGroupBackupDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param destination_region:
+            The value to assign to the destination_region property of this CopyVolumeGroupBackupDetails.
+        :type destination_region: str
+
+        :param display_name:
+            The value to assign to the display_name property of this CopyVolumeGroupBackupDetails.
+        :type display_name: str
+
+        :param kms_key_id:
+            The value to assign to the kms_key_id property of this CopyVolumeGroupBackupDetails.
+        :type kms_key_id: str
+
+        """
+        self.swagger_types = {
+            'destination_region': 'str',
+            'display_name': 'str',
+            'kms_key_id': 'str'
+        }
+
+        self.attribute_map = {
+            'destination_region': 'destinationRegion',
+            'display_name': 'displayName',
+            'kms_key_id': 'kmsKeyId'
+        }
+
+        self._destination_region = None
+        self._display_name = None
+        self._kms_key_id = None
+
+    @property
+    def destination_region(self):
+        """
+        **[Required]** Gets the destination_region of this CopyVolumeGroupBackupDetails.
+        The name of the destination region.
+
+        Example: `us-ashburn-1`
+
+
+        :return: The destination_region of this CopyVolumeGroupBackupDetails.
+        :rtype: str
+        """
+        return self._destination_region
+
+    @destination_region.setter
+    def destination_region(self, destination_region):
+        """
+        Sets the destination_region of this CopyVolumeGroupBackupDetails.
+        The name of the destination region.
+
+        Example: `us-ashburn-1`
+
+
+        :param destination_region: The destination_region of this CopyVolumeGroupBackupDetails.
+        :type: str
+        """
+        self._destination_region = destination_region
+
+    @property
+    def display_name(self):
+        """
+        Gets the display_name of this CopyVolumeGroupBackupDetails.
+        A user-friendly name for the volume group backup. Does not have to be unique and it's changeable.
+        Avoid entering confidential information.
+
+
+        :return: The display_name of this CopyVolumeGroupBackupDetails.
+        :rtype: str
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        """
+        Sets the display_name of this CopyVolumeGroupBackupDetails.
+        A user-friendly name for the volume group backup. Does not have to be unique and it's changeable.
+        Avoid entering confidential information.
+
+
+        :param display_name: The display_name of this CopyVolumeGroupBackupDetails.
+        :type: str
+        """
+        self._display_name = display_name
+
+    @property
+    def kms_key_id(self):
+        """
+        Gets the kms_key_id of this CopyVolumeGroupBackupDetails.
+        The OCID of the Key Management key in the destination region which will be the master encryption key
+        for the copied volume group backup.
+        If you do not specify this attribute the volume group backup will be encrypted with the Oracle-provided encryption
+        key when it is copied to the destination region.
+
+
+        For more information about the Key Management service and encryption keys, see
+        `Overview of Key Management`__ and
+        `Using Keys`__.
+
+        __ https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm
+        __ https://docs.cloud.oracle.com/Content/KeyManagement/Tasks/usingkeys.htm
+
+
+        :return: The kms_key_id of this CopyVolumeGroupBackupDetails.
+        :rtype: str
+        """
+        return self._kms_key_id
+
+    @kms_key_id.setter
+    def kms_key_id(self, kms_key_id):
+        """
+        Sets the kms_key_id of this CopyVolumeGroupBackupDetails.
+        The OCID of the Key Management key in the destination region which will be the master encryption key
+        for the copied volume group backup.
+        If you do not specify this attribute the volume group backup will be encrypted with the Oracle-provided encryption
+        key when it is copied to the destination region.
+
+
+        For more information about the Key Management service and encryption keys, see
+        `Overview of Key Management`__ and
+        `Using Keys`__.
+
+        __ https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm
+        __ https://docs.cloud.oracle.com/Content/KeyManagement/Tasks/usingkeys.htm
+
+
+        :param kms_key_id: The kms_key_id of this CopyVolumeGroupBackupDetails.
+        :type: str
+        """
+        self._kms_key_id = kms_key_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/core/models/instance_configuration_instance_source_via_image_details.py
+++ b/src/oci/core/models/instance_configuration_instance_source_via_image_details.py
@@ -54,7 +54,7 @@ class InstanceConfigurationInstanceSourceViaImageDetails(InstanceConfigurationIn
         """
         Gets the boot_volume_size_in_gbs of this InstanceConfigurationInstanceSourceViaImageDetails.
         The size of the boot volume in GBs. The minimum value is 50 GB and the maximum
-        value is 16384 GB (16TB).
+        value is 32,768 GB (32 TB).
 
 
         :return: The boot_volume_size_in_gbs of this InstanceConfigurationInstanceSourceViaImageDetails.
@@ -67,7 +67,7 @@ class InstanceConfigurationInstanceSourceViaImageDetails(InstanceConfigurationIn
         """
         Sets the boot_volume_size_in_gbs of this InstanceConfigurationInstanceSourceViaImageDetails.
         The size of the boot volume in GBs. The minimum value is 50 GB and the maximum
-        value is 16384 GB (16TB).
+        value is 32,768 GB (32 TB).
 
 
         :param boot_volume_size_in_gbs: The boot_volume_size_in_gbs of this InstanceConfigurationInstanceSourceViaImageDetails.

--- a/src/oci/core/models/instance_source_via_image_details.py
+++ b/src/oci/core/models/instance_source_via_image_details.py
@@ -60,7 +60,7 @@ class InstanceSourceViaImageDetails(InstanceSourceDetails):
     def boot_volume_size_in_gbs(self):
         """
         Gets the boot_volume_size_in_gbs of this InstanceSourceViaImageDetails.
-        The size of the boot volume in GBs. Minimum value is 50 GB and maximum value is 16384 GB (16TB).
+        The size of the boot volume in GBs. Minimum value is 50 GB and maximum value is 32,768 GB (32 TB).
 
 
         :return: The boot_volume_size_in_gbs of this InstanceSourceViaImageDetails.
@@ -72,7 +72,7 @@ class InstanceSourceViaImageDetails(InstanceSourceDetails):
     def boot_volume_size_in_gbs(self, boot_volume_size_in_gbs):
         """
         Sets the boot_volume_size_in_gbs of this InstanceSourceViaImageDetails.
-        The size of the boot volume in GBs. Minimum value is 50 GB and maximum value is 16384 GB (16TB).
+        The size of the boot volume in GBs. Minimum value is 50 GB and maximum value is 32,768 GB (32 TB).
 
 
         :param boot_volume_size_in_gbs: The boot_volume_size_in_gbs of this InstanceSourceViaImageDetails.

--- a/src/oci/data_flow/models/application.py
+++ b/src/oci/data_flow/models/application.py
@@ -118,6 +118,10 @@ class Application(object):
             The value to assign to the logs_bucket_uri property of this Application.
         :type logs_bucket_uri: str
 
+        :param metastore_id:
+            The value to assign to the metastore_id property of this Application.
+        :type metastore_id: str
+
         :param num_executors:
             The value to assign to the num_executors property of this Application.
         :type num_executors: int
@@ -173,6 +177,7 @@ class Application(object):
             'language': 'str',
             'lifecycle_state': 'str',
             'logs_bucket_uri': 'str',
+            'metastore_id': 'str',
             'num_executors': 'int',
             'owner_principal_id': 'str',
             'owner_user_name': 'str',
@@ -202,6 +207,7 @@ class Application(object):
             'language': 'language',
             'lifecycle_state': 'lifecycleState',
             'logs_bucket_uri': 'logsBucketUri',
+            'metastore_id': 'metastoreId',
             'num_executors': 'numExecutors',
             'owner_principal_id': 'ownerPrincipalId',
             'owner_user_name': 'ownerUserName',
@@ -230,6 +236,7 @@ class Application(object):
         self._language = None
         self._lifecycle_state = None
         self._logs_bucket_uri = None
+        self._metastore_id = None
         self._num_executors = None
         self._owner_principal_id = None
         self._owner_user_name = None
@@ -709,6 +716,30 @@ class Application(object):
         :type: str
         """
         self._logs_bucket_uri = logs_bucket_uri
+
+    @property
+    def metastore_id(self):
+        """
+        Gets the metastore_id of this Application.
+        The OCID of OCI Hive Metastore.
+
+
+        :return: The metastore_id of this Application.
+        :rtype: str
+        """
+        return self._metastore_id
+
+    @metastore_id.setter
+    def metastore_id(self, metastore_id):
+        """
+        Sets the metastore_id of this Application.
+        The OCID of OCI Hive Metastore.
+
+
+        :param metastore_id: The metastore_id of this Application.
+        :type: str
+        """
+        self._metastore_id = metastore_id
 
     @property
     def num_executors(self):

--- a/src/oci/data_flow/models/create_application_details.py
+++ b/src/oci/data_flow/models/create_application_details.py
@@ -95,6 +95,10 @@ class CreateApplicationDetails(object):
             The value to assign to the logs_bucket_uri property of this CreateApplicationDetails.
         :type logs_bucket_uri: str
 
+        :param metastore_id:
+            The value to assign to the metastore_id property of this CreateApplicationDetails.
+        :type metastore_id: str
+
         :param num_executors:
             The value to assign to the num_executors property of this CreateApplicationDetails.
         :type num_executors: int
@@ -132,6 +136,7 @@ class CreateApplicationDetails(object):
             'freeform_tags': 'dict(str, str)',
             'language': 'str',
             'logs_bucket_uri': 'str',
+            'metastore_id': 'str',
             'num_executors': 'int',
             'parameters': 'list[ApplicationParameter]',
             'private_endpoint_id': 'str',
@@ -155,6 +160,7 @@ class CreateApplicationDetails(object):
             'freeform_tags': 'freeformTags',
             'language': 'language',
             'logs_bucket_uri': 'logsBucketUri',
+            'metastore_id': 'metastoreId',
             'num_executors': 'numExecutors',
             'parameters': 'parameters',
             'private_endpoint_id': 'privateEndpointId',
@@ -177,6 +183,7 @@ class CreateApplicationDetails(object):
         self._freeform_tags = None
         self._language = None
         self._logs_bucket_uri = None
+        self._metastore_id = None
         self._num_executors = None
         self._parameters = None
         self._private_endpoint_id = None
@@ -600,6 +607,30 @@ class CreateApplicationDetails(object):
         :type: str
         """
         self._logs_bucket_uri = logs_bucket_uri
+
+    @property
+    def metastore_id(self):
+        """
+        Gets the metastore_id of this CreateApplicationDetails.
+        The OCID of OCI Hive Metastore.
+
+
+        :return: The metastore_id of this CreateApplicationDetails.
+        :rtype: str
+        """
+        return self._metastore_id
+
+    @metastore_id.setter
+    def metastore_id(self, metastore_id):
+        """
+        Sets the metastore_id of this CreateApplicationDetails.
+        The OCID of OCI Hive Metastore.
+
+
+        :param metastore_id: The metastore_id of this CreateApplicationDetails.
+        :type: str
+        """
+        self._metastore_id = metastore_id
 
     @property
     def num_executors(self):

--- a/src/oci/data_flow/models/create_run_details.py
+++ b/src/oci/data_flow/models/create_run_details.py
@@ -23,6 +23,7 @@ class CreateRunDetails(object):
     - executorShape
     - freeformTags
     - logsBucketUri
+    - metastoreId
     - numExecutors
     - parameters
     - sparkVersion
@@ -97,6 +98,10 @@ class CreateRunDetails(object):
             The value to assign to the logs_bucket_uri property of this CreateRunDetails.
         :type logs_bucket_uri: str
 
+        :param metastore_id:
+            The value to assign to the metastore_id property of this CreateRunDetails.
+        :type metastore_id: str
+
         :param num_executors:
             The value to assign to the num_executors property of this CreateRunDetails.
         :type num_executors: int
@@ -127,6 +132,7 @@ class CreateRunDetails(object):
             'executor_shape': 'str',
             'freeform_tags': 'dict(str, str)',
             'logs_bucket_uri': 'str',
+            'metastore_id': 'str',
             'num_executors': 'int',
             'parameters': 'list[ApplicationParameter]',
             'spark_version': 'str',
@@ -146,6 +152,7 @@ class CreateRunDetails(object):
             'executor_shape': 'executorShape',
             'freeform_tags': 'freeformTags',
             'logs_bucket_uri': 'logsBucketUri',
+            'metastore_id': 'metastoreId',
             'num_executors': 'numExecutors',
             'parameters': 'parameters',
             'spark_version': 'sparkVersion',
@@ -164,6 +171,7 @@ class CreateRunDetails(object):
         self._executor_shape = None
         self._freeform_tags = None
         self._logs_bucket_uri = None
+        self._metastore_id = None
         self._num_executors = None
         self._parameters = None
         self._spark_version = None
@@ -504,6 +512,30 @@ class CreateRunDetails(object):
         :type: str
         """
         self._logs_bucket_uri = logs_bucket_uri
+
+    @property
+    def metastore_id(self):
+        """
+        Gets the metastore_id of this CreateRunDetails.
+        The OCID of OCI Hive Metastore.
+
+
+        :return: The metastore_id of this CreateRunDetails.
+        :rtype: str
+        """
+        return self._metastore_id
+
+    @metastore_id.setter
+    def metastore_id(self, metastore_id):
+        """
+        Sets the metastore_id of this CreateRunDetails.
+        The OCID of OCI Hive Metastore.
+
+
+        :param metastore_id: The metastore_id of this CreateRunDetails.
+        :type: str
+        """
+        self._metastore_id = metastore_id
 
     @property
     def num_executors(self):

--- a/src/oci/data_flow/models/run.py
+++ b/src/oci/data_flow/models/run.py
@@ -142,6 +142,10 @@ class Run(object):
             The value to assign to the logs_bucket_uri property of this Run.
         :type logs_bucket_uri: str
 
+        :param metastore_id:
+            The value to assign to the metastore_id property of this Run.
+        :type metastore_id: str
+
         :param num_executors:
             The value to assign to the num_executors property of this Run.
         :type num_executors: int
@@ -228,6 +232,7 @@ class Run(object):
             'lifecycle_details': 'str',
             'lifecycle_state': 'str',
             'logs_bucket_uri': 'str',
+            'metastore_id': 'str',
             'num_executors': 'int',
             'opc_request_id': 'str',
             'owner_principal_id': 'str',
@@ -267,6 +272,7 @@ class Run(object):
             'lifecycle_details': 'lifecycleDetails',
             'lifecycle_state': 'lifecycleState',
             'logs_bucket_uri': 'logsBucketUri',
+            'metastore_id': 'metastoreId',
             'num_executors': 'numExecutors',
             'opc_request_id': 'opcRequestId',
             'owner_principal_id': 'ownerPrincipalId',
@@ -305,6 +311,7 @@ class Run(object):
         self._lifecycle_details = None
         self._lifecycle_state = None
         self._logs_bucket_uri = None
+        self._metastore_id = None
         self._num_executors = None
         self._opc_request_id = None
         self._owner_principal_id = None
@@ -863,6 +870,30 @@ class Run(object):
         :type: str
         """
         self._logs_bucket_uri = logs_bucket_uri
+
+    @property
+    def metastore_id(self):
+        """
+        Gets the metastore_id of this Run.
+        The OCID of OCI Hive Metastore.
+
+
+        :return: The metastore_id of this Run.
+        :rtype: str
+        """
+        return self._metastore_id
+
+    @metastore_id.setter
+    def metastore_id(self, metastore_id):
+        """
+        Sets the metastore_id of this Run.
+        The OCID of OCI Hive Metastore.
+
+
+        :param metastore_id: The metastore_id of this Run.
+        :type: str
+        """
+        self._metastore_id = metastore_id
 
     @property
     def num_executors(self):

--- a/src/oci/data_flow/models/update_application_details.py
+++ b/src/oci/data_flow/models/update_application_details.py
@@ -95,6 +95,10 @@ class UpdateApplicationDetails(object):
             The value to assign to the logs_bucket_uri property of this UpdateApplicationDetails.
         :type logs_bucket_uri: str
 
+        :param metastore_id:
+            The value to assign to the metastore_id property of this UpdateApplicationDetails.
+        :type metastore_id: str
+
         :param num_executors:
             The value to assign to the num_executors property of this UpdateApplicationDetails.
         :type num_executors: int
@@ -128,6 +132,7 @@ class UpdateApplicationDetails(object):
             'executor_shape': 'str',
             'freeform_tags': 'dict(str, str)',
             'logs_bucket_uri': 'str',
+            'metastore_id': 'str',
             'num_executors': 'int',
             'parameters': 'list[ApplicationParameter]',
             'private_endpoint_id': 'str',
@@ -150,6 +155,7 @@ class UpdateApplicationDetails(object):
             'executor_shape': 'executorShape',
             'freeform_tags': 'freeformTags',
             'logs_bucket_uri': 'logsBucketUri',
+            'metastore_id': 'metastoreId',
             'num_executors': 'numExecutors',
             'parameters': 'parameters',
             'private_endpoint_id': 'privateEndpointId',
@@ -171,6 +177,7 @@ class UpdateApplicationDetails(object):
         self._executor_shape = None
         self._freeform_tags = None
         self._logs_bucket_uri = None
+        self._metastore_id = None
         self._num_executors = None
         self._parameters = None
         self._private_endpoint_id = None
@@ -593,6 +600,30 @@ class UpdateApplicationDetails(object):
         :type: str
         """
         self._logs_bucket_uri = logs_bucket_uri
+
+    @property
+    def metastore_id(self):
+        """
+        Gets the metastore_id of this UpdateApplicationDetails.
+        The OCID of OCI Hive Metastore.
+
+
+        :return: The metastore_id of this UpdateApplicationDetails.
+        :rtype: str
+        """
+        return self._metastore_id
+
+    @metastore_id.setter
+    def metastore_id(self, metastore_id):
+        """
+        Sets the metastore_id of this UpdateApplicationDetails.
+        The OCID of OCI Hive Metastore.
+
+
+        :param metastore_id: The metastore_id of this UpdateApplicationDetails.
+        :type: str
+        """
+        self._metastore_id = metastore_id
 
     @property
     def num_executors(self):

--- a/src/oci/data_science/data_science_client.py
+++ b/src/oci/data_science/data_science_client.py
@@ -904,7 +904,13 @@ class DataScienceClient(object):
             A token that uniquely identifies a request so it can be retried in case of a timeout or server error without risk of executing that same action again. Retry tokens expire after 24 hours, but can be invalidated before then due to conflicting operations. For example, if a resource has been deleted and purged from the system, then a retry of the original creation request might be rejected.
 
         :param str content_disposition: (optional)
-            The content disposition of the body.
+            This header allows you to specify a filename during upload. This file name is used to dispose of the file contents
+            while downloading the file. If this optional field is not populated in the request, then the OCID of the model is used for the file
+            name when downloading.
+            Example: `{\"Content-Disposition\": \"attachment\"
+                       \"filename\"=\"model.tar.gz\"
+                       \"Content-Length\": \"2347\"
+                       \"Content-Type\": \"application/gzip\"}`
 
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
@@ -3773,10 +3779,10 @@ class DataScienceClient(object):
 
     def update_model_deployment(self, model_deployment_id, update_model_deployment_details, **kwargs):
         """
-        Updates the properties of a model deployment. Some of the properties of `modelDeploymentConfigurationDetails` or `CategoryLogDetails` can also be updated with zero down time when
-        the model deployment's lifecycle state is ACTIVE i.e `instanceShapeName` can be updated along with `modelId`, similarly `logId` can be updated along with `logGroupId`. But
-        `instanceShapeName` or `modelId` cannot be updated along with `logId` or `logGroupId`. All of the fields can be updated when the deployment is in the INACTIVE lifecycle state.
-        Changes will take effect the next time the model deployment is activated.
+        Updates the properties of a model deployment. Some of the properties of `modelDeploymentConfigurationDetails` or `CategoryLogDetails` can also be updated with zero down time
+        when the model deployment\u2019s lifecycle state is ACTIVE or NEEDS_ATTENTION i.e `instanceShapeName`, `instanceCount` and `modelId`, separately `loadBalancerShape` or `CategoryLogDetails`
+        can also be updated independently. All of the fields can be updated when the deployment is in the INACTIVE lifecycle state. Changes will take effect the next time the model
+        deployment is activated.
 
 
         :param str model_deployment_id: (required)
@@ -3785,10 +3791,10 @@ class DataScienceClient(object):
             __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param oci.data_science.models.UpdateModelDeploymentDetails update_model_deployment_details: (required)
-            Details for updating a model deployment. Some of the properties of `modelDeploymentConfigurationDetails` or `CategoryLogDetails` can also be updated with zero down time when
-            the model deployment's lifecycle state is ACTIVE i.e `instanceShapeName` can be updated along with `modelId`, similarly `logId` can be updated along with `logGroupId`. But
-            `instanceShapeName` or `modelId` cannot be updated along with `logId` or `logGroupId`. All of the fields can be updated when the deployment is in the INACTIVE lifecycle state.
-            Changes will take effect the next time the model deployment is activated.
+            Details for updating a model deployment. Some of the properties of `modelDeploymentConfigurationDetails` or `CategoryLogDetails` can also be updated with zero down time
+            when the model deployment\u2019s lifecycle state is ACTIVE or NEEDS_ATTENTION i.e `instanceShapeName`, `instanceCount` and `modelId`, separately `loadBalancerShape` or
+            `CategoryLogDetails` can also be updated independently. All of the fields can be updated when the deployment is in the INACTIVE lifecycle state. Changes will take effect the next
+            time the model deployment is activated.
 
         :param str if_match: (optional)
             For optimistic concurrency control. In the PUT or DELETE call

--- a/src/oci/data_science/data_science_client_composite_operations.py
+++ b/src/oci/data_science/data_science_client_composite_operations.py
@@ -662,10 +662,10 @@ class DataScienceClientCompositeOperations(object):
             __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
 
         :param oci.data_science.models.UpdateModelDeploymentDetails update_model_deployment_details: (required)
-            Details for updating a model deployment. Some of the properties of `modelDeploymentConfigurationDetails` or `CategoryLogDetails` can also be updated with zero down time when
-            the model deployment's lifecycle state is ACTIVE i.e `instanceShapeName` can be updated along with `modelId`, similarly `logId` can be updated along with `logGroupId`. But
-            `instanceShapeName` or `modelId` cannot be updated along with `logId` or `logGroupId`. All of the fields can be updated when the deployment is in the INACTIVE lifecycle state.
-            Changes will take effect the next time the model deployment is activated.
+            Details for updating a model deployment. Some of the properties of `modelDeploymentConfigurationDetails` or `CategoryLogDetails` can also be updated with zero down time
+            when the model deployment\u2019s lifecycle state is ACTIVE or NEEDS_ATTENTION i.e `instanceShapeName`, `instanceCount` and `modelId`, separately `loadBalancerShape` or
+            `CategoryLogDetails` can also be updated independently. All of the fields can be updated when the deployment is in the INACTIVE lifecycle state. Changes will take effect the next
+            time the model deployment is activated.
 
         :param list[str] wait_for_states:
             An array of states to wait on. These should be valid values for :py:attr:`~oci.data_science.models.WorkRequest.status`

--- a/src/oci/data_science/models/__init__.py
+++ b/src/oci/data_science/models/__init__.py
@@ -17,6 +17,7 @@ from .create_project_details import CreateProjectDetails
 from .fixed_size_scaling_policy import FixedSizeScalingPolicy
 from .instance_configuration import InstanceConfiguration
 from .log_details import LogDetails
+from .metadata import Metadata
 from .model import Model
 from .model_configuration_details import ModelConfigurationDetails
 from .model_deployment import ModelDeployment
@@ -64,6 +65,7 @@ data_science_type_mapping = {
     "FixedSizeScalingPolicy": FixedSizeScalingPolicy,
     "InstanceConfiguration": InstanceConfiguration,
     "LogDetails": LogDetails,
+    "Metadata": Metadata,
     "Model": Model,
     "ModelConfigurationDetails": ModelConfigurationDetails,
     "ModelDeployment": ModelDeployment,

--- a/src/oci/data_science/models/create_model_details.py
+++ b/src/oci/data_science/models/create_model_details.py
@@ -42,6 +42,22 @@ class CreateModelDetails(object):
             The value to assign to the defined_tags property of this CreateModelDetails.
         :type defined_tags: dict(str, dict(str, object))
 
+        :param custom_metadata_list:
+            The value to assign to the custom_metadata_list property of this CreateModelDetails.
+        :type custom_metadata_list: list[oci.data_science.models.Metadata]
+
+        :param defined_metadata_list:
+            The value to assign to the defined_metadata_list property of this CreateModelDetails.
+        :type defined_metadata_list: list[oci.data_science.models.Metadata]
+
+        :param input_schema:
+            The value to assign to the input_schema property of this CreateModelDetails.
+        :type input_schema: str
+
+        :param output_schema:
+            The value to assign to the output_schema property of this CreateModelDetails.
+        :type output_schema: str
+
         """
         self.swagger_types = {
             'compartment_id': 'str',
@@ -49,7 +65,11 @@ class CreateModelDetails(object):
             'display_name': 'str',
             'description': 'str',
             'freeform_tags': 'dict(str, str)',
-            'defined_tags': 'dict(str, dict(str, object))'
+            'defined_tags': 'dict(str, dict(str, object))',
+            'custom_metadata_list': 'list[Metadata]',
+            'defined_metadata_list': 'list[Metadata]',
+            'input_schema': 'str',
+            'output_schema': 'str'
         }
 
         self.attribute_map = {
@@ -58,7 +78,11 @@ class CreateModelDetails(object):
             'display_name': 'displayName',
             'description': 'description',
             'freeform_tags': 'freeformTags',
-            'defined_tags': 'definedTags'
+            'defined_tags': 'definedTags',
+            'custom_metadata_list': 'customMetadataList',
+            'defined_metadata_list': 'definedMetadataList',
+            'input_schema': 'inputSchema',
+            'output_schema': 'outputSchema'
         }
 
         self._compartment_id = None
@@ -67,6 +91,10 @@ class CreateModelDetails(object):
         self._description = None
         self._freeform_tags = None
         self._defined_tags = None
+        self._custom_metadata_list = None
+        self._defined_metadata_list = None
+        self._input_schema = None
+        self._output_schema = None
 
     @property
     def compartment_id(self):
@@ -233,6 +261,102 @@ class CreateModelDetails(object):
         :type: dict(str, dict(str, object))
         """
         self._defined_tags = defined_tags
+
+    @property
+    def custom_metadata_list(self):
+        """
+        Gets the custom_metadata_list of this CreateModelDetails.
+        An array of custom metadata details for the model.
+
+
+        :return: The custom_metadata_list of this CreateModelDetails.
+        :rtype: list[oci.data_science.models.Metadata]
+        """
+        return self._custom_metadata_list
+
+    @custom_metadata_list.setter
+    def custom_metadata_list(self, custom_metadata_list):
+        """
+        Sets the custom_metadata_list of this CreateModelDetails.
+        An array of custom metadata details for the model.
+
+
+        :param custom_metadata_list: The custom_metadata_list of this CreateModelDetails.
+        :type: list[oci.data_science.models.Metadata]
+        """
+        self._custom_metadata_list = custom_metadata_list
+
+    @property
+    def defined_metadata_list(self):
+        """
+        Gets the defined_metadata_list of this CreateModelDetails.
+        An array of defined metadata details for the model.
+
+
+        :return: The defined_metadata_list of this CreateModelDetails.
+        :rtype: list[oci.data_science.models.Metadata]
+        """
+        return self._defined_metadata_list
+
+    @defined_metadata_list.setter
+    def defined_metadata_list(self, defined_metadata_list):
+        """
+        Sets the defined_metadata_list of this CreateModelDetails.
+        An array of defined metadata details for the model.
+
+
+        :param defined_metadata_list: The defined_metadata_list of this CreateModelDetails.
+        :type: list[oci.data_science.models.Metadata]
+        """
+        self._defined_metadata_list = defined_metadata_list
+
+    @property
+    def input_schema(self):
+        """
+        Gets the input_schema of this CreateModelDetails.
+        Input schema file content in String format
+
+
+        :return: The input_schema of this CreateModelDetails.
+        :rtype: str
+        """
+        return self._input_schema
+
+    @input_schema.setter
+    def input_schema(self, input_schema):
+        """
+        Sets the input_schema of this CreateModelDetails.
+        Input schema file content in String format
+
+
+        :param input_schema: The input_schema of this CreateModelDetails.
+        :type: str
+        """
+        self._input_schema = input_schema
+
+    @property
+    def output_schema(self):
+        """
+        Gets the output_schema of this CreateModelDetails.
+        Output schema file content in String format
+
+
+        :return: The output_schema of this CreateModelDetails.
+        :rtype: str
+        """
+        return self._output_schema
+
+    @output_schema.setter
+    def output_schema(self, output_schema):
+        """
+        Sets the output_schema of this CreateModelDetails.
+        Output schema file content in String format
+
+
+        :param output_schema: The output_schema of this CreateModelDetails.
+        :type: str
+        """
+        self._output_schema = output_schema
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/data_science/models/create_model_provenance_details.py
+++ b/src/oci/data_science/models/create_model_provenance_details.py
@@ -38,13 +38,18 @@ class CreateModelProvenanceDetails(object):
             The value to assign to the training_script property of this CreateModelProvenanceDetails.
         :type training_script: str
 
+        :param training_id:
+            The value to assign to the training_id property of this CreateModelProvenanceDetails.
+        :type training_id: str
+
         """
         self.swagger_types = {
             'repository_url': 'str',
             'git_branch': 'str',
             'git_commit': 'str',
             'script_dir': 'str',
-            'training_script': 'str'
+            'training_script': 'str',
+            'training_id': 'str'
         }
 
         self.attribute_map = {
@@ -52,7 +57,8 @@ class CreateModelProvenanceDetails(object):
             'git_branch': 'gitBranch',
             'git_commit': 'gitCommit',
             'script_dir': 'scriptDir',
-            'training_script': 'trainingScript'
+            'training_script': 'trainingScript',
+            'training_id': 'trainingId'
         }
 
         self._repository_url = None
@@ -60,6 +66,7 @@ class CreateModelProvenanceDetails(object):
         self._git_commit = None
         self._script_dir = None
         self._training_script = None
+        self._training_id = None
 
     @property
     def repository_url(self):
@@ -180,6 +187,34 @@ class CreateModelProvenanceDetails(object):
         :type: str
         """
         self._training_script = training_script
+
+    @property
+    def training_id(self):
+        """
+        Gets the training_id of this CreateModelProvenanceDetails.
+        The `OCID`__ of a training session(Job or NotebookSession) in which the model was trained. It is used for model reproducibility purposes.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :return: The training_id of this CreateModelProvenanceDetails.
+        :rtype: str
+        """
+        return self._training_id
+
+    @training_id.setter
+    def training_id(self, training_id):
+        """
+        Sets the training_id of this CreateModelProvenanceDetails.
+        The `OCID`__ of a training session(Job or NotebookSession) in which the model was trained. It is used for model reproducibility purposes.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :param training_id: The training_id of this CreateModelProvenanceDetails.
+        :type: str
+        """
+        self._training_id = training_id
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/data_science/models/metadata.py
+++ b/src/oci/data_science/models/metadata.py
@@ -1,0 +1,193 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class Metadata(object):
+    """
+    Defines properties of each model metadata.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new Metadata object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param key:
+            The value to assign to the key property of this Metadata.
+        :type key: str
+
+        :param value:
+            The value to assign to the value property of this Metadata.
+        :type value: str
+
+        :param description:
+            The value to assign to the description property of this Metadata.
+        :type description: str
+
+        :param category:
+            The value to assign to the category property of this Metadata.
+        :type category: str
+
+        """
+        self.swagger_types = {
+            'key': 'str',
+            'value': 'str',
+            'description': 'str',
+            'category': 'str'
+        }
+
+        self.attribute_map = {
+            'key': 'key',
+            'value': 'value',
+            'description': 'description',
+            'category': 'category'
+        }
+
+        self._key = None
+        self._value = None
+        self._description = None
+        self._category = None
+
+    @property
+    def key(self):
+        """
+        Gets the key of this Metadata.
+        Key of the model Metadata. The key can either be user defined or OCI defined.
+           List of OCI defined keys:
+                 * useCaseType
+                 * libraryName
+                 * libraryVersion
+                 * estimatorClass
+                 * hyperParameters
+                 * testartifactresults
+
+
+        :return: The key of this Metadata.
+        :rtype: str
+        """
+        return self._key
+
+    @key.setter
+    def key(self, key):
+        """
+        Sets the key of this Metadata.
+        Key of the model Metadata. The key can either be user defined or OCI defined.
+           List of OCI defined keys:
+                 * useCaseType
+                 * libraryName
+                 * libraryVersion
+                 * estimatorClass
+                 * hyperParameters
+                 * testartifactresults
+
+
+        :param key: The key of this Metadata.
+        :type: str
+        """
+        self._key = key
+
+    @property
+    def value(self):
+        """
+        Gets the value of this Metadata.
+        Allowed values for useCaseType:
+                     binary_classification, regression, multinomial_classification, clustering, recommender,
+                     dimensionality_reduction/representation, time_series_forecasting, anomaly_detection,
+                     topic_modeling, ner, sentiment_analysis, image_classification, object_localization, other
+
+        Allowed values for libraryName:
+                     scikit-learn, xgboost, tensorflow, pytorch, mxnet, keras, lightGBM, pymc3, pyOD, spacy,
+                     prophet, sktime, statsmodels, cuml, oracle_automl, h2o, transformers, nltk, emcee, pystan,
+                     bert, gensim, flair, word2vec, ensemble, other
+
+
+        :return: The value of this Metadata.
+        :rtype: str
+        """
+        return self._value
+
+    @value.setter
+    def value(self, value):
+        """
+        Sets the value of this Metadata.
+        Allowed values for useCaseType:
+                     binary_classification, regression, multinomial_classification, clustering, recommender,
+                     dimensionality_reduction/representation, time_series_forecasting, anomaly_detection,
+                     topic_modeling, ner, sentiment_analysis, image_classification, object_localization, other
+
+        Allowed values for libraryName:
+                     scikit-learn, xgboost, tensorflow, pytorch, mxnet, keras, lightGBM, pymc3, pyOD, spacy,
+                     prophet, sktime, statsmodels, cuml, oracle_automl, h2o, transformers, nltk, emcee, pystan,
+                     bert, gensim, flair, word2vec, ensemble, other
+
+
+        :param value: The value of this Metadata.
+        :type: str
+        """
+        self._value = value
+
+    @property
+    def description(self):
+        """
+        Gets the description of this Metadata.
+        Description of model metadata
+
+
+        :return: The description of this Metadata.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """
+        Sets the description of this Metadata.
+        Description of model metadata
+
+
+        :param description: The description of this Metadata.
+        :type: str
+        """
+        self._description = description
+
+    @property
+    def category(self):
+        """
+        Gets the category of this Metadata.
+        Category of model metadata which should be null for defined metadata.For custom metadata is should be one of the following values \"Performance,Training Profile,Training and Validation Datasets,Training Environment,other\".
+
+
+        :return: The category of this Metadata.
+        :rtype: str
+        """
+        return self._category
+
+    @category.setter
+    def category(self, category):
+        """
+        Sets the category of this Metadata.
+        Category of model metadata which should be null for defined metadata.For custom metadata is should be one of the following values \"Performance,Training Profile,Training and Validation Datasets,Training Environment,other\".
+
+
+        :param category: The category of this Metadata.
+        :type: str
+        """
+        self._category = category
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/data_science/models/model.py
+++ b/src/oci/data_science/models/model.py
@@ -76,6 +76,22 @@ class Model(object):
             The value to assign to the defined_tags property of this Model.
         :type defined_tags: dict(str, dict(str, object))
 
+        :param custom_metadata_list:
+            The value to assign to the custom_metadata_list property of this Model.
+        :type custom_metadata_list: list[oci.data_science.models.Metadata]
+
+        :param defined_metadata_list:
+            The value to assign to the defined_metadata_list property of this Model.
+        :type defined_metadata_list: list[oci.data_science.models.Metadata]
+
+        :param input_schema:
+            The value to assign to the input_schema property of this Model.
+        :type input_schema: str
+
+        :param output_schema:
+            The value to assign to the output_schema property of this Model.
+        :type output_schema: str
+
         """
         self.swagger_types = {
             'id': 'str',
@@ -87,7 +103,11 @@ class Model(object):
             'time_created': 'datetime',
             'created_by': 'str',
             'freeform_tags': 'dict(str, str)',
-            'defined_tags': 'dict(str, dict(str, object))'
+            'defined_tags': 'dict(str, dict(str, object))',
+            'custom_metadata_list': 'list[Metadata]',
+            'defined_metadata_list': 'list[Metadata]',
+            'input_schema': 'str',
+            'output_schema': 'str'
         }
 
         self.attribute_map = {
@@ -100,7 +120,11 @@ class Model(object):
             'time_created': 'timeCreated',
             'created_by': 'createdBy',
             'freeform_tags': 'freeformTags',
-            'defined_tags': 'definedTags'
+            'defined_tags': 'definedTags',
+            'custom_metadata_list': 'customMetadataList',
+            'defined_metadata_list': 'definedMetadataList',
+            'input_schema': 'inputSchema',
+            'output_schema': 'outputSchema'
         }
 
         self._id = None
@@ -113,6 +137,10 @@ class Model(object):
         self._created_by = None
         self._freeform_tags = None
         self._defined_tags = None
+        self._custom_metadata_list = None
+        self._defined_metadata_list = None
+        self._input_schema = None
+        self._output_schema = None
 
     @property
     def id(self):
@@ -393,6 +421,102 @@ class Model(object):
         :type: dict(str, dict(str, object))
         """
         self._defined_tags = defined_tags
+
+    @property
+    def custom_metadata_list(self):
+        """
+        Gets the custom_metadata_list of this Model.
+        An array of custom metadata details for the model.
+
+
+        :return: The custom_metadata_list of this Model.
+        :rtype: list[oci.data_science.models.Metadata]
+        """
+        return self._custom_metadata_list
+
+    @custom_metadata_list.setter
+    def custom_metadata_list(self, custom_metadata_list):
+        """
+        Sets the custom_metadata_list of this Model.
+        An array of custom metadata details for the model.
+
+
+        :param custom_metadata_list: The custom_metadata_list of this Model.
+        :type: list[oci.data_science.models.Metadata]
+        """
+        self._custom_metadata_list = custom_metadata_list
+
+    @property
+    def defined_metadata_list(self):
+        """
+        Gets the defined_metadata_list of this Model.
+        An array of defined metadata details for the model.
+
+
+        :return: The defined_metadata_list of this Model.
+        :rtype: list[oci.data_science.models.Metadata]
+        """
+        return self._defined_metadata_list
+
+    @defined_metadata_list.setter
+    def defined_metadata_list(self, defined_metadata_list):
+        """
+        Sets the defined_metadata_list of this Model.
+        An array of defined metadata details for the model.
+
+
+        :param defined_metadata_list: The defined_metadata_list of this Model.
+        :type: list[oci.data_science.models.Metadata]
+        """
+        self._defined_metadata_list = defined_metadata_list
+
+    @property
+    def input_schema(self):
+        """
+        Gets the input_schema of this Model.
+        Input schema file content in String format
+
+
+        :return: The input_schema of this Model.
+        :rtype: str
+        """
+        return self._input_schema
+
+    @input_schema.setter
+    def input_schema(self, input_schema):
+        """
+        Sets the input_schema of this Model.
+        Input schema file content in String format
+
+
+        :param input_schema: The input_schema of this Model.
+        :type: str
+        """
+        self._input_schema = input_schema
+
+    @property
+    def output_schema(self):
+        """
+        Gets the output_schema of this Model.
+        Output schema file content in String format
+
+
+        :return: The output_schema of this Model.
+        :rtype: str
+        """
+        return self._output_schema
+
+    @output_schema.setter
+    def output_schema(self, output_schema):
+        """
+        Sets the output_schema of this Model.
+        Output schema file content in String format
+
+
+        :param output_schema: The output_schema of this Model.
+        :type: str
+        """
+        self._output_schema = output_schema
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/data_science/models/model_deployment.py
+++ b/src/oci/data_science/models/model_deployment.py
@@ -10,7 +10,7 @@ from oci.decorators import init_model_state_from_kwargs
 @init_model_state_from_kwargs
 class ModelDeployment(object):
     """
-    Model deployments are interactive coding environments for data scientists.
+    Model deployments are used by data scientists to perform predictions from the model hosted on an HTTP server.
     """
 
     #: A constant which can be used with the lifecycle_state property of a ModelDeployment.

--- a/src/oci/data_science/models/model_provenance.py
+++ b/src/oci/data_science/models/model_provenance.py
@@ -38,13 +38,18 @@ class ModelProvenance(object):
             The value to assign to the training_script property of this ModelProvenance.
         :type training_script: str
 
+        :param training_id:
+            The value to assign to the training_id property of this ModelProvenance.
+        :type training_id: str
+
         """
         self.swagger_types = {
             'repository_url': 'str',
             'git_branch': 'str',
             'git_commit': 'str',
             'script_dir': 'str',
-            'training_script': 'str'
+            'training_script': 'str',
+            'training_id': 'str'
         }
 
         self.attribute_map = {
@@ -52,7 +57,8 @@ class ModelProvenance(object):
             'git_branch': 'gitBranch',
             'git_commit': 'gitCommit',
             'script_dir': 'scriptDir',
-            'training_script': 'trainingScript'
+            'training_script': 'trainingScript',
+            'training_id': 'trainingId'
         }
 
         self._repository_url = None
@@ -60,6 +66,7 @@ class ModelProvenance(object):
         self._git_commit = None
         self._script_dir = None
         self._training_script = None
+        self._training_id = None
 
     @property
     def repository_url(self):
@@ -180,6 +187,34 @@ class ModelProvenance(object):
         :type: str
         """
         self._training_script = training_script
+
+    @property
+    def training_id(self):
+        """
+        Gets the training_id of this ModelProvenance.
+        The `OCID`__ of a training session(Job or NotebookSession) in which the model was trained. It is used for model reproducibility purposes.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :return: The training_id of this ModelProvenance.
+        :rtype: str
+        """
+        return self._training_id
+
+    @training_id.setter
+    def training_id(self, training_id):
+        """
+        Sets the training_id of this ModelProvenance.
+        The `OCID`__ of a training session(Job or NotebookSession) in which the model was trained. It is used for model reproducibility purposes.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :param training_id: The training_id of this ModelProvenance.
+        :type: str
+        """
+        self._training_id = training_id
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/data_science/models/update_model_details.py
+++ b/src/oci/data_science/models/update_model_details.py
@@ -34,25 +34,39 @@ class UpdateModelDetails(object):
             The value to assign to the defined_tags property of this UpdateModelDetails.
         :type defined_tags: dict(str, dict(str, object))
 
+        :param custom_metadata_list:
+            The value to assign to the custom_metadata_list property of this UpdateModelDetails.
+        :type custom_metadata_list: list[oci.data_science.models.Metadata]
+
+        :param defined_metadata_list:
+            The value to assign to the defined_metadata_list property of this UpdateModelDetails.
+        :type defined_metadata_list: list[oci.data_science.models.Metadata]
+
         """
         self.swagger_types = {
             'display_name': 'str',
             'description': 'str',
             'freeform_tags': 'dict(str, str)',
-            'defined_tags': 'dict(str, dict(str, object))'
+            'defined_tags': 'dict(str, dict(str, object))',
+            'custom_metadata_list': 'list[Metadata]',
+            'defined_metadata_list': 'list[Metadata]'
         }
 
         self.attribute_map = {
             'display_name': 'displayName',
             'description': 'description',
             'freeform_tags': 'freeformTags',
-            'defined_tags': 'definedTags'
+            'defined_tags': 'definedTags',
+            'custom_metadata_list': 'customMetadataList',
+            'defined_metadata_list': 'definedMetadataList'
         }
 
         self._display_name = None
         self._description = None
         self._freeform_tags = None
         self._defined_tags = None
+        self._custom_metadata_list = None
+        self._defined_metadata_list = None
 
     @property
     def display_name(self):
@@ -163,6 +177,54 @@ class UpdateModelDetails(object):
         :type: dict(str, dict(str, object))
         """
         self._defined_tags = defined_tags
+
+    @property
+    def custom_metadata_list(self):
+        """
+        Gets the custom_metadata_list of this UpdateModelDetails.
+        An array of custom metadata details for the model.
+
+
+        :return: The custom_metadata_list of this UpdateModelDetails.
+        :rtype: list[oci.data_science.models.Metadata]
+        """
+        return self._custom_metadata_list
+
+    @custom_metadata_list.setter
+    def custom_metadata_list(self, custom_metadata_list):
+        """
+        Sets the custom_metadata_list of this UpdateModelDetails.
+        An array of custom metadata details for the model.
+
+
+        :param custom_metadata_list: The custom_metadata_list of this UpdateModelDetails.
+        :type: list[oci.data_science.models.Metadata]
+        """
+        self._custom_metadata_list = custom_metadata_list
+
+    @property
+    def defined_metadata_list(self):
+        """
+        Gets the defined_metadata_list of this UpdateModelDetails.
+        An array of defined metadata details for the model.
+
+
+        :return: The defined_metadata_list of this UpdateModelDetails.
+        :rtype: list[oci.data_science.models.Metadata]
+        """
+        return self._defined_metadata_list
+
+    @defined_metadata_list.setter
+    def defined_metadata_list(self, defined_metadata_list):
+        """
+        Sets the defined_metadata_list of this UpdateModelDetails.
+        An array of defined metadata details for the model.
+
+
+        :param defined_metadata_list: The defined_metadata_list of this UpdateModelDetails.
+        :type: list[oci.data_science.models.Metadata]
+        """
+        self._defined_metadata_list = defined_metadata_list
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/data_science/models/update_model_provenance_details.py
+++ b/src/oci/data_science/models/update_model_provenance_details.py
@@ -38,13 +38,18 @@ class UpdateModelProvenanceDetails(object):
             The value to assign to the training_script property of this UpdateModelProvenanceDetails.
         :type training_script: str
 
+        :param training_id:
+            The value to assign to the training_id property of this UpdateModelProvenanceDetails.
+        :type training_id: str
+
         """
         self.swagger_types = {
             'repository_url': 'str',
             'git_branch': 'str',
             'git_commit': 'str',
             'script_dir': 'str',
-            'training_script': 'str'
+            'training_script': 'str',
+            'training_id': 'str'
         }
 
         self.attribute_map = {
@@ -52,7 +57,8 @@ class UpdateModelProvenanceDetails(object):
             'git_branch': 'gitBranch',
             'git_commit': 'gitCommit',
             'script_dir': 'scriptDir',
-            'training_script': 'trainingScript'
+            'training_script': 'trainingScript',
+            'training_id': 'trainingId'
         }
 
         self._repository_url = None
@@ -60,6 +66,7 @@ class UpdateModelProvenanceDetails(object):
         self._git_commit = None
         self._script_dir = None
         self._training_script = None
+        self._training_id = None
 
     @property
     def repository_url(self):
@@ -180,6 +187,34 @@ class UpdateModelProvenanceDetails(object):
         :type: str
         """
         self._training_script = training_script
+
+    @property
+    def training_id(self):
+        """
+        Gets the training_id of this UpdateModelProvenanceDetails.
+        The `OCID`__ of a training session(Job or NotebookSession) in which the model was trained. It is used for model reproducibility purposes.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :return: The training_id of this UpdateModelProvenanceDetails.
+        :rtype: str
+        """
+        return self._training_id
+
+    @training_id.setter
+    def training_id(self, training_id):
+        """
+        Sets the training_id of this UpdateModelProvenanceDetails.
+        The `OCID`__ of a training session(Job or NotebookSession) in which the model was trained. It is used for model reproducibility purposes.
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :param training_id: The training_id of this UpdateModelProvenanceDetails.
+        :type: str
+        """
+        self._training_id = training_id
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/database/models/autonomous_database.py
+++ b/src/oci/database/models/autonomous_database.py
@@ -221,6 +221,14 @@ class AutonomousDatabase(object):
     #: This constant has a value of "REMOTE_STANDBY_DG_REGION"
     DATAGUARD_REGION_TYPE_REMOTE_STANDBY_DG_REGION = "REMOTE_STANDBY_DG_REGION"
 
+    #: A constant which can be used with the autonomous_maintenance_schedule_type property of a AutonomousDatabase.
+    #: This constant has a value of "EARLY"
+    AUTONOMOUS_MAINTENANCE_SCHEDULE_TYPE_EARLY = "EARLY"
+
+    #: A constant which can be used with the autonomous_maintenance_schedule_type property of a AutonomousDatabase.
+    #: This constant has a value of "REGULAR"
+    AUTONOMOUS_MAINTENANCE_SCHEDULE_TYPE_REGULAR = "REGULAR"
+
     def __init__(self, **kwargs):
         """
         Initializes a new AutonomousDatabase object with values from keyword arguments.
@@ -538,6 +546,12 @@ class AutonomousDatabase(object):
             The value to assign to the peer_db_ids property of this AutonomousDatabase.
         :type peer_db_ids: list[str]
 
+        :param autonomous_maintenance_schedule_type:
+            The value to assign to the autonomous_maintenance_schedule_type property of this AutonomousDatabase.
+            Allowed values for this property are: "EARLY", "REGULAR", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type autonomous_maintenance_schedule_type: str
+
         """
         self.swagger_types = {
             'id': 'str',
@@ -611,7 +625,8 @@ class AutonomousDatabase(object):
             'time_local_data_guard_enabled': 'datetime',
             'dataguard_region_type': 'str',
             'time_data_guard_role_changed': 'datetime',
-            'peer_db_ids': 'list[str]'
+            'peer_db_ids': 'list[str]',
+            'autonomous_maintenance_schedule_type': 'str'
         }
 
         self.attribute_map = {
@@ -686,7 +701,8 @@ class AutonomousDatabase(object):
             'time_local_data_guard_enabled': 'timeLocalDataGuardEnabled',
             'dataguard_region_type': 'dataguardRegionType',
             'time_data_guard_role_changed': 'timeDataGuardRoleChanged',
-            'peer_db_ids': 'peerDbIds'
+            'peer_db_ids': 'peerDbIds',
+            'autonomous_maintenance_schedule_type': 'autonomousMaintenanceScheduleType'
         }
 
         self._id = None
@@ -761,6 +777,7 @@ class AutonomousDatabase(object):
         self._dataguard_region_type = None
         self._time_data_guard_role_changed = None
         self._peer_db_ids = None
+        self._autonomous_maintenance_schedule_type = None
 
     @property
     def id(self):
@@ -2747,6 +2764,38 @@ class AutonomousDatabase(object):
         :type: list[str]
         """
         self._peer_db_ids = peer_db_ids
+
+    @property
+    def autonomous_maintenance_schedule_type(self):
+        """
+        Gets the autonomous_maintenance_schedule_type of this AutonomousDatabase.
+        The maintenance schedule type of the Autonomous Database on shared Exadata infrastructure. The EARLY maintenance schedule of this Autonomous Database
+        follows a schedule that applies patches prior to the REGULAR schedule.The REGULAR maintenance schedule of this Autonomous Database follows the normal cycle.
+
+        Allowed values for this property are: "EARLY", "REGULAR", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The autonomous_maintenance_schedule_type of this AutonomousDatabase.
+        :rtype: str
+        """
+        return self._autonomous_maintenance_schedule_type
+
+    @autonomous_maintenance_schedule_type.setter
+    def autonomous_maintenance_schedule_type(self, autonomous_maintenance_schedule_type):
+        """
+        Sets the autonomous_maintenance_schedule_type of this AutonomousDatabase.
+        The maintenance schedule type of the Autonomous Database on shared Exadata infrastructure. The EARLY maintenance schedule of this Autonomous Database
+        follows a schedule that applies patches prior to the REGULAR schedule.The REGULAR maintenance schedule of this Autonomous Database follows the normal cycle.
+
+
+        :param autonomous_maintenance_schedule_type: The autonomous_maintenance_schedule_type of this AutonomousDatabase.
+        :type: str
+        """
+        allowed_values = ["EARLY", "REGULAR"]
+        if not value_allowed_none_or_none_sentinel(autonomous_maintenance_schedule_type, allowed_values):
+            autonomous_maintenance_schedule_type = 'UNKNOWN_ENUM_VALUE'
+        self._autonomous_maintenance_schedule_type = autonomous_maintenance_schedule_type
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/database/models/autonomous_database_summary.py
+++ b/src/oci/database/models/autonomous_database_summary.py
@@ -223,6 +223,14 @@ class AutonomousDatabaseSummary(object):
     #: This constant has a value of "REMOTE_STANDBY_DG_REGION"
     DATAGUARD_REGION_TYPE_REMOTE_STANDBY_DG_REGION = "REMOTE_STANDBY_DG_REGION"
 
+    #: A constant which can be used with the autonomous_maintenance_schedule_type property of a AutonomousDatabaseSummary.
+    #: This constant has a value of "EARLY"
+    AUTONOMOUS_MAINTENANCE_SCHEDULE_TYPE_EARLY = "EARLY"
+
+    #: A constant which can be used with the autonomous_maintenance_schedule_type property of a AutonomousDatabaseSummary.
+    #: This constant has a value of "REGULAR"
+    AUTONOMOUS_MAINTENANCE_SCHEDULE_TYPE_REGULAR = "REGULAR"
+
     def __init__(self, **kwargs):
         """
         Initializes a new AutonomousDatabaseSummary object with values from keyword arguments.
@@ -540,6 +548,12 @@ class AutonomousDatabaseSummary(object):
             The value to assign to the peer_db_ids property of this AutonomousDatabaseSummary.
         :type peer_db_ids: list[str]
 
+        :param autonomous_maintenance_schedule_type:
+            The value to assign to the autonomous_maintenance_schedule_type property of this AutonomousDatabaseSummary.
+            Allowed values for this property are: "EARLY", "REGULAR", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type autonomous_maintenance_schedule_type: str
+
         """
         self.swagger_types = {
             'id': 'str',
@@ -613,7 +627,8 @@ class AutonomousDatabaseSummary(object):
             'time_local_data_guard_enabled': 'datetime',
             'dataguard_region_type': 'str',
             'time_data_guard_role_changed': 'datetime',
-            'peer_db_ids': 'list[str]'
+            'peer_db_ids': 'list[str]',
+            'autonomous_maintenance_schedule_type': 'str'
         }
 
         self.attribute_map = {
@@ -688,7 +703,8 @@ class AutonomousDatabaseSummary(object):
             'time_local_data_guard_enabled': 'timeLocalDataGuardEnabled',
             'dataguard_region_type': 'dataguardRegionType',
             'time_data_guard_role_changed': 'timeDataGuardRoleChanged',
-            'peer_db_ids': 'peerDbIds'
+            'peer_db_ids': 'peerDbIds',
+            'autonomous_maintenance_schedule_type': 'autonomousMaintenanceScheduleType'
         }
 
         self._id = None
@@ -763,6 +779,7 @@ class AutonomousDatabaseSummary(object):
         self._dataguard_region_type = None
         self._time_data_guard_role_changed = None
         self._peer_db_ids = None
+        self._autonomous_maintenance_schedule_type = None
 
     @property
     def id(self):
@@ -2749,6 +2766,38 @@ class AutonomousDatabaseSummary(object):
         :type: list[str]
         """
         self._peer_db_ids = peer_db_ids
+
+    @property
+    def autonomous_maintenance_schedule_type(self):
+        """
+        Gets the autonomous_maintenance_schedule_type of this AutonomousDatabaseSummary.
+        The maintenance schedule type of the Autonomous Database on shared Exadata infrastructure. The EARLY maintenance schedule of this Autonomous Database
+        follows a schedule that applies patches prior to the REGULAR schedule.The REGULAR maintenance schedule of this Autonomous Database follows the normal cycle.
+
+        Allowed values for this property are: "EARLY", "REGULAR", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The autonomous_maintenance_schedule_type of this AutonomousDatabaseSummary.
+        :rtype: str
+        """
+        return self._autonomous_maintenance_schedule_type
+
+    @autonomous_maintenance_schedule_type.setter
+    def autonomous_maintenance_schedule_type(self, autonomous_maintenance_schedule_type):
+        """
+        Sets the autonomous_maintenance_schedule_type of this AutonomousDatabaseSummary.
+        The maintenance schedule type of the Autonomous Database on shared Exadata infrastructure. The EARLY maintenance schedule of this Autonomous Database
+        follows a schedule that applies patches prior to the REGULAR schedule.The REGULAR maintenance schedule of this Autonomous Database follows the normal cycle.
+
+
+        :param autonomous_maintenance_schedule_type: The autonomous_maintenance_schedule_type of this AutonomousDatabaseSummary.
+        :type: str
+        """
+        allowed_values = ["EARLY", "REGULAR"]
+        if not value_allowed_none_or_none_sentinel(autonomous_maintenance_schedule_type, allowed_values):
+            autonomous_maintenance_schedule_type = 'UNKNOWN_ENUM_VALUE'
+        self._autonomous_maintenance_schedule_type = autonomous_maintenance_schedule_type
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/database/models/create_autonomous_database_base.py
+++ b/src/oci/database/models/create_autonomous_database_base.py
@@ -68,6 +68,14 @@ class CreateAutonomousDatabaseBase(object):
     #: This constant has a value of "CROSS_REGION_DATAGUARD"
     SOURCE_CROSS_REGION_DATAGUARD = "CROSS_REGION_DATAGUARD"
 
+    #: A constant which can be used with the autonomous_maintenance_schedule_type property of a CreateAutonomousDatabaseBase.
+    #: This constant has a value of "EARLY"
+    AUTONOMOUS_MAINTENANCE_SCHEDULE_TYPE_EARLY = "EARLY"
+
+    #: A constant which can be used with the autonomous_maintenance_schedule_type property of a CreateAutonomousDatabaseBase.
+    #: This constant has a value of "REGULAR"
+    AUTONOMOUS_MAINTENANCE_SCHEDULE_TYPE_REGULAR = "REGULAR"
+
     def __init__(self, **kwargs):
         """
         Initializes a new CreateAutonomousDatabaseBase object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
@@ -205,6 +213,11 @@ class CreateAutonomousDatabaseBase(object):
             The value to assign to the customer_contacts property of this CreateAutonomousDatabaseBase.
         :type customer_contacts: list[oci.database.models.CustomerContact]
 
+        :param autonomous_maintenance_schedule_type:
+            The value to assign to the autonomous_maintenance_schedule_type property of this CreateAutonomousDatabaseBase.
+            Allowed values for this property are: "EARLY", "REGULAR"
+        :type autonomous_maintenance_schedule_type: str
+
         """
         self.swagger_types = {
             'compartment_id': 'str',
@@ -236,7 +249,8 @@ class CreateAutonomousDatabaseBase(object):
             'defined_tags': 'dict(str, dict(str, object))',
             'db_version': 'str',
             'source': 'str',
-            'customer_contacts': 'list[CustomerContact]'
+            'customer_contacts': 'list[CustomerContact]',
+            'autonomous_maintenance_schedule_type': 'str'
         }
 
         self.attribute_map = {
@@ -269,7 +283,8 @@ class CreateAutonomousDatabaseBase(object):
             'defined_tags': 'definedTags',
             'db_version': 'dbVersion',
             'source': 'source',
-            'customer_contacts': 'customerContacts'
+            'customer_contacts': 'customerContacts',
+            'autonomous_maintenance_schedule_type': 'autonomousMaintenanceScheduleType'
         }
 
         self._compartment_id = None
@@ -302,6 +317,7 @@ class CreateAutonomousDatabaseBase(object):
         self._db_version = None
         self._source = None
         self._customer_contacts = None
+        self._autonomous_maintenance_schedule_type = None
 
     @staticmethod
     def get_subtype(object_dictionary):
@@ -1284,6 +1300,40 @@ class CreateAutonomousDatabaseBase(object):
         :type: list[oci.database.models.CustomerContact]
         """
         self._customer_contacts = customer_contacts
+
+    @property
+    def autonomous_maintenance_schedule_type(self):
+        """
+        Gets the autonomous_maintenance_schedule_type of this CreateAutonomousDatabaseBase.
+        The maintenance schedule type of the Autonomous Database on shared Exadata infrastructure. The EARLY maintenance schedule of this Autonomous Database
+        follows a schedule that applies patches prior to the REGULAR schedule.The REGULAR maintenance schedule of this Autonomous Database follows the normal cycle.
+
+        Allowed values for this property are: "EARLY", "REGULAR"
+
+
+        :return: The autonomous_maintenance_schedule_type of this CreateAutonomousDatabaseBase.
+        :rtype: str
+        """
+        return self._autonomous_maintenance_schedule_type
+
+    @autonomous_maintenance_schedule_type.setter
+    def autonomous_maintenance_schedule_type(self, autonomous_maintenance_schedule_type):
+        """
+        Sets the autonomous_maintenance_schedule_type of this CreateAutonomousDatabaseBase.
+        The maintenance schedule type of the Autonomous Database on shared Exadata infrastructure. The EARLY maintenance schedule of this Autonomous Database
+        follows a schedule that applies patches prior to the REGULAR schedule.The REGULAR maintenance schedule of this Autonomous Database follows the normal cycle.
+
+
+        :param autonomous_maintenance_schedule_type: The autonomous_maintenance_schedule_type of this CreateAutonomousDatabaseBase.
+        :type: str
+        """
+        allowed_values = ["EARLY", "REGULAR"]
+        if not value_allowed_none_or_none_sentinel(autonomous_maintenance_schedule_type, allowed_values):
+            raise ValueError(
+                "Invalid value for `autonomous_maintenance_schedule_type`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._autonomous_maintenance_schedule_type = autonomous_maintenance_schedule_type
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/database/models/create_autonomous_database_clone_details.py
+++ b/src/oci/database/models/create_autonomous_database_clone_details.py
@@ -150,6 +150,11 @@ class CreateAutonomousDatabaseCloneDetails(CreateAutonomousDatabaseBase):
             The value to assign to the customer_contacts property of this CreateAutonomousDatabaseCloneDetails.
         :type customer_contacts: list[oci.database.models.CustomerContact]
 
+        :param autonomous_maintenance_schedule_type:
+            The value to assign to the autonomous_maintenance_schedule_type property of this CreateAutonomousDatabaseCloneDetails.
+            Allowed values for this property are: "EARLY", "REGULAR"
+        :type autonomous_maintenance_schedule_type: str
+
         :param source_id:
             The value to assign to the source_id property of this CreateAutonomousDatabaseCloneDetails.
         :type source_id: str
@@ -191,6 +196,7 @@ class CreateAutonomousDatabaseCloneDetails(CreateAutonomousDatabaseBase):
             'db_version': 'str',
             'source': 'str',
             'customer_contacts': 'list[CustomerContact]',
+            'autonomous_maintenance_schedule_type': 'str',
             'source_id': 'str',
             'clone_type': 'str'
         }
@@ -226,6 +232,7 @@ class CreateAutonomousDatabaseCloneDetails(CreateAutonomousDatabaseBase):
             'db_version': 'dbVersion',
             'source': 'source',
             'customer_contacts': 'customerContacts',
+            'autonomous_maintenance_schedule_type': 'autonomousMaintenanceScheduleType',
             'source_id': 'sourceId',
             'clone_type': 'cloneType'
         }
@@ -260,6 +267,7 @@ class CreateAutonomousDatabaseCloneDetails(CreateAutonomousDatabaseBase):
         self._db_version = None
         self._source = None
         self._customer_contacts = None
+        self._autonomous_maintenance_schedule_type = None
         self._source_id = None
         self._clone_type = None
         self._source = 'DATABASE'

--- a/src/oci/database/models/create_autonomous_database_details.py
+++ b/src/oci/database/models/create_autonomous_database_details.py
@@ -142,6 +142,11 @@ class CreateAutonomousDatabaseDetails(CreateAutonomousDatabaseBase):
             The value to assign to the customer_contacts property of this CreateAutonomousDatabaseDetails.
         :type customer_contacts: list[oci.database.models.CustomerContact]
 
+        :param autonomous_maintenance_schedule_type:
+            The value to assign to the autonomous_maintenance_schedule_type property of this CreateAutonomousDatabaseDetails.
+            Allowed values for this property are: "EARLY", "REGULAR"
+        :type autonomous_maintenance_schedule_type: str
+
         """
         self.swagger_types = {
             'compartment_id': 'str',
@@ -173,7 +178,8 @@ class CreateAutonomousDatabaseDetails(CreateAutonomousDatabaseBase):
             'defined_tags': 'dict(str, dict(str, object))',
             'db_version': 'str',
             'source': 'str',
-            'customer_contacts': 'list[CustomerContact]'
+            'customer_contacts': 'list[CustomerContact]',
+            'autonomous_maintenance_schedule_type': 'str'
         }
 
         self.attribute_map = {
@@ -206,7 +212,8 @@ class CreateAutonomousDatabaseDetails(CreateAutonomousDatabaseBase):
             'defined_tags': 'definedTags',
             'db_version': 'dbVersion',
             'source': 'source',
-            'customer_contacts': 'customerContacts'
+            'customer_contacts': 'customerContacts',
+            'autonomous_maintenance_schedule_type': 'autonomousMaintenanceScheduleType'
         }
 
         self._compartment_id = None
@@ -239,6 +246,7 @@ class CreateAutonomousDatabaseDetails(CreateAutonomousDatabaseBase):
         self._db_version = None
         self._source = None
         self._customer_contacts = None
+        self._autonomous_maintenance_schedule_type = None
         self._source = 'NONE'
 
     def __repr__(self):

--- a/src/oci/database/models/create_autonomous_database_from_backup_details.py
+++ b/src/oci/database/models/create_autonomous_database_from_backup_details.py
@@ -150,6 +150,11 @@ class CreateAutonomousDatabaseFromBackupDetails(CreateAutonomousDatabaseBase):
             The value to assign to the customer_contacts property of this CreateAutonomousDatabaseFromBackupDetails.
         :type customer_contacts: list[oci.database.models.CustomerContact]
 
+        :param autonomous_maintenance_schedule_type:
+            The value to assign to the autonomous_maintenance_schedule_type property of this CreateAutonomousDatabaseFromBackupDetails.
+            Allowed values for this property are: "EARLY", "REGULAR"
+        :type autonomous_maintenance_schedule_type: str
+
         :param autonomous_database_backup_id:
             The value to assign to the autonomous_database_backup_id property of this CreateAutonomousDatabaseFromBackupDetails.
         :type autonomous_database_backup_id: str
@@ -191,6 +196,7 @@ class CreateAutonomousDatabaseFromBackupDetails(CreateAutonomousDatabaseBase):
             'db_version': 'str',
             'source': 'str',
             'customer_contacts': 'list[CustomerContact]',
+            'autonomous_maintenance_schedule_type': 'str',
             'autonomous_database_backup_id': 'str',
             'clone_type': 'str'
         }
@@ -226,6 +232,7 @@ class CreateAutonomousDatabaseFromBackupDetails(CreateAutonomousDatabaseBase):
             'db_version': 'dbVersion',
             'source': 'source',
             'customer_contacts': 'customerContacts',
+            'autonomous_maintenance_schedule_type': 'autonomousMaintenanceScheduleType',
             'autonomous_database_backup_id': 'autonomousDatabaseBackupId',
             'clone_type': 'cloneType'
         }
@@ -260,6 +267,7 @@ class CreateAutonomousDatabaseFromBackupDetails(CreateAutonomousDatabaseBase):
         self._db_version = None
         self._source = None
         self._customer_contacts = None
+        self._autonomous_maintenance_schedule_type = None
         self._autonomous_database_backup_id = None
         self._clone_type = None
         self._source = 'BACKUP_FROM_ID'

--- a/src/oci/database/models/create_autonomous_database_from_backup_timestamp_details.py
+++ b/src/oci/database/models/create_autonomous_database_from_backup_timestamp_details.py
@@ -150,6 +150,11 @@ class CreateAutonomousDatabaseFromBackupTimestampDetails(CreateAutonomousDatabas
             The value to assign to the customer_contacts property of this CreateAutonomousDatabaseFromBackupTimestampDetails.
         :type customer_contacts: list[oci.database.models.CustomerContact]
 
+        :param autonomous_maintenance_schedule_type:
+            The value to assign to the autonomous_maintenance_schedule_type property of this CreateAutonomousDatabaseFromBackupTimestampDetails.
+            Allowed values for this property are: "EARLY", "REGULAR"
+        :type autonomous_maintenance_schedule_type: str
+
         :param autonomous_database_id:
             The value to assign to the autonomous_database_id property of this CreateAutonomousDatabaseFromBackupTimestampDetails.
         :type autonomous_database_id: str
@@ -195,6 +200,7 @@ class CreateAutonomousDatabaseFromBackupTimestampDetails(CreateAutonomousDatabas
             'db_version': 'str',
             'source': 'str',
             'customer_contacts': 'list[CustomerContact]',
+            'autonomous_maintenance_schedule_type': 'str',
             'autonomous_database_id': 'str',
             'timestamp': 'datetime',
             'clone_type': 'str'
@@ -231,6 +237,7 @@ class CreateAutonomousDatabaseFromBackupTimestampDetails(CreateAutonomousDatabas
             'db_version': 'dbVersion',
             'source': 'source',
             'customer_contacts': 'customerContacts',
+            'autonomous_maintenance_schedule_type': 'autonomousMaintenanceScheduleType',
             'autonomous_database_id': 'autonomousDatabaseId',
             'timestamp': 'timestamp',
             'clone_type': 'cloneType'
@@ -266,6 +273,7 @@ class CreateAutonomousDatabaseFromBackupTimestampDetails(CreateAutonomousDatabas
         self._db_version = None
         self._source = None
         self._customer_contacts = None
+        self._autonomous_maintenance_schedule_type = None
         self._autonomous_database_id = None
         self._timestamp = None
         self._clone_type = None

--- a/src/oci/database/models/create_cross_region_autonomous_database_data_guard_details.py
+++ b/src/oci/database/models/create_cross_region_autonomous_database_data_guard_details.py
@@ -142,6 +142,11 @@ class CreateCrossRegionAutonomousDatabaseDataGuardDetails(CreateAutonomousDataba
             The value to assign to the customer_contacts property of this CreateCrossRegionAutonomousDatabaseDataGuardDetails.
         :type customer_contacts: list[oci.database.models.CustomerContact]
 
+        :param autonomous_maintenance_schedule_type:
+            The value to assign to the autonomous_maintenance_schedule_type property of this CreateCrossRegionAutonomousDatabaseDataGuardDetails.
+            Allowed values for this property are: "EARLY", "REGULAR"
+        :type autonomous_maintenance_schedule_type: str
+
         :param source_id:
             The value to assign to the source_id property of this CreateCrossRegionAutonomousDatabaseDataGuardDetails.
         :type source_id: str
@@ -178,6 +183,7 @@ class CreateCrossRegionAutonomousDatabaseDataGuardDetails(CreateAutonomousDataba
             'db_version': 'str',
             'source': 'str',
             'customer_contacts': 'list[CustomerContact]',
+            'autonomous_maintenance_schedule_type': 'str',
             'source_id': 'str'
         }
 
@@ -212,6 +218,7 @@ class CreateCrossRegionAutonomousDatabaseDataGuardDetails(CreateAutonomousDataba
             'db_version': 'dbVersion',
             'source': 'source',
             'customer_contacts': 'customerContacts',
+            'autonomous_maintenance_schedule_type': 'autonomousMaintenanceScheduleType',
             'source_id': 'sourceId'
         }
 
@@ -245,6 +252,7 @@ class CreateCrossRegionAutonomousDatabaseDataGuardDetails(CreateAutonomousDataba
         self._db_version = None
         self._source = None
         self._customer_contacts = None
+        self._autonomous_maintenance_schedule_type = None
         self._source_id = None
         self._source = 'CROSS_REGION_DATAGUARD'
 

--- a/src/oci/database/models/create_refreshable_autonomous_database_clone_details.py
+++ b/src/oci/database/models/create_refreshable_autonomous_database_clone_details.py
@@ -150,6 +150,11 @@ class CreateRefreshableAutonomousDatabaseCloneDetails(CreateAutonomousDatabaseBa
             The value to assign to the customer_contacts property of this CreateRefreshableAutonomousDatabaseCloneDetails.
         :type customer_contacts: list[oci.database.models.CustomerContact]
 
+        :param autonomous_maintenance_schedule_type:
+            The value to assign to the autonomous_maintenance_schedule_type property of this CreateRefreshableAutonomousDatabaseCloneDetails.
+            Allowed values for this property are: "EARLY", "REGULAR"
+        :type autonomous_maintenance_schedule_type: str
+
         :param source_id:
             The value to assign to the source_id property of this CreateRefreshableAutonomousDatabaseCloneDetails.
         :type source_id: str
@@ -191,6 +196,7 @@ class CreateRefreshableAutonomousDatabaseCloneDetails(CreateAutonomousDatabaseBa
             'db_version': 'str',
             'source': 'str',
             'customer_contacts': 'list[CustomerContact]',
+            'autonomous_maintenance_schedule_type': 'str',
             'source_id': 'str',
             'refreshable_mode': 'str'
         }
@@ -226,6 +232,7 @@ class CreateRefreshableAutonomousDatabaseCloneDetails(CreateAutonomousDatabaseBa
             'db_version': 'dbVersion',
             'source': 'source',
             'customer_contacts': 'customerContacts',
+            'autonomous_maintenance_schedule_type': 'autonomousMaintenanceScheduleType',
             'source_id': 'sourceId',
             'refreshable_mode': 'refreshableMode'
         }
@@ -260,6 +267,7 @@ class CreateRefreshableAutonomousDatabaseCloneDetails(CreateAutonomousDatabaseBa
         self._db_version = None
         self._source = None
         self._customer_contacts = None
+        self._autonomous_maintenance_schedule_type = None
         self._source_id = None
         self._refreshable_mode = None
         self._source = 'CLONE_TO_REFRESHABLE'

--- a/src/oci/database/models/db_node.py
+++ b/src/oci/database/models/db_node.py
@@ -74,6 +74,22 @@ class DbNode(object):
             The value to assign to the backup_vnic_id property of this DbNode.
         :type backup_vnic_id: str
 
+        :param host_ip_id:
+            The value to assign to the host_ip_id property of this DbNode.
+        :type host_ip_id: str
+
+        :param backup_ip_id:
+            The value to assign to the backup_ip_id property of this DbNode.
+        :type backup_ip_id: str
+
+        :param vnic2_id:
+            The value to assign to the vnic2_id property of this DbNode.
+        :type vnic2_id: str
+
+        :param backup_vnic2_id:
+            The value to assign to the backup_vnic2_id property of this DbNode.
+        :type backup_vnic2_id: str
+
         :param lifecycle_state:
             The value to assign to the lifecycle_state property of this DbNode.
             Allowed values for this property are: "PROVISIONING", "AVAILABLE", "UPDATING", "STOPPING", "STOPPED", "STARTING", "TERMINATING", "TERMINATED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
@@ -120,6 +136,10 @@ class DbNode(object):
             'db_system_id': 'str',
             'vnic_id': 'str',
             'backup_vnic_id': 'str',
+            'host_ip_id': 'str',
+            'backup_ip_id': 'str',
+            'vnic2_id': 'str',
+            'backup_vnic2_id': 'str',
             'lifecycle_state': 'str',
             'hostname': 'str',
             'fault_domain': 'str',
@@ -136,6 +156,10 @@ class DbNode(object):
             'db_system_id': 'dbSystemId',
             'vnic_id': 'vnicId',
             'backup_vnic_id': 'backupVnicId',
+            'host_ip_id': 'hostIpId',
+            'backup_ip_id': 'backupIpId',
+            'vnic2_id': 'vnic2Id',
+            'backup_vnic2_id': 'backupVnic2Id',
             'lifecycle_state': 'lifecycleState',
             'hostname': 'hostname',
             'fault_domain': 'faultDomain',
@@ -151,6 +175,10 @@ class DbNode(object):
         self._db_system_id = None
         self._vnic_id = None
         self._backup_vnic_id = None
+        self._host_ip_id = None
+        self._backup_ip_id = None
+        self._vnic2_id = None
+        self._backup_vnic2_id = None
         self._lifecycle_state = None
         self._hostname = None
         self._fault_domain = None
@@ -272,6 +300,134 @@ class DbNode(object):
         :type: str
         """
         self._backup_vnic_id = backup_vnic_id
+
+    @property
+    def host_ip_id(self):
+        """
+        Gets the host_ip_id of this DbNode.
+        The `OCID`__ of the host IP address associated with the database node.
+
+        **Note:** Applies only to Exadata Cloud Service.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The host_ip_id of this DbNode.
+        :rtype: str
+        """
+        return self._host_ip_id
+
+    @host_ip_id.setter
+    def host_ip_id(self, host_ip_id):
+        """
+        Sets the host_ip_id of this DbNode.
+        The `OCID`__ of the host IP address associated with the database node.
+
+        **Note:** Applies only to Exadata Cloud Service.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param host_ip_id: The host_ip_id of this DbNode.
+        :type: str
+        """
+        self._host_ip_id = host_ip_id
+
+    @property
+    def backup_ip_id(self):
+        """
+        Gets the backup_ip_id of this DbNode.
+        The `OCID`__ of the backup IP address associated with the database node.
+
+        **Note:** Applies only to Exadata Cloud Service.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The backup_ip_id of this DbNode.
+        :rtype: str
+        """
+        return self._backup_ip_id
+
+    @backup_ip_id.setter
+    def backup_ip_id(self, backup_ip_id):
+        """
+        Sets the backup_ip_id of this DbNode.
+        The `OCID`__ of the backup IP address associated with the database node.
+
+        **Note:** Applies only to Exadata Cloud Service.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param backup_ip_id: The backup_ip_id of this DbNode.
+        :type: str
+        """
+        self._backup_ip_id = backup_ip_id
+
+    @property
+    def vnic2_id(self):
+        """
+        Gets the vnic2_id of this DbNode.
+        The `OCID`__ of the second VNIC.
+
+        **Note:** Applies only to Exadata Cloud Service.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The vnic2_id of this DbNode.
+        :rtype: str
+        """
+        return self._vnic2_id
+
+    @vnic2_id.setter
+    def vnic2_id(self, vnic2_id):
+        """
+        Sets the vnic2_id of this DbNode.
+        The `OCID`__ of the second VNIC.
+
+        **Note:** Applies only to Exadata Cloud Service.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param vnic2_id: The vnic2_id of this DbNode.
+        :type: str
+        """
+        self._vnic2_id = vnic2_id
+
+    @property
+    def backup_vnic2_id(self):
+        """
+        Gets the backup_vnic2_id of this DbNode.
+        The `OCID`__ of the second backup VNIC.
+
+        **Note:** Applies only to Exadata Cloud Service.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The backup_vnic2_id of this DbNode.
+        :rtype: str
+        """
+        return self._backup_vnic2_id
+
+    @backup_vnic2_id.setter
+    def backup_vnic2_id(self, backup_vnic2_id):
+        """
+        Sets the backup_vnic2_id of this DbNode.
+        The `OCID`__ of the second backup VNIC.
+
+        **Note:** Applies only to Exadata Cloud Service.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param backup_vnic2_id: The backup_vnic2_id of this DbNode.
+        :type: str
+        """
+        self._backup_vnic2_id = backup_vnic2_id
 
     @property
     def lifecycle_state(self):

--- a/src/oci/database/models/db_node_summary.py
+++ b/src/oci/database/models/db_node_summary.py
@@ -80,6 +80,22 @@ class DbNodeSummary(object):
             The value to assign to the backup_vnic_id property of this DbNodeSummary.
         :type backup_vnic_id: str
 
+        :param host_ip_id:
+            The value to assign to the host_ip_id property of this DbNodeSummary.
+        :type host_ip_id: str
+
+        :param backup_ip_id:
+            The value to assign to the backup_ip_id property of this DbNodeSummary.
+        :type backup_ip_id: str
+
+        :param vnic2_id:
+            The value to assign to the vnic2_id property of this DbNodeSummary.
+        :type vnic2_id: str
+
+        :param backup_vnic2_id:
+            The value to assign to the backup_vnic2_id property of this DbNodeSummary.
+        :type backup_vnic2_id: str
+
         :param lifecycle_state:
             The value to assign to the lifecycle_state property of this DbNodeSummary.
             Allowed values for this property are: "PROVISIONING", "AVAILABLE", "UPDATING", "STOPPING", "STOPPED", "STARTING", "TERMINATING", "TERMINATED", "FAILED", 'UNKNOWN_ENUM_VALUE'.
@@ -126,6 +142,10 @@ class DbNodeSummary(object):
             'db_system_id': 'str',
             'vnic_id': 'str',
             'backup_vnic_id': 'str',
+            'host_ip_id': 'str',
+            'backup_ip_id': 'str',
+            'vnic2_id': 'str',
+            'backup_vnic2_id': 'str',
             'lifecycle_state': 'str',
             'hostname': 'str',
             'fault_domain': 'str',
@@ -142,6 +162,10 @@ class DbNodeSummary(object):
             'db_system_id': 'dbSystemId',
             'vnic_id': 'vnicId',
             'backup_vnic_id': 'backupVnicId',
+            'host_ip_id': 'hostIpId',
+            'backup_ip_id': 'backupIpId',
+            'vnic2_id': 'vnic2Id',
+            'backup_vnic2_id': 'backupVnic2Id',
             'lifecycle_state': 'lifecycleState',
             'hostname': 'hostname',
             'fault_domain': 'faultDomain',
@@ -157,6 +181,10 @@ class DbNodeSummary(object):
         self._db_system_id = None
         self._vnic_id = None
         self._backup_vnic_id = None
+        self._host_ip_id = None
+        self._backup_ip_id = None
+        self._vnic2_id = None
+        self._backup_vnic2_id = None
         self._lifecycle_state = None
         self._hostname = None
         self._fault_domain = None
@@ -278,6 +306,134 @@ class DbNodeSummary(object):
         :type: str
         """
         self._backup_vnic_id = backup_vnic_id
+
+    @property
+    def host_ip_id(self):
+        """
+        Gets the host_ip_id of this DbNodeSummary.
+        The `OCID`__ of the host IP address associated with the database node.
+
+        **Note:** Applies only to Exadata Cloud Service.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The host_ip_id of this DbNodeSummary.
+        :rtype: str
+        """
+        return self._host_ip_id
+
+    @host_ip_id.setter
+    def host_ip_id(self, host_ip_id):
+        """
+        Sets the host_ip_id of this DbNodeSummary.
+        The `OCID`__ of the host IP address associated with the database node.
+
+        **Note:** Applies only to Exadata Cloud Service.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param host_ip_id: The host_ip_id of this DbNodeSummary.
+        :type: str
+        """
+        self._host_ip_id = host_ip_id
+
+    @property
+    def backup_ip_id(self):
+        """
+        Gets the backup_ip_id of this DbNodeSummary.
+        The `OCID`__ of the backup IP address associated with the database node.
+
+        **Note:** Applies only to Exadata Cloud Service.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The backup_ip_id of this DbNodeSummary.
+        :rtype: str
+        """
+        return self._backup_ip_id
+
+    @backup_ip_id.setter
+    def backup_ip_id(self, backup_ip_id):
+        """
+        Sets the backup_ip_id of this DbNodeSummary.
+        The `OCID`__ of the backup IP address associated with the database node.
+
+        **Note:** Applies only to Exadata Cloud Service.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param backup_ip_id: The backup_ip_id of this DbNodeSummary.
+        :type: str
+        """
+        self._backup_ip_id = backup_ip_id
+
+    @property
+    def vnic2_id(self):
+        """
+        Gets the vnic2_id of this DbNodeSummary.
+        The `OCID`__ of the second VNIC.
+
+        **Note:** Applies only to Exadata Cloud Service.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The vnic2_id of this DbNodeSummary.
+        :rtype: str
+        """
+        return self._vnic2_id
+
+    @vnic2_id.setter
+    def vnic2_id(self, vnic2_id):
+        """
+        Sets the vnic2_id of this DbNodeSummary.
+        The `OCID`__ of the second VNIC.
+
+        **Note:** Applies only to Exadata Cloud Service.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param vnic2_id: The vnic2_id of this DbNodeSummary.
+        :type: str
+        """
+        self._vnic2_id = vnic2_id
+
+    @property
+    def backup_vnic2_id(self):
+        """
+        Gets the backup_vnic2_id of this DbNodeSummary.
+        The `OCID`__ of the second backup VNIC.
+
+        **Note:** Applies only to Exadata Cloud Service.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :return: The backup_vnic2_id of this DbNodeSummary.
+        :rtype: str
+        """
+        return self._backup_vnic2_id
+
+    @backup_vnic2_id.setter
+    def backup_vnic2_id(self, backup_vnic2_id):
+        """
+        Sets the backup_vnic2_id of this DbNodeSummary.
+        The `OCID`__ of the second backup VNIC.
+
+        **Note:** Applies only to Exadata Cloud Service.
+
+        __ https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm
+
+
+        :param backup_vnic2_id: The backup_vnic2_id of this DbNodeSummary.
+        :type: str
+        """
+        self._backup_vnic2_id = backup_vnic2_id
 
     @property
     def lifecycle_state(self):

--- a/src/oci/mysql/db_backups_client.py
+++ b/src/oci/mysql/db_backups_client.py
@@ -86,6 +86,108 @@ class DbBackupsClient(object):
         self.base_client = BaseClient("db_backups", config, signer, mysql_type_mapping, **base_client_init_kwargs)
         self.retry_strategy = kwargs.get('retry_strategy')
 
+    def change_backup_compartment(self, backup_id, change_backup_compartment_details, **kwargs):
+        """
+        Moves a DB System Backup into a different compartment.
+        When provided, If-Match is checked against ETag values of the Backup.
+
+
+        :param str backup_id: (required)
+            The OCID of the Backup
+
+        :param oci.mysql.models.ChangeBackupCompartmentDetails change_backup_compartment_details: (required)
+            Target compartment for a DB System Backup.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call for a
+            resource, set the `If-Match` header to the value of the etag from a
+            previous GET or POST response for that resource. The resource will be
+            updated or deleted only if the etag you provide matches the resource's
+            current etag value.
+
+        :param str opc_request_id: (optional)
+            Customer-defined unique identifier for the request. If you need to
+            contact Oracle about a specific request, please provide the request
+            ID that you supplied in this header with the request.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case
+            of a timeout or server error without risk of executing that same action
+            again. Retry tokens expire after 24 hours, but can be invalidated before
+            then due to conflicting operations (for example, if a resource has been
+            deleted and purged from the system, then a retry of the original
+            creation request may be rejected).
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://docs.oracle.com/en-us/iaas/tools/python/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type None
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/mysql/change_backup_compartment.py.html>`__ to see an example of how to use change_backup_compartment API.
+        """
+        resource_path = "/backups/{backupId}/actions/changeCompartment"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "if_match",
+            "opc_request_id",
+            "opc_retry_token"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "change_backup_compartment got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "backupId": backup_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing),
+            "opc-retry-token": kwargs.get("opc_retry_token", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_backup_compartment_details)
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=change_backup_compartment_details)
+
     def create_backup(self, create_backup_details, **kwargs):
         """
         Create a backup of a DB System.

--- a/src/oci/mysql/db_backups_client_composite_operations.py
+++ b/src/oci/mysql/db_backups_client_composite_operations.py
@@ -23,6 +23,47 @@ class DbBackupsClientCompositeOperations(object):
         """
         self.client = client
 
+    def change_backup_compartment_and_wait_for_state(self, backup_id, change_backup_compartment_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.mysql.DbBackupsClient.change_backup_compartment` and waits for the :py:class:`~oci.mysql.models.WorkRequest`
+        to enter the given state(s).
+
+        :param str backup_id: (required)
+            The OCID of the Backup
+
+        :param oci.mysql.models.ChangeBackupCompartmentDetails change_backup_compartment_details: (required)
+            Target compartment for a DB System Backup.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.mysql.models.WorkRequest.status`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.mysql.DbBackupsClient.change_backup_compartment`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.change_backup_compartment(backup_id, change_backup_compartment_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_work_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def create_backup_and_wait_for_state(self, create_backup_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.mysql.DbBackupsClient.create_backup` and waits for the :py:class:`~oci.mysql.models.WorkRequest`

--- a/src/oci/mysql/models/__init__.py
+++ b/src/oci/mysql/models/__init__.py
@@ -16,6 +16,7 @@ from .backup import Backup
 from .backup_policy import BackupPolicy
 from .backup_summary import BackupSummary
 from .ca_certificate import CaCertificate
+from .change_backup_compartment_details import ChangeBackupCompartmentDetails
 from .channel import Channel
 from .channel_source import ChannelSource
 from .channel_source_mysql import ChannelSourceMysql
@@ -93,6 +94,7 @@ mysql_type_mapping = {
     "BackupPolicy": BackupPolicy,
     "BackupSummary": BackupSummary,
     "CaCertificate": CaCertificate,
+    "ChangeBackupCompartmentDetails": ChangeBackupCompartmentDetails,
     "Channel": Channel,
     "ChannelSource": ChannelSource,
     "ChannelSourceMysql": ChannelSourceMysql,

--- a/src/oci/mysql/models/change_backup_compartment_details.py
+++ b/src/oci/mysql/models/change_backup_compartment_details.py
@@ -1,0 +1,70 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ChangeBackupCompartmentDetails(object):
+    """
+    OCID of the target compartment for DB System Backup change compartment request.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ChangeBackupCompartmentDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param compartment_id:
+            The value to assign to the compartment_id property of this ChangeBackupCompartmentDetails.
+        :type compartment_id: str
+
+        """
+        self.swagger_types = {
+            'compartment_id': 'str'
+        }
+
+        self.attribute_map = {
+            'compartment_id': 'compartmentId'
+        }
+
+        self._compartment_id = None
+
+    @property
+    def compartment_id(self):
+        """
+        **[Required]** Gets the compartment_id of this ChangeBackupCompartmentDetails.
+        OCID of the target compartment.
+
+
+        :return: The compartment_id of this ChangeBackupCompartmentDetails.
+        :rtype: str
+        """
+        return self._compartment_id
+
+    @compartment_id.setter
+    def compartment_id(self, compartment_id):
+        """
+        Sets the compartment_id of this ChangeBackupCompartmentDetails.
+        OCID of the target compartment.
+
+
+        :param compartment_id: The compartment_id of this ChangeBackupCompartmentDetails.
+        :type: str
+        """
+        self._compartment_id = compartment_id
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/version.py
+++ b/src/oci/version.py
@@ -2,4 +2,4 @@
 # Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
 # This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 
-__version__ = "2.43.1"
+__version__ = "2.43.2"


### PR DESCRIPTION
## Added

* Support for manually copying volume group backups across regions in the Block Volume service

* Support for work requests for the copy volume backup and copy boot volume backup operations in the Block Volume service

* Support for specifying external Hive metastores during application creation in the Data Flow service

* Support for changing the compartment of a backup in the MySQL Database service

* Support for model catalog features including provenance, metadata, schemas, and artifact introspection in the Data Science service

* Support for Exadata system network bonding in the Database service

* Support for creating autonomous databases with early patching enabled in the Database service