### PR TITLE
Releasing version 2.44.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 ====================
+2.44.0 - 2021-08-17
+====================
+
+Added
+-----
+* Support for getting management agent hosts which are eligible to create Operations Insights host resources on, in the Operations Insights service
+* Support for getting summarized agent counts and summarized plugin counts in the Management Agent Cloud service
+
+Breaking
+--------
+* Model `WorkSubmissionKey` was removed from Management Agent Cloud service
+* Type for parameter `plugin_name` changed to `list[str]` from `str` in operation `list_management_agent_plugins` in the Management Agent Cloud Service
+* Type for parameter `version` changed to `list[str]` from `str` in operation `list_management_agent_plugins` in the Management Agent Cloud Service
+* Type for parameter `platform_type` changed to `list[str]` from `str` in operation `list_management_agent_plugins` in the Management Agent Cloud Service
+
+====================
 2.43.2 - 2021-08-03
 ====================
 

--- a/docs/api/management_agent.rst
+++ b/docs/api/management_agent.rst
@@ -22,12 +22,18 @@ Management Agent
     oci.management_agent.models.CreateManagementAgentInstallKeyDetails
     oci.management_agent.models.DeployPluginsDetails
     oci.management_agent.models.ManagementAgent
+    oci.management_agent.models.ManagementAgentAggregation
+    oci.management_agent.models.ManagementAgentAggregationCollection
+    oci.management_agent.models.ManagementAgentAggregationDimensions
     oci.management_agent.models.ManagementAgentError
     oci.management_agent.models.ManagementAgentImage
     oci.management_agent.models.ManagementAgentImageSummary
     oci.management_agent.models.ManagementAgentInstallKey
     oci.management_agent.models.ManagementAgentInstallKeySummary
     oci.management_agent.models.ManagementAgentPlugin
+    oci.management_agent.models.ManagementAgentPluginAggregation
+    oci.management_agent.models.ManagementAgentPluginAggregationCollection
+    oci.management_agent.models.ManagementAgentPluginAggregationDimensions
     oci.management_agent.models.ManagementAgentPluginDetails
     oci.management_agent.models.ManagementAgentPluginSummary
     oci.management_agent.models.ManagementAgentSummary
@@ -38,4 +44,3 @@ Management Agent
     oci.management_agent.models.WorkRequestLogEntry
     oci.management_agent.models.WorkRequestResource
     oci.management_agent.models.WorkRequestSummary
-    oci.management_agent.models.WorkSubmissionKey

--- a/docs/api/management_agent/models/oci.management_agent.models.ManagementAgentAggregation.rst
+++ b/docs/api/management_agent/models/oci.management_agent.models.ManagementAgentAggregation.rst
@@ -1,0 +1,11 @@
+ManagementAgentAggregation
+==========================
+
+.. currentmodule:: oci.management_agent.models
+
+.. autoclass:: ManagementAgentAggregation
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/management_agent/models/oci.management_agent.models.ManagementAgentAggregationCollection.rst
+++ b/docs/api/management_agent/models/oci.management_agent.models.ManagementAgentAggregationCollection.rst
@@ -1,0 +1,11 @@
+ManagementAgentAggregationCollection
+====================================
+
+.. currentmodule:: oci.management_agent.models
+
+.. autoclass:: ManagementAgentAggregationCollection
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/management_agent/models/oci.management_agent.models.ManagementAgentAggregationDimensions.rst
+++ b/docs/api/management_agent/models/oci.management_agent.models.ManagementAgentAggregationDimensions.rst
@@ -1,0 +1,11 @@
+ManagementAgentAggregationDimensions
+====================================
+
+.. currentmodule:: oci.management_agent.models
+
+.. autoclass:: ManagementAgentAggregationDimensions
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/management_agent/models/oci.management_agent.models.ManagementAgentPluginAggregation.rst
+++ b/docs/api/management_agent/models/oci.management_agent.models.ManagementAgentPluginAggregation.rst
@@ -1,0 +1,11 @@
+ManagementAgentPluginAggregation
+================================
+
+.. currentmodule:: oci.management_agent.models
+
+.. autoclass:: ManagementAgentPluginAggregation
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/management_agent/models/oci.management_agent.models.ManagementAgentPluginAggregationCollection.rst
+++ b/docs/api/management_agent/models/oci.management_agent.models.ManagementAgentPluginAggregationCollection.rst
@@ -1,9 +1,9 @@
-WorkSubmissionKey
-=================
+ManagementAgentPluginAggregationCollection
+==========================================
 
 .. currentmodule:: oci.management_agent.models
 
-.. autoclass:: WorkSubmissionKey
+.. autoclass:: ManagementAgentPluginAggregationCollection
     :show-inheritance:
     :special-members: __init__
     :members:

--- a/docs/api/management_agent/models/oci.management_agent.models.ManagementAgentPluginAggregationDimensions.rst
+++ b/docs/api/management_agent/models/oci.management_agent.models.ManagementAgentPluginAggregationDimensions.rst
@@ -1,0 +1,11 @@
+ManagementAgentPluginAggregationDimensions
+==========================================
+
+.. currentmodule:: oci.management_agent.models
+
+.. autoclass:: ManagementAgentPluginAggregationDimensions
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/opsi.rst
+++ b/docs/api/opsi.rst
@@ -62,6 +62,7 @@ Opsi
     oci.opsi.models.HostDetails
     oci.opsi.models.HostEntities
     oci.opsi.models.HostHardwareConfiguration
+    oci.opsi.models.HostImportableAgentEntitySummary
     oci.opsi.models.HostInsight
     oci.opsi.models.HostInsightResourceStatisticsAggregation
     oci.opsi.models.HostInsightSummary
@@ -80,6 +81,8 @@ Opsi
     oci.opsi.models.HostResourceStatistics
     oci.opsi.models.HostedEntityCollection
     oci.opsi.models.HostedEntitySummary
+    oci.opsi.models.ImportableAgentEntitySummary
+    oci.opsi.models.ImportableAgentEntitySummaryCollection
     oci.opsi.models.ImportableEnterpriseManagerEntity
     oci.opsi.models.ImportableEnterpriseManagerEntityCollection
     oci.opsi.models.IngestDatabaseConfigurationDetails

--- a/docs/api/opsi/models/oci.opsi.models.HostImportableAgentEntitySummary.rst
+++ b/docs/api/opsi/models/oci.opsi.models.HostImportableAgentEntitySummary.rst
@@ -1,0 +1,11 @@
+HostImportableAgentEntitySummary
+================================
+
+.. currentmodule:: oci.opsi.models
+
+.. autoclass:: HostImportableAgentEntitySummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/opsi/models/oci.opsi.models.ImportableAgentEntitySummary.rst
+++ b/docs/api/opsi/models/oci.opsi.models.ImportableAgentEntitySummary.rst
@@ -1,0 +1,11 @@
+ImportableAgentEntitySummary
+============================
+
+.. currentmodule:: oci.opsi.models
+
+.. autoclass:: ImportableAgentEntitySummary
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/opsi/models/oci.opsi.models.ImportableAgentEntitySummaryCollection.rst
+++ b/docs/api/opsi/models/oci.opsi.models.ImportableAgentEntitySummaryCollection.rst
@@ -1,0 +1,11 @@
+ImportableAgentEntitySummaryCollection
+======================================
+
+.. currentmodule:: oci.opsi.models
+
+.. autoclass:: ImportableAgentEntitySummaryCollection
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/examples/copy_boot_volume_backup_example.py
+++ b/examples/copy_boot_volume_backup_example.py
@@ -6,7 +6,7 @@
 #
 # # USAGE:
 # `python examples/copy_boot_volume_backup_example.py  \
-#        --volume-backup-id 'foo' \
+#        --boot-volume-backup-id 'foo' \
 #        --destination-region '<destination_region>' \
 #        --display_name 'bar' \
 #        --kms-key-id 'baz'`
@@ -58,34 +58,18 @@ destination_region = args.destination_region
 kms_key_id = args.kms_key_id
 display_name = args.display_name
 
-# load config and create clients (one for the source region and one for the destination region).
+# load config and create clients one for BlockstorageClient and another for BlockstorageClientCompositeOperations.
 source_config = oci.config.from_file()
-destination_config = source_config.copy()
-destination_config["region"] = destination_region
-source_blockstorage_client = oci.core.BlockstorageClient(source_config)
-destination_blockstorage_client = oci.core.BlockstorageClient(destination_config)
-
 print('Copying boot volume backup with ID {} from {} to {} using new display name: {} and kms key id: {} \n'.format(
     source_backup_id, source_config["region"], destination_region, display_name, kms_key_id))
-result = source_blockstorage_client.copy_boot_volume_backup(
-    source_backup_id,
-    oci.core.models.CopyBootVolumeBackupDetails(
+blockstorage_client = oci.core.BlockstorageClient(source_config)
+blockstorage_composite_client = oci.core.BlockstorageClientCompositeOperations(blockstorage_client)
+copied_backup = blockstorage_composite_client.copy_boot_volume_backup_and_wait_for_work_request(
+    boot_volume_backup_id=source_backup_id,
+    copy_boot_volume_backup_details=oci.core.models.CopyBootVolumeBackupDetails(
         destination_region=destination_region,
         display_name=display_name,
         kms_key_id=kms_key_id
-    )
-)
-
-print('Copy boot volume backup response status: {}, copied backup: {}\n'.format(result.status, result.data))
-print('Waiting for the copied backup to be in available state...')
-
-# query the destination region for the copied' backup's status and wait for it to be available.
-copied_backup = oci.wait_until(
-    destination_blockstorage_client,
-    destination_blockstorage_client.get_boot_volume_backup(result.data.id),
-    'lifecycle_state',
-    'AVAILABLE'
-).data
-
+    )).data
 print('Backup successfully copied: {}'.format(copied_backup))
 print('Example script done')

--- a/examples/launch_instance_example.py
+++ b/examples/launch_instance_example.py
@@ -400,6 +400,20 @@ def launch_instance(compute_client_composite_operations, launch_instance_details
     return instance
 
 
+def launch_instance_and_wait_for_work_request(compute_client_composite_operations, launch_instance_details):
+    work_request_response = compute_client_composite_operations.launch_instance_and_wait_for_work_request(
+        launch_instance_details
+    )
+    work_request = work_request_response.data
+
+    # Now retrieve the instance details from the information in the work request resources
+    instance_id = work_request.resources[0].identifier
+    get_instance_response = compute_client_composite_operations.client.get_instance(instance_id)
+    instance = get_instance_response.data
+
+    return instance, work_request.id
+
+
 def terminate_instance(compute_client_composite_operations, instance):
     print('Terminating Instance: {}'.format(instance.id))
     compute_client_composite_operations.terminate_instance_and_wait_for_state(
@@ -436,6 +450,38 @@ def print_instance_details(compute_client, virtual_network_client, instance):
     print()
 
 
+def print_work_request_details(work_request_client, work_request_id):
+    get_work_request_response = work_request_client.get_work_request(work_request_id)
+    work_request_details = get_work_request_response.data
+
+    list_errors_response = work_request_client.list_work_request_errors(work_request_id)
+    work_request_errors = list_errors_response.data
+
+    print('Work Request Details')
+    print('====================')
+    print('{}'.format(work_request_details))
+    print()
+
+    print('Work Request Errors')
+    print('===================')
+    if len(work_request_errors) > 0:
+        print('{}'.format(work_request_errors))
+    else:
+        print('No errors occurred.')
+    print()
+
+    print('Work Request Logs')
+    print('=================')
+
+    # Limit to 20 log entries
+    log_limit = 20
+    page_size = 5
+    resp = oci.pagination.list_call_get_up_to_limit(work_request_client.list_work_request_logs, log_limit, page_size, work_request_id)
+    for work_request_log in resp.data:
+        print('{}'.format(work_request_log))
+    print()
+
+
 if __name__ == "__main__":
     if len(sys.argv) != 4:
         raise RuntimeError('Invalid number of arguments provided to the script. '
@@ -453,6 +499,7 @@ if __name__ == "__main__":
     compute_client_composite_operations = oci.core.ComputeClientCompositeOperations(compute_client)
     virtual_network_client = oci.core.VirtualNetworkClient(config)
     virtual_network_composite_operations = oci.core.VirtualNetworkClientCompositeOperations(virtual_network_client)
+    work_request_client = oci.work_requests.WorkRequestClient(config)
 
     availability_domain = get_availability_domain(identity_client, compartment_id)
     shape = get_shape(compute_client, compartment_id, availability_domain)
@@ -463,6 +510,7 @@ if __name__ == "__main__":
     internet_gateway = None
     network_security_group = None
     instance = None
+    instance_via_work_requests = None
     instance_with_network_security_group = None
 
     try:
@@ -482,6 +530,16 @@ if __name__ == "__main__":
         instance = launch_instance(compute_client_composite_operations, launch_instance_details)
         print_instance_details(compute_client, virtual_network_client, instance)
 
+        print('Launching Instance and waiting on work request ...')
+        launch_instance_details = get_launch_instance_details(
+            compartment_id, availability_domain, shape, image, subnet, ssh_public_key
+        )
+        instance_via_work_requests, work_request_id = launch_instance_and_wait_for_work_request(
+            compute_client_composite_operations, launch_instance_details
+        )
+        print_work_request_details(work_request_client, work_request_id)
+        print_instance_details(compute_client, virtual_network_client, instance_via_work_requests)
+
         print('Launching Instance with Network Security Group ...')
         launch_instance_details.create_vnic_details.nsg_ids = [network_security_group.id]
         instance_with_network_security_group = launch_instance(
@@ -492,6 +550,8 @@ if __name__ == "__main__":
     finally:
         if instance_with_network_security_group:
             terminate_instance(compute_client_composite_operations, instance_with_network_security_group)
+        if instance_via_work_requests:
+            terminate_instance(compute_client_composite_operations, instance_via_work_requests)
         if instance:
             terminate_instance(compute_client_composite_operations, instance)
 

--- a/src/oci/management_agent/management_agent_client.py
+++ b/src/oci/management_agent/management_agent_client.py
@@ -825,7 +825,7 @@ class ManagementAgentClient(object):
             The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
 
         :param str sort_order: (optional)
-            The sort order to use, either 'asc' or 'desc'.
+            The sort order to use, either 'ASC' or 'DESC'.
 
             Allowed values are: "ASC", "DESC"
 
@@ -936,7 +936,7 @@ class ManagementAgentClient(object):
 
 
         :param str compartment_id: (required)
-            The ID of the compartment from which the Management Agents to be listed.
+            The OCID of the compartment to which a request will be scoped.
 
         :param str opc_retry_token: (optional)
             A token that uniquely identifies a request so it can be retried in case of a timeout or
@@ -1074,7 +1074,7 @@ class ManagementAgentClient(object):
 
 
         :param str compartment_id: (required)
-            The ID of the compartment from which the Management Agents to be listed.
+            The OCID of the compartment to which a request will be scoped.
 
         :param bool compartment_id_in_subtree: (optional)
             if set to true then it fetches install key for all compartments where user has access to else only on the compartment specified.
@@ -1206,7 +1206,7 @@ class ManagementAgentClient(object):
 
 
         :param str compartment_id: (required)
-            The ID of the compartment from which the Management Agents to be listed.
+            The OCID of the compartment to which a request will be scoped.
 
         :param str display_name: (optional)
             Filter to return only Management Agent Plugins having the particular display name.
@@ -1235,6 +1235,11 @@ class ManagementAgentClient(object):
 
             Allowed values are: "CREATING", "UPDATING", "ACTIVE", "INACTIVE", "TERMINATED", "DELETING", "DELETED", "FAILED"
 
+        :param list[str] platform_type: (optional)
+            Filter to return only results having the particular platform type.
+
+            Allowed values are: "LINUX", "WINDOWS"
+
         :param obj retry_strategy: (optional)
             A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
 
@@ -1261,7 +1266,8 @@ class ManagementAgentClient(object):
             "sort_order",
             "sort_by",
             "opc_request_id",
-            "lifecycle_state"
+            "lifecycle_state",
+            "platform_type"
         ]
         extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
         if extra_kwargs:
@@ -1289,6 +1295,14 @@ class ManagementAgentClient(object):
                     "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
                 )
 
+        if 'platform_type' in kwargs:
+            platform_type_allowed_values = ["LINUX", "WINDOWS"]
+            for platform_type_item in kwargs['platform_type']:
+                if platform_type_item not in platform_type_allowed_values:
+                    raise ValueError(
+                        "Invalid value for `platform_type`, must be one of {0}".format(platform_type_allowed_values)
+                    )
+
         query_params = {
             "compartmentId": compartment_id,
             "displayName": kwargs.get("display_name", missing),
@@ -1296,7 +1310,8 @@ class ManagementAgentClient(object):
             "page": kwargs.get("page", missing),
             "sortOrder": kwargs.get("sort_order", missing),
             "sortBy": kwargs.get("sort_by", missing),
-            "lifecycleState": kwargs.get("lifecycle_state", missing)
+            "lifecycleState": kwargs.get("lifecycle_state", missing),
+            "platformType": self.base_client.generate_collection_format_param(kwargs.get("platform_type", missing), 'multi')
         }
         query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
 
@@ -1333,12 +1348,12 @@ class ManagementAgentClient(object):
 
 
         :param str compartment_id: (required)
-            The ID of the compartment from which the Management Agents to be listed.
+            The OCID of the compartment to which a request will be scoped.
 
-        :param str plugin_name: (optional)
-            Filter to return only Management Agents having the particular Plugin installed.
+        :param list[str] plugin_name: (optional)
+            Filter to return only Management Agents having the particular Plugin installed. A special pluginName of 'None' can be provided and this will return only Management Agents having no plugin installed.
 
-        :param str version: (optional)
+        :param list[str] version: (optional)
             Filter to return only Management Agents having the particular agent version.
 
         :param str display_name: (optional)
@@ -1349,10 +1364,21 @@ class ManagementAgentClient(object):
 
             Allowed values are: "CREATING", "UPDATING", "ACTIVE", "INACTIVE", "TERMINATED", "DELETING", "DELETED", "FAILED"
 
-        :param str platform_type: (optional)
-            Filter to return only Management Agents having the particular platform type.
+        :param str availability_status: (optional)
+            Filter to return only Management Agents in the particular availability status.
+
+            Allowed values are: "ACTIVE", "SILENT", "NOT_AVAILABLE"
+
+        :param str host_id: (optional)
+            Filter to return only Management Agents having the particular agent host id.
+
+        :param list[str] platform_type: (optional)
+            Filter to return only results having the particular platform type.
 
             Allowed values are: "LINUX", "WINDOWS"
+
+        :param bool is_customer_deployed: (optional)
+            true, if the agent image is manually downloaded and installed. false, if the agent is deployed as a plugin in Oracle Cloud Agent.
 
         :param int limit: (optional)
             The maximum number of items to return.
@@ -1368,7 +1394,7 @@ class ManagementAgentClient(object):
         :param str sort_by: (optional)
             The field to sort by. Only one sort order may be provided. Default order for timeCreated is descending. Default order for displayName is ascending. If no value is specified timeCreated is default.
 
-            Allowed values are: "timeCreated", "displayName"
+            Allowed values are: "timeCreated", "displayName", "host", "availabilityStatus", "platformType", "pluginDisplayNames", "version"
 
         :param str opc_request_id: (optional)
             The client request ID for tracing.
@@ -1397,7 +1423,10 @@ class ManagementAgentClient(object):
             "version",
             "display_name",
             "lifecycle_state",
+            "availability_status",
+            "host_id",
             "platform_type",
+            "is_customer_deployed",
             "limit",
             "page",
             "sort_order",
@@ -1416,12 +1445,20 @@ class ManagementAgentClient(object):
                     "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
                 )
 
+        if 'availability_status' in kwargs:
+            availability_status_allowed_values = ["ACTIVE", "SILENT", "NOT_AVAILABLE"]
+            if kwargs['availability_status'] not in availability_status_allowed_values:
+                raise ValueError(
+                    "Invalid value for `availability_status`, must be one of {0}".format(availability_status_allowed_values)
+                )
+
         if 'platform_type' in kwargs:
             platform_type_allowed_values = ["LINUX", "WINDOWS"]
-            if kwargs['platform_type'] not in platform_type_allowed_values:
-                raise ValueError(
-                    "Invalid value for `platform_type`, must be one of {0}".format(platform_type_allowed_values)
-                )
+            for platform_type_item in kwargs['platform_type']:
+                if platform_type_item not in platform_type_allowed_values:
+                    raise ValueError(
+                        "Invalid value for `platform_type`, must be one of {0}".format(platform_type_allowed_values)
+                    )
 
         if 'sort_order' in kwargs:
             sort_order_allowed_values = ["ASC", "DESC"]
@@ -1431,7 +1468,7 @@ class ManagementAgentClient(object):
                 )
 
         if 'sort_by' in kwargs:
-            sort_by_allowed_values = ["timeCreated", "displayName"]
+            sort_by_allowed_values = ["timeCreated", "displayName", "host", "availabilityStatus", "platformType", "pluginDisplayNames", "version"]
             if kwargs['sort_by'] not in sort_by_allowed_values:
                 raise ValueError(
                     "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
@@ -1439,11 +1476,14 @@ class ManagementAgentClient(object):
 
         query_params = {
             "compartmentId": compartment_id,
-            "pluginName": kwargs.get("plugin_name", missing),
-            "version": kwargs.get("version", missing),
+            "pluginName": self.base_client.generate_collection_format_param(kwargs.get("plugin_name", missing), 'multi'),
+            "version": self.base_client.generate_collection_format_param(kwargs.get("version", missing), 'multi'),
             "displayName": kwargs.get("display_name", missing),
             "lifecycleState": kwargs.get("lifecycle_state", missing),
-            "platformType": kwargs.get("platform_type", missing),
+            "availabilityStatus": kwargs.get("availability_status", missing),
+            "hostId": kwargs.get("host_id", missing),
+            "platformType": self.base_client.generate_collection_format_param(kwargs.get("platform_type", missing), 'multi'),
+            "isCustomerDeployed": kwargs.get("is_customer_deployed", missing),
             "limit": kwargs.get("limit", missing),
             "page": kwargs.get("page", missing),
             "sortOrder": kwargs.get("sort_order", missing),
@@ -1722,7 +1762,7 @@ class ManagementAgentClient(object):
 
 
         :param str compartment_id: (required)
-            The ID of the compartment from which the Management Agents to be listed.
+            The OCID of the compartment to which a request will be scoped.
 
         :param str agent_id: (optional)
             The ManagementAgentID of the agent from which the Management Agents to be filtered.
@@ -1849,6 +1889,188 @@ class ManagementAgentClient(object):
                 query_params=query_params,
                 header_params=header_params,
                 response_type="list[WorkRequestSummary]")
+
+    def summarize_management_agent_counts(self, compartment_id, group_by, **kwargs):
+        """
+        Gets count of the inventory of agents for a given compartment id, group by, and isPluginDeployed parameters.
+        Supported groupBy parameters: availabilityStatus, platformType, version
+
+
+        :param str compartment_id: (required)
+            The OCID of the compartment to which a request will be scoped.
+
+        :param oci.management_agent.models.list[str] group_by: (required)
+            The field by which to group Management Agents. Currently, only one groupBy dimension is supported at a time.
+
+            Allowed values are: "availabilityStatus", "platformType", "version"
+
+        :param bool has_plugins: (optional)
+            When set to true then agents that have at least one plugin deployed will be returned. When set to false only agents that have no plugins deployed will be returned.
+
+        :param str page: (optional)
+            The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://docs.oracle.com/en-us/iaas/tools/python/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.management_agent.models.ManagementAgentAggregationCollection`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/managementagent/summarize_management_agent_counts.py.html>`__ to see an example of how to use summarize_management_agent_counts API.
+        """
+        resource_path = "/managementAgentCounts"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "has_plugins",
+            "page",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "summarize_management_agent_counts got unknown kwargs: {!r}".format(extra_kwargs))
+
+        group_by_allowed_values = ["availabilityStatus", "platformType", "version"]
+        for group_by_item in group_by:
+            if group_by_item not in group_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `group_by`, must be one of {0}".format(group_by_allowed_values)
+                )
+
+        query_params = {
+            "compartmentId": compartment_id,
+            "groupBy": self.base_client.generate_collection_format_param(group_by, 'multi'),
+            "hasPlugins": kwargs.get("has_plugins", missing),
+            "page": kwargs.get("page", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="ManagementAgentAggregationCollection")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="ManagementAgentAggregationCollection")
+
+    def summarize_management_agent_plugin_counts(self, compartment_id, group_by, **kwargs):
+        """
+        Gets count of the inventory of management agent plugins for a given compartment id and group by parameter.
+        Supported groupBy parameter: pluginName
+
+
+        :param str compartment_id: (required)
+            The OCID of the compartment to which a request will be scoped.
+
+        :param str group_by: (required)
+            The field by which to group Management Agent Plugins
+
+            Allowed values are: "pluginName"
+
+        :param str page: (optional)
+            The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://docs.oracle.com/en-us/iaas/tools/python/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.management_agent.models.ManagementAgentPluginAggregationCollection`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/managementagent/summarize_management_agent_plugin_counts.py.html>`__ to see an example of how to use summarize_management_agent_plugin_counts API.
+        """
+        resource_path = "/managementAgentPluginCounts"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "page",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "summarize_management_agent_plugin_counts got unknown kwargs: {!r}".format(extra_kwargs))
+
+        group_by_allowed_values = ["pluginName"]
+        if group_by not in group_by_allowed_values:
+            raise ValueError(
+                "Invalid value for `group_by`, must be one of {0}".format(group_by_allowed_values)
+            )
+
+        query_params = {
+            "compartmentId": compartment_id,
+            "groupBy": group_by,
+            "page": kwargs.get("page", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="ManagementAgentPluginAggregationCollection")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="ManagementAgentPluginAggregationCollection")
 
     def update_management_agent(self, management_agent_id, update_management_agent_details, **kwargs):
         """

--- a/src/oci/management_agent/models/__init__.py
+++ b/src/oci/management_agent/models/__init__.py
@@ -8,12 +8,18 @@ from .availability_history_summary import AvailabilityHistorySummary
 from .create_management_agent_install_key_details import CreateManagementAgentInstallKeyDetails
 from .deploy_plugins_details import DeployPluginsDetails
 from .management_agent import ManagementAgent
+from .management_agent_aggregation import ManagementAgentAggregation
+from .management_agent_aggregation_collection import ManagementAgentAggregationCollection
+from .management_agent_aggregation_dimensions import ManagementAgentAggregationDimensions
 from .management_agent_error import ManagementAgentError
 from .management_agent_image import ManagementAgentImage
 from .management_agent_image_summary import ManagementAgentImageSummary
 from .management_agent_install_key import ManagementAgentInstallKey
 from .management_agent_install_key_summary import ManagementAgentInstallKeySummary
 from .management_agent_plugin import ManagementAgentPlugin
+from .management_agent_plugin_aggregation import ManagementAgentPluginAggregation
+from .management_agent_plugin_aggregation_collection import ManagementAgentPluginAggregationCollection
+from .management_agent_plugin_aggregation_dimensions import ManagementAgentPluginAggregationDimensions
 from .management_agent_plugin_details import ManagementAgentPluginDetails
 from .management_agent_plugin_summary import ManagementAgentPluginSummary
 from .management_agent_summary import ManagementAgentSummary
@@ -24,7 +30,6 @@ from .work_request_error import WorkRequestError
 from .work_request_log_entry import WorkRequestLogEntry
 from .work_request_resource import WorkRequestResource
 from .work_request_summary import WorkRequestSummary
-from .work_submission_key import WorkSubmissionKey
 
 # Maps type names to classes for management_agent services.
 management_agent_type_mapping = {
@@ -32,12 +37,18 @@ management_agent_type_mapping = {
     "CreateManagementAgentInstallKeyDetails": CreateManagementAgentInstallKeyDetails,
     "DeployPluginsDetails": DeployPluginsDetails,
     "ManagementAgent": ManagementAgent,
+    "ManagementAgentAggregation": ManagementAgentAggregation,
+    "ManagementAgentAggregationCollection": ManagementAgentAggregationCollection,
+    "ManagementAgentAggregationDimensions": ManagementAgentAggregationDimensions,
     "ManagementAgentError": ManagementAgentError,
     "ManagementAgentImage": ManagementAgentImage,
     "ManagementAgentImageSummary": ManagementAgentImageSummary,
     "ManagementAgentInstallKey": ManagementAgentInstallKey,
     "ManagementAgentInstallKeySummary": ManagementAgentInstallKeySummary,
     "ManagementAgentPlugin": ManagementAgentPlugin,
+    "ManagementAgentPluginAggregation": ManagementAgentPluginAggregation,
+    "ManagementAgentPluginAggregationCollection": ManagementAgentPluginAggregationCollection,
+    "ManagementAgentPluginAggregationDimensions": ManagementAgentPluginAggregationDimensions,
     "ManagementAgentPluginDetails": ManagementAgentPluginDetails,
     "ManagementAgentPluginSummary": ManagementAgentPluginSummary,
     "ManagementAgentSummary": ManagementAgentSummary,
@@ -47,6 +58,5 @@ management_agent_type_mapping = {
     "WorkRequestError": WorkRequestError,
     "WorkRequestLogEntry": WorkRequestLogEntry,
     "WorkRequestResource": WorkRequestResource,
-    "WorkRequestSummary": WorkRequestSummary,
-    "WorkSubmissionKey": WorkSubmissionKey
+    "WorkRequestSummary": WorkRequestSummary
 }

--- a/src/oci/management_agent/models/management_agent.py
+++ b/src/oci/management_agent/models/management_agent.py
@@ -104,6 +104,10 @@ class ManagementAgent(object):
             The value to assign to the host property of this ManagementAgent.
         :type host: str
 
+        :param host_id:
+            The value to assign to the host_id property of this ManagementAgent.
+        :type host_id: str
+
         :param install_path:
             The value to assign to the install_path property of this ManagementAgent.
         :type install_path: str
@@ -148,6 +152,10 @@ class ManagementAgent(object):
             The value to assign to the lifecycle_details property of this ManagementAgent.
         :type lifecycle_details: str
 
+        :param is_customer_deployed:
+            The value to assign to the is_customer_deployed property of this ManagementAgent.
+        :type is_customer_deployed: bool
+
         :param freeform_tags:
             The value to assign to the freeform_tags property of this ManagementAgent.
         :type freeform_tags: dict(str, str)
@@ -166,6 +174,7 @@ class ManagementAgent(object):
             'platform_version': 'str',
             'version': 'str',
             'host': 'str',
+            'host_id': 'str',
             'install_path': 'str',
             'plugin_list': 'list[ManagementAgentPluginDetails]',
             'compartment_id': 'str',
@@ -176,6 +185,7 @@ class ManagementAgent(object):
             'availability_status': 'str',
             'lifecycle_state': 'str',
             'lifecycle_details': 'str',
+            'is_customer_deployed': 'bool',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))'
         }
@@ -189,6 +199,7 @@ class ManagementAgent(object):
             'platform_version': 'platformVersion',
             'version': 'version',
             'host': 'host',
+            'host_id': 'hostId',
             'install_path': 'installPath',
             'plugin_list': 'pluginList',
             'compartment_id': 'compartmentId',
@@ -199,6 +210,7 @@ class ManagementAgent(object):
             'availability_status': 'availabilityStatus',
             'lifecycle_state': 'lifecycleState',
             'lifecycle_details': 'lifecycleDetails',
+            'is_customer_deployed': 'isCustomerDeployed',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags'
         }
@@ -211,6 +223,7 @@ class ManagementAgent(object):
         self._platform_version = None
         self._version = None
         self._host = None
+        self._host_id = None
         self._install_path = None
         self._plugin_list = None
         self._compartment_id = None
@@ -221,6 +234,7 @@ class ManagementAgent(object):
         self._availability_status = None
         self._lifecycle_state = None
         self._lifecycle_details = None
+        self._is_customer_deployed = None
         self._freeform_tags = None
         self._defined_tags = None
 
@@ -423,6 +437,30 @@ class ManagementAgent(object):
         self._host = host
 
     @property
+    def host_id(self):
+        """
+        Gets the host_id of this ManagementAgent.
+        Host resource ocid
+
+
+        :return: The host_id of this ManagementAgent.
+        :rtype: str
+        """
+        return self._host_id
+
+    @host_id.setter
+    def host_id(self, host_id):
+        """
+        Sets the host_id of this ManagementAgent.
+        Host resource ocid
+
+
+        :param host_id: The host_id of this ManagementAgent.
+        :type: str
+        """
+        self._host_id = host_id
+
+    @property
     def install_path(self):
         """
         Gets the install_path of this ManagementAgent.
@@ -498,7 +536,7 @@ class ManagementAgent(object):
     def is_agent_auto_upgradable(self):
         """
         Gets the is_agent_auto_upgradable of this ManagementAgent.
-        true if the agent can be upgraded automatically; false if it must be upgraded manually. true is currently unsupported.
+        true if the agent can be upgraded automatically; false if it must be upgraded manually.
 
 
         :return: The is_agent_auto_upgradable of this ManagementAgent.
@@ -510,7 +548,7 @@ class ManagementAgent(object):
     def is_agent_auto_upgradable(self, is_agent_auto_upgradable):
         """
         Sets the is_agent_auto_upgradable of this ManagementAgent.
-        true if the agent can be upgraded automatically; false if it must be upgraded manually. true is currently unsupported.
+        true if the agent can be upgraded automatically; false if it must be upgraded manually.
 
 
         :param is_agent_auto_upgradable: The is_agent_auto_upgradable of this ManagementAgent.
@@ -673,6 +711,30 @@ class ManagementAgent(object):
         :type: str
         """
         self._lifecycle_details = lifecycle_details
+
+    @property
+    def is_customer_deployed(self):
+        """
+        Gets the is_customer_deployed of this ManagementAgent.
+        true, if the agent image is manually downloaded and installed. false, if the agent is deployed as a plugin in Oracle Cloud Agent.
+
+
+        :return: The is_customer_deployed of this ManagementAgent.
+        :rtype: bool
+        """
+        return self._is_customer_deployed
+
+    @is_customer_deployed.setter
+    def is_customer_deployed(self, is_customer_deployed):
+        """
+        Sets the is_customer_deployed of this ManagementAgent.
+        true, if the agent image is manually downloaded and installed. false, if the agent is deployed as a plugin in Oracle Cloud Agent.
+
+
+        :param is_customer_deployed: The is_customer_deployed of this ManagementAgent.
+        :type: bool
+        """
+        self._is_customer_deployed = is_customer_deployed
 
     @property
     def freeform_tags(self):

--- a/src/oci/management_agent/models/management_agent_aggregation.py
+++ b/src/oci/management_agent/models/management_agent_aggregation.py
@@ -1,0 +1,97 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ManagementAgentAggregation(object):
+    """
+    A count of Management Agents sharing the values for specified dimensions.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ManagementAgentAggregation object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param dimensions:
+            The value to assign to the dimensions property of this ManagementAgentAggregation.
+        :type dimensions: oci.management_agent.models.ManagementAgentAggregationDimensions
+
+        :param count:
+            The value to assign to the count property of this ManagementAgentAggregation.
+        :type count: int
+
+        """
+        self.swagger_types = {
+            'dimensions': 'ManagementAgentAggregationDimensions',
+            'count': 'int'
+        }
+
+        self.attribute_map = {
+            'dimensions': 'dimensions',
+            'count': 'count'
+        }
+
+        self._dimensions = None
+        self._count = None
+
+    @property
+    def dimensions(self):
+        """
+        Gets the dimensions of this ManagementAgentAggregation.
+
+        :return: The dimensions of this ManagementAgentAggregation.
+        :rtype: oci.management_agent.models.ManagementAgentAggregationDimensions
+        """
+        return self._dimensions
+
+    @dimensions.setter
+    def dimensions(self, dimensions):
+        """
+        Sets the dimensions of this ManagementAgentAggregation.
+
+        :param dimensions: The dimensions of this ManagementAgentAggregation.
+        :type: oci.management_agent.models.ManagementAgentAggregationDimensions
+        """
+        self._dimensions = dimensions
+
+    @property
+    def count(self):
+        """
+        Gets the count of this ManagementAgentAggregation.
+        The number of Management Agents in this group
+
+
+        :return: The count of this ManagementAgentAggregation.
+        :rtype: int
+        """
+        return self._count
+
+    @count.setter
+    def count(self, count):
+        """
+        Sets the count of this ManagementAgentAggregation.
+        The number of Management Agents in this group
+
+
+        :param count: The count of this ManagementAgentAggregation.
+        :type: int
+        """
+        self._count = count
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/management_agent/models/management_agent_aggregation_collection.py
+++ b/src/oci/management_agent/models/management_agent_aggregation_collection.py
@@ -1,0 +1,70 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ManagementAgentAggregationCollection(object):
+    """
+    The summary of Management Agent count items
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ManagementAgentAggregationCollection object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param items:
+            The value to assign to the items property of this ManagementAgentAggregationCollection.
+        :type items: list[oci.management_agent.models.ManagementAgentAggregation]
+
+        """
+        self.swagger_types = {
+            'items': 'list[ManagementAgentAggregation]'
+        }
+
+        self.attribute_map = {
+            'items': 'items'
+        }
+
+        self._items = None
+
+    @property
+    def items(self):
+        """
+        **[Required]** Gets the items of this ManagementAgentAggregationCollection.
+        List in which each item describes an aggregation of Managment Agents
+
+
+        :return: The items of this ManagementAgentAggregationCollection.
+        :rtype: list[oci.management_agent.models.ManagementAgentAggregation]
+        """
+        return self._items
+
+    @items.setter
+    def items(self, items):
+        """
+        Sets the items of this ManagementAgentAggregationCollection.
+        List in which each item describes an aggregation of Managment Agents
+
+
+        :param items: The items of this ManagementAgentAggregationCollection.
+        :type: list[oci.management_agent.models.ManagementAgentAggregation]
+        """
+        self._items = items
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/management_agent/models/management_agent_aggregation_dimensions.py
+++ b/src/oci/management_agent/models/management_agent_aggregation_dimensions.py
@@ -1,0 +1,199 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ManagementAgentAggregationDimensions(object):
+    """
+    The Aggregation of Management Agent Dimensions
+    """
+
+    #: A constant which can be used with the availability_status property of a ManagementAgentAggregationDimensions.
+    #: This constant has a value of "ACTIVE"
+    AVAILABILITY_STATUS_ACTIVE = "ACTIVE"
+
+    #: A constant which can be used with the availability_status property of a ManagementAgentAggregationDimensions.
+    #: This constant has a value of "SILENT"
+    AVAILABILITY_STATUS_SILENT = "SILENT"
+
+    #: A constant which can be used with the availability_status property of a ManagementAgentAggregationDimensions.
+    #: This constant has a value of "NOT_AVAILABLE"
+    AVAILABILITY_STATUS_NOT_AVAILABLE = "NOT_AVAILABLE"
+
+    #: A constant which can be used with the platform_type property of a ManagementAgentAggregationDimensions.
+    #: This constant has a value of "LINUX"
+    PLATFORM_TYPE_LINUX = "LINUX"
+
+    #: A constant which can be used with the platform_type property of a ManagementAgentAggregationDimensions.
+    #: This constant has a value of "WINDOWS"
+    PLATFORM_TYPE_WINDOWS = "WINDOWS"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ManagementAgentAggregationDimensions object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param availability_status:
+            The value to assign to the availability_status property of this ManagementAgentAggregationDimensions.
+            Allowed values for this property are: "ACTIVE", "SILENT", "NOT_AVAILABLE", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type availability_status: str
+
+        :param platform_type:
+            The value to assign to the platform_type property of this ManagementAgentAggregationDimensions.
+            Allowed values for this property are: "LINUX", "WINDOWS", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type platform_type: str
+
+        :param version:
+            The value to assign to the version property of this ManagementAgentAggregationDimensions.
+        :type version: str
+
+        :param has_plugins:
+            The value to assign to the has_plugins property of this ManagementAgentAggregationDimensions.
+        :type has_plugins: bool
+
+        """
+        self.swagger_types = {
+            'availability_status': 'str',
+            'platform_type': 'str',
+            'version': 'str',
+            'has_plugins': 'bool'
+        }
+
+        self.attribute_map = {
+            'availability_status': 'availabilityStatus',
+            'platform_type': 'platformType',
+            'version': 'version',
+            'has_plugins': 'hasPlugins'
+        }
+
+        self._availability_status = None
+        self._platform_type = None
+        self._version = None
+        self._has_plugins = None
+
+    @property
+    def availability_status(self):
+        """
+        Gets the availability_status of this ManagementAgentAggregationDimensions.
+        The availability status of managementAgent
+
+        Allowed values for this property are: "ACTIVE", "SILENT", "NOT_AVAILABLE", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The availability_status of this ManagementAgentAggregationDimensions.
+        :rtype: str
+        """
+        return self._availability_status
+
+    @availability_status.setter
+    def availability_status(self, availability_status):
+        """
+        Sets the availability_status of this ManagementAgentAggregationDimensions.
+        The availability status of managementAgent
+
+
+        :param availability_status: The availability_status of this ManagementAgentAggregationDimensions.
+        :type: str
+        """
+        allowed_values = ["ACTIVE", "SILENT", "NOT_AVAILABLE"]
+        if not value_allowed_none_or_none_sentinel(availability_status, allowed_values):
+            availability_status = 'UNKNOWN_ENUM_VALUE'
+        self._availability_status = availability_status
+
+    @property
+    def platform_type(self):
+        """
+        Gets the platform_type of this ManagementAgentAggregationDimensions.
+        Platform Type
+
+        Allowed values for this property are: "LINUX", "WINDOWS", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The platform_type of this ManagementAgentAggregationDimensions.
+        :rtype: str
+        """
+        return self._platform_type
+
+    @platform_type.setter
+    def platform_type(self, platform_type):
+        """
+        Sets the platform_type of this ManagementAgentAggregationDimensions.
+        Platform Type
+
+
+        :param platform_type: The platform_type of this ManagementAgentAggregationDimensions.
+        :type: str
+        """
+        allowed_values = ["LINUX", "WINDOWS"]
+        if not value_allowed_none_or_none_sentinel(platform_type, allowed_values):
+            platform_type = 'UNKNOWN_ENUM_VALUE'
+        self._platform_type = platform_type
+
+    @property
+    def version(self):
+        """
+        Gets the version of this ManagementAgentAggregationDimensions.
+        Agent image version
+
+
+        :return: The version of this ManagementAgentAggregationDimensions.
+        :rtype: str
+        """
+        return self._version
+
+    @version.setter
+    def version(self, version):
+        """
+        Sets the version of this ManagementAgentAggregationDimensions.
+        Agent image version
+
+
+        :param version: The version of this ManagementAgentAggregationDimensions.
+        :type: str
+        """
+        self._version = version
+
+    @property
+    def has_plugins(self):
+        """
+        Gets the has_plugins of this ManagementAgentAggregationDimensions.
+        Whether or not a managementAgent has at least one plugin
+
+
+        :return: The has_plugins of this ManagementAgentAggregationDimensions.
+        :rtype: bool
+        """
+        return self._has_plugins
+
+    @has_plugins.setter
+    def has_plugins(self, has_plugins):
+        """
+        Sets the has_plugins of this ManagementAgentAggregationDimensions.
+        Whether or not a managementAgent has at least one plugin
+
+
+        :param has_plugins: The has_plugins of this ManagementAgentAggregationDimensions.
+        :type: bool
+        """
+        self._has_plugins = has_plugins
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/management_agent/models/management_agent_plugin_aggregation.py
+++ b/src/oci/management_agent/models/management_agent_plugin_aggregation.py
@@ -1,0 +1,97 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ManagementAgentPluginAggregation(object):
+    """
+    A count of Management Agents Plugins sharing the values for specified dimensions.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ManagementAgentPluginAggregation object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param dimensions:
+            The value to assign to the dimensions property of this ManagementAgentPluginAggregation.
+        :type dimensions: oci.management_agent.models.ManagementAgentPluginAggregationDimensions
+
+        :param count:
+            The value to assign to the count property of this ManagementAgentPluginAggregation.
+        :type count: int
+
+        """
+        self.swagger_types = {
+            'dimensions': 'ManagementAgentPluginAggregationDimensions',
+            'count': 'int'
+        }
+
+        self.attribute_map = {
+            'dimensions': 'dimensions',
+            'count': 'count'
+        }
+
+        self._dimensions = None
+        self._count = None
+
+    @property
+    def dimensions(self):
+        """
+        Gets the dimensions of this ManagementAgentPluginAggregation.
+
+        :return: The dimensions of this ManagementAgentPluginAggregation.
+        :rtype: oci.management_agent.models.ManagementAgentPluginAggregationDimensions
+        """
+        return self._dimensions
+
+    @dimensions.setter
+    def dimensions(self, dimensions):
+        """
+        Sets the dimensions of this ManagementAgentPluginAggregation.
+
+        :param dimensions: The dimensions of this ManagementAgentPluginAggregation.
+        :type: oci.management_agent.models.ManagementAgentPluginAggregationDimensions
+        """
+        self._dimensions = dimensions
+
+    @property
+    def count(self):
+        """
+        Gets the count of this ManagementAgentPluginAggregation.
+        The number of Management Agent Plugins in this group
+
+
+        :return: The count of this ManagementAgentPluginAggregation.
+        :rtype: int
+        """
+        return self._count
+
+    @count.setter
+    def count(self, count):
+        """
+        Sets the count of this ManagementAgentPluginAggregation.
+        The number of Management Agent Plugins in this group
+
+
+        :param count: The count of this ManagementAgentPluginAggregation.
+        :type: int
+        """
+        self._count = count
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/management_agent/models/management_agent_plugin_aggregation_collection.py
+++ b/src/oci/management_agent/models/management_agent_plugin_aggregation_collection.py
@@ -1,0 +1,70 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ManagementAgentPluginAggregationCollection(object):
+    """
+    The summary of Management Agent Plugin count items
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ManagementAgentPluginAggregationCollection object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param items:
+            The value to assign to the items property of this ManagementAgentPluginAggregationCollection.
+        :type items: list[oci.management_agent.models.ManagementAgentPluginAggregation]
+
+        """
+        self.swagger_types = {
+            'items': 'list[ManagementAgentPluginAggregation]'
+        }
+
+        self.attribute_map = {
+            'items': 'items'
+        }
+
+        self._items = None
+
+    @property
+    def items(self):
+        """
+        **[Required]** Gets the items of this ManagementAgentPluginAggregationCollection.
+        List in which each item describes an aggregation of Managment Agent Plugins
+
+
+        :return: The items of this ManagementAgentPluginAggregationCollection.
+        :rtype: list[oci.management_agent.models.ManagementAgentPluginAggregation]
+        """
+        return self._items
+
+    @items.setter
+    def items(self, items):
+        """
+        Sets the items of this ManagementAgentPluginAggregationCollection.
+        List in which each item describes an aggregation of Managment Agent Plugins
+
+
+        :param items: The items of this ManagementAgentPluginAggregationCollection.
+        :type: list[oci.management_agent.models.ManagementAgentPluginAggregation]
+        """
+        self._items = items
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/management_agent/models/management_agent_plugin_aggregation_dimensions.py
+++ b/src/oci/management_agent/models/management_agent_plugin_aggregation_dimensions.py
@@ -1,0 +1,70 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ManagementAgentPluginAggregationDimensions(object):
+    """
+    The Aggregation of Management Agent Plugin Dimensions
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ManagementAgentPluginAggregationDimensions object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param plugin_name:
+            The value to assign to the plugin_name property of this ManagementAgentPluginAggregationDimensions.
+        :type plugin_name: str
+
+        """
+        self.swagger_types = {
+            'plugin_name': 'str'
+        }
+
+        self.attribute_map = {
+            'plugin_name': 'pluginName'
+        }
+
+        self._plugin_name = None
+
+    @property
+    def plugin_name(self):
+        """
+        Gets the plugin_name of this ManagementAgentPluginAggregationDimensions.
+        Management Agent Plugin Name
+
+
+        :return: The plugin_name of this ManagementAgentPluginAggregationDimensions.
+        :rtype: str
+        """
+        return self._plugin_name
+
+    @plugin_name.setter
+    def plugin_name(self, plugin_name):
+        """
+        Sets the plugin_name of this ManagementAgentPluginAggregationDimensions.
+        Management Agent Plugin Name
+
+
+        :param plugin_name: The plugin_name of this ManagementAgentPluginAggregationDimensions.
+        :type: str
+        """
+        self._plugin_name = plugin_name
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/management_agent/models/management_agent_plugin_details.py
+++ b/src/oci/management_agent/models/management_agent_plugin_details.py
@@ -34,25 +34,32 @@ class ManagementAgentPluginDetails(object):
             The value to assign to the plugin_version property of this ManagementAgentPluginDetails.
         :type plugin_version: str
 
+        :param is_enabled:
+            The value to assign to the is_enabled property of this ManagementAgentPluginDetails.
+        :type is_enabled: bool
+
         """
         self.swagger_types = {
             'plugin_id': 'str',
             'plugin_name': 'str',
             'plugin_display_name': 'str',
-            'plugin_version': 'str'
+            'plugin_version': 'str',
+            'is_enabled': 'bool'
         }
 
         self.attribute_map = {
             'plugin_id': 'pluginId',
             'plugin_name': 'pluginName',
             'plugin_display_name': 'pluginDisplayName',
-            'plugin_version': 'pluginVersion'
+            'plugin_version': 'pluginVersion',
+            'is_enabled': 'isEnabled'
         }
 
         self._plugin_id = None
         self._plugin_name = None
         self._plugin_display_name = None
         self._plugin_version = None
+        self._is_enabled = None
 
     @property
     def plugin_id(self):
@@ -149,6 +156,30 @@ class ManagementAgentPluginDetails(object):
         :type: str
         """
         self._plugin_version = plugin_version
+
+    @property
+    def is_enabled(self):
+        """
+        Gets the is_enabled of this ManagementAgentPluginDetails.
+        flag indicating whether the plugin is in enabled mode or disabled mode.
+
+
+        :return: The is_enabled of this ManagementAgentPluginDetails.
+        :rtype: bool
+        """
+        return self._is_enabled
+
+    @is_enabled.setter
+    def is_enabled(self, is_enabled):
+        """
+        Sets the is_enabled of this ManagementAgentPluginDetails.
+        flag indicating whether the plugin is in enabled mode or disabled mode.
+
+
+        :param is_enabled: The is_enabled of this ManagementAgentPluginDetails.
+        :type: bool
+        """
+        self._is_enabled = is_enabled
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/management_agent/models/management_agent_summary.py
+++ b/src/oci/management_agent/models/management_agent_summary.py
@@ -108,9 +108,17 @@ class ManagementAgentSummary(object):
             The value to assign to the time_created property of this ManagementAgentSummary.
         :type time_created: datetime
 
+        :param time_updated:
+            The value to assign to the time_updated property of this ManagementAgentSummary.
+        :type time_updated: datetime
+
         :param host:
             The value to assign to the host property of this ManagementAgentSummary.
         :type host: str
+
+        :param host_id:
+            The value to assign to the host_id property of this ManagementAgentSummary.
+        :type host_id: str
 
         :param plugin_list:
             The value to assign to the plugin_list property of this ManagementAgentSummary.
@@ -140,6 +148,10 @@ class ManagementAgentSummary(object):
             The value to assign to the lifecycle_details property of this ManagementAgentSummary.
         :type lifecycle_details: str
 
+        :param is_customer_deployed:
+            The value to assign to the is_customer_deployed property of this ManagementAgentSummary.
+        :type is_customer_deployed: bool
+
         :param freeform_tags:
             The value to assign to the freeform_tags property of this ManagementAgentSummary.
         :type freeform_tags: dict(str, str)
@@ -159,13 +171,16 @@ class ManagementAgentSummary(object):
             'version': 'str',
             'is_agent_auto_upgradable': 'bool',
             'time_created': 'datetime',
+            'time_updated': 'datetime',
             'host': 'str',
+            'host_id': 'str',
             'plugin_list': 'list[ManagementAgentPluginDetails]',
             'compartment_id': 'str',
             'time_last_heartbeat': 'datetime',
             'availability_status': 'str',
             'lifecycle_state': 'str',
             'lifecycle_details': 'str',
+            'is_customer_deployed': 'bool',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))'
         }
@@ -180,13 +195,16 @@ class ManagementAgentSummary(object):
             'version': 'version',
             'is_agent_auto_upgradable': 'isAgentAutoUpgradable',
             'time_created': 'timeCreated',
+            'time_updated': 'timeUpdated',
             'host': 'host',
+            'host_id': 'hostId',
             'plugin_list': 'pluginList',
             'compartment_id': 'compartmentId',
             'time_last_heartbeat': 'timeLastHeartbeat',
             'availability_status': 'availabilityStatus',
             'lifecycle_state': 'lifecycleState',
             'lifecycle_details': 'lifecycleDetails',
+            'is_customer_deployed': 'isCustomerDeployed',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags'
         }
@@ -200,13 +218,16 @@ class ManagementAgentSummary(object):
         self._version = None
         self._is_agent_auto_upgradable = None
         self._time_created = None
+        self._time_updated = None
         self._host = None
+        self._host_id = None
         self._plugin_list = None
         self._compartment_id = None
         self._time_last_heartbeat = None
         self._availability_status = None
         self._lifecycle_state = None
         self._lifecycle_details = None
+        self._is_customer_deployed = None
         self._freeform_tags = None
         self._defined_tags = None
 
@@ -388,7 +409,7 @@ class ManagementAgentSummary(object):
     def is_agent_auto_upgradable(self):
         """
         Gets the is_agent_auto_upgradable of this ManagementAgentSummary.
-        true if the agent can be upgraded automatically; false if it must be upgraded manually. true is currently unsupported.
+        true if the agent can be upgraded automatically; false if it must be upgraded manually.
 
 
         :return: The is_agent_auto_upgradable of this ManagementAgentSummary.
@@ -400,7 +421,7 @@ class ManagementAgentSummary(object):
     def is_agent_auto_upgradable(self, is_agent_auto_upgradable):
         """
         Sets the is_agent_auto_upgradable of this ManagementAgentSummary.
-        true if the agent can be upgraded automatically; false if it must be upgraded manually. true is currently unsupported.
+        true if the agent can be upgraded automatically; false if it must be upgraded manually.
 
 
         :param is_agent_auto_upgradable: The is_agent_auto_upgradable of this ManagementAgentSummary.
@@ -433,6 +454,30 @@ class ManagementAgentSummary(object):
         self._time_created = time_created
 
     @property
+    def time_updated(self):
+        """
+        Gets the time_updated of this ManagementAgentSummary.
+        The time the Management Agent was last updated. An RFC3339 formatted datetime string
+
+
+        :return: The time_updated of this ManagementAgentSummary.
+        :rtype: datetime
+        """
+        return self._time_updated
+
+    @time_updated.setter
+    def time_updated(self, time_updated):
+        """
+        Sets the time_updated of this ManagementAgentSummary.
+        The time the Management Agent was last updated. An RFC3339 formatted datetime string
+
+
+        :param time_updated: The time_updated of this ManagementAgentSummary.
+        :type: datetime
+        """
+        self._time_updated = time_updated
+
+    @property
     def host(self):
         """
         Gets the host of this ManagementAgentSummary.
@@ -455,6 +500,30 @@ class ManagementAgentSummary(object):
         :type: str
         """
         self._host = host
+
+    @property
+    def host_id(self):
+        """
+        Gets the host_id of this ManagementAgentSummary.
+        Host resource ocid
+
+
+        :return: The host_id of this ManagementAgentSummary.
+        :rtype: str
+        """
+        return self._host_id
+
+    @host_id.setter
+    def host_id(self, host_id):
+        """
+        Sets the host_id of this ManagementAgentSummary.
+        Host resource ocid
+
+
+        :param host_id: The host_id of this ManagementAgentSummary.
+        :type: str
+        """
+        self._host_id = host_id
 
     @property
     def plugin_list(self):
@@ -611,6 +680,30 @@ class ManagementAgentSummary(object):
         :type: str
         """
         self._lifecycle_details = lifecycle_details
+
+    @property
+    def is_customer_deployed(self):
+        """
+        Gets the is_customer_deployed of this ManagementAgentSummary.
+        true, if the agent image is manually downloaded and installed. false, if the agent is deployed as a plugin in Oracle Cloud Agent.
+
+
+        :return: The is_customer_deployed of this ManagementAgentSummary.
+        :rtype: bool
+        """
+        return self._is_customer_deployed
+
+    @is_customer_deployed.setter
+    def is_customer_deployed(self, is_customer_deployed):
+        """
+        Sets the is_customer_deployed of this ManagementAgentSummary.
+        true, if the agent image is manually downloaded and installed. false, if the agent is deployed as a plugin in Oracle Cloud Agent.
+
+
+        :param is_customer_deployed: The is_customer_deployed of this ManagementAgentSummary.
+        :type: bool
+        """
+        self._is_customer_deployed = is_customer_deployed
 
     @property
     def freeform_tags(self):

--- a/src/oci/management_agent/models/update_management_agent_details.py
+++ b/src/oci/management_agent/models/update_management_agent_details.py
@@ -58,7 +58,7 @@ class UpdateManagementAgentDetails(object):
     def is_agent_auto_upgradable(self):
         """
         Gets the is_agent_auto_upgradable of this UpdateManagementAgentDetails.
-        true if the agent can be upgraded automatically; false if it must be upgraded manually. true is currently unsupported.
+        Setting of this flag is no longer supported.
 
 
         :return: The is_agent_auto_upgradable of this UpdateManagementAgentDetails.
@@ -70,7 +70,7 @@ class UpdateManagementAgentDetails(object):
     def is_agent_auto_upgradable(self, is_agent_auto_upgradable):
         """
         Sets the is_agent_auto_upgradable of this UpdateManagementAgentDetails.
-        true if the agent can be upgraded automatically; false if it must be upgraded manually. true is currently unsupported.
+        Setting of this flag is no longer supported.
 
 
         :param is_agent_auto_upgradable: The is_agent_auto_upgradable of this UpdateManagementAgentDetails.

--- a/src/oci/opsi/models/__init__.py
+++ b/src/oci/opsi/models/__init__.py
@@ -48,6 +48,7 @@ from .host_cpu_usage import HostCpuUsage
 from .host_details import HostDetails
 from .host_entities import HostEntities
 from .host_hardware_configuration import HostHardwareConfiguration
+from .host_importable_agent_entity_summary import HostImportableAgentEntitySummary
 from .host_insight import HostInsight
 from .host_insight_resource_statistics_aggregation import HostInsightResourceStatisticsAggregation
 from .host_insight_summary import HostInsightSummary
@@ -66,6 +67,8 @@ from .host_resource_capacity_trend_aggregation import HostResourceCapacityTrendA
 from .host_resource_statistics import HostResourceStatistics
 from .hosted_entity_collection import HostedEntityCollection
 from .hosted_entity_summary import HostedEntitySummary
+from .importable_agent_entity_summary import ImportableAgentEntitySummary
+from .importable_agent_entity_summary_collection import ImportableAgentEntitySummaryCollection
 from .importable_enterprise_manager_entity import ImportableEnterpriseManagerEntity
 from .importable_enterprise_manager_entity_collection import ImportableEnterpriseManagerEntityCollection
 from .ingest_database_configuration_details import IngestDatabaseConfigurationDetails
@@ -197,6 +200,7 @@ opsi_type_mapping = {
     "HostDetails": HostDetails,
     "HostEntities": HostEntities,
     "HostHardwareConfiguration": HostHardwareConfiguration,
+    "HostImportableAgentEntitySummary": HostImportableAgentEntitySummary,
     "HostInsight": HostInsight,
     "HostInsightResourceStatisticsAggregation": HostInsightResourceStatisticsAggregation,
     "HostInsightSummary": HostInsightSummary,
@@ -215,6 +219,8 @@ opsi_type_mapping = {
     "HostResourceStatistics": HostResourceStatistics,
     "HostedEntityCollection": HostedEntityCollection,
     "HostedEntitySummary": HostedEntitySummary,
+    "ImportableAgentEntitySummary": ImportableAgentEntitySummary,
+    "ImportableAgentEntitySummaryCollection": ImportableAgentEntitySummaryCollection,
     "ImportableEnterpriseManagerEntity": ImportableEnterpriseManagerEntity,
     "ImportableEnterpriseManagerEntityCollection": ImportableEnterpriseManagerEntityCollection,
     "IngestDatabaseConfigurationDetails": IngestDatabaseConfigurationDetails,

--- a/src/oci/opsi/models/host_importable_agent_entity_summary.py
+++ b/src/oci/opsi/models/host_importable_agent_entity_summary.py
@@ -1,0 +1,138 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+from .importable_agent_entity_summary import ImportableAgentEntitySummary
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class HostImportableAgentEntitySummary(ImportableAgentEntitySummary):
+    """
+    An agent host entity that can be imported into Operations Insights.
+    """
+
+    #: A constant which can be used with the platform_type property of a HostImportableAgentEntitySummary.
+    #: This constant has a value of "LINUX"
+    PLATFORM_TYPE_LINUX = "LINUX"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new HostImportableAgentEntitySummary object with values from keyword arguments. The default value of the :py:attr:`~oci.opsi.models.HostImportableAgentEntitySummary.entity_source` attribute
+        of this class is ``MACS_MANAGED_EXTERNAL_HOST`` and it should not be changed.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param entity_source:
+            The value to assign to the entity_source property of this HostImportableAgentEntitySummary.
+            Allowed values for this property are: "MACS_MANAGED_EXTERNAL_HOST", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type entity_source: str
+
+        :param management_agent_id:
+            The value to assign to the management_agent_id property of this HostImportableAgentEntitySummary.
+        :type management_agent_id: str
+
+        :param management_agent_display_name:
+            The value to assign to the management_agent_display_name property of this HostImportableAgentEntitySummary.
+        :type management_agent_display_name: str
+
+        :param host_name:
+            The value to assign to the host_name property of this HostImportableAgentEntitySummary.
+        :type host_name: str
+
+        :param platform_type:
+            The value to assign to the platform_type property of this HostImportableAgentEntitySummary.
+            Allowed values for this property are: "LINUX", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type platform_type: str
+
+        """
+        self.swagger_types = {
+            'entity_source': 'str',
+            'management_agent_id': 'str',
+            'management_agent_display_name': 'str',
+            'host_name': 'str',
+            'platform_type': 'str'
+        }
+
+        self.attribute_map = {
+            'entity_source': 'entitySource',
+            'management_agent_id': 'managementAgentId',
+            'management_agent_display_name': 'managementAgentDisplayName',
+            'host_name': 'hostName',
+            'platform_type': 'platformType'
+        }
+
+        self._entity_source = None
+        self._management_agent_id = None
+        self._management_agent_display_name = None
+        self._host_name = None
+        self._platform_type = None
+        self._entity_source = 'MACS_MANAGED_EXTERNAL_HOST'
+
+    @property
+    def host_name(self):
+        """
+        **[Required]** Gets the host_name of this HostImportableAgentEntitySummary.
+        The host name. The host name is unique amongst the hosts managed by the same management agent.
+
+
+        :return: The host_name of this HostImportableAgentEntitySummary.
+        :rtype: str
+        """
+        return self._host_name
+
+    @host_name.setter
+    def host_name(self, host_name):
+        """
+        Sets the host_name of this HostImportableAgentEntitySummary.
+        The host name. The host name is unique amongst the hosts managed by the same management agent.
+
+
+        :param host_name: The host_name of this HostImportableAgentEntitySummary.
+        :type: str
+        """
+        self._host_name = host_name
+
+    @property
+    def platform_type(self):
+        """
+        **[Required]** Gets the platform_type of this HostImportableAgentEntitySummary.
+        Platform type.
+
+        Allowed values for this property are: "LINUX", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The platform_type of this HostImportableAgentEntitySummary.
+        :rtype: str
+        """
+        return self._platform_type
+
+    @platform_type.setter
+    def platform_type(self, platform_type):
+        """
+        Sets the platform_type of this HostImportableAgentEntitySummary.
+        Platform type.
+
+
+        :param platform_type: The platform_type of this HostImportableAgentEntitySummary.
+        :type: str
+        """
+        allowed_values = ["LINUX"]
+        if not value_allowed_none_or_none_sentinel(platform_type, allowed_values):
+            platform_type = 'UNKNOWN_ENUM_VALUE'
+        self._platform_type = platform_type
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/opsi/models/importable_agent_entity_summary.py
+++ b/src/oci/opsi/models/importable_agent_entity_summary.py
@@ -1,0 +1,169 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ImportableAgentEntitySummary(object):
+    """
+    An agent entity that can be imported into Operations Insights.
+    """
+
+    #: A constant which can be used with the entity_source property of a ImportableAgentEntitySummary.
+    #: This constant has a value of "MACS_MANAGED_EXTERNAL_HOST"
+    ENTITY_SOURCE_MACS_MANAGED_EXTERNAL_HOST = "MACS_MANAGED_EXTERNAL_HOST"
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ImportableAgentEntitySummary object with values from keyword arguments. This class has the following subclasses and if you are using this class as input
+        to a service operations then you should favor using a subclass over the base class:
+
+        * :class:`~oci.opsi.models.HostImportableAgentEntitySummary`
+
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param entity_source:
+            The value to assign to the entity_source property of this ImportableAgentEntitySummary.
+            Allowed values for this property are: "MACS_MANAGED_EXTERNAL_HOST", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type entity_source: str
+
+        :param management_agent_id:
+            The value to assign to the management_agent_id property of this ImportableAgentEntitySummary.
+        :type management_agent_id: str
+
+        :param management_agent_display_name:
+            The value to assign to the management_agent_display_name property of this ImportableAgentEntitySummary.
+        :type management_agent_display_name: str
+
+        """
+        self.swagger_types = {
+            'entity_source': 'str',
+            'management_agent_id': 'str',
+            'management_agent_display_name': 'str'
+        }
+
+        self.attribute_map = {
+            'entity_source': 'entitySource',
+            'management_agent_id': 'managementAgentId',
+            'management_agent_display_name': 'managementAgentDisplayName'
+        }
+
+        self._entity_source = None
+        self._management_agent_id = None
+        self._management_agent_display_name = None
+
+    @staticmethod
+    def get_subtype(object_dictionary):
+        """
+        Given the hash representation of a subtype of this class,
+        use the info in the hash to return the class of the subtype.
+        """
+        type = object_dictionary['entitySource']
+
+        if type == 'MACS_MANAGED_EXTERNAL_HOST':
+            return 'HostImportableAgentEntitySummary'
+        else:
+            return 'ImportableAgentEntitySummary'
+
+    @property
+    def entity_source(self):
+        """
+        **[Required]** Gets the entity_source of this ImportableAgentEntitySummary.
+        Source of the importable agent entity.
+
+        Allowed values for this property are: "MACS_MANAGED_EXTERNAL_HOST", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The entity_source of this ImportableAgentEntitySummary.
+        :rtype: str
+        """
+        return self._entity_source
+
+    @entity_source.setter
+    def entity_source(self, entity_source):
+        """
+        Sets the entity_source of this ImportableAgentEntitySummary.
+        Source of the importable agent entity.
+
+
+        :param entity_source: The entity_source of this ImportableAgentEntitySummary.
+        :type: str
+        """
+        allowed_values = ["MACS_MANAGED_EXTERNAL_HOST"]
+        if not value_allowed_none_or_none_sentinel(entity_source, allowed_values):
+            entity_source = 'UNKNOWN_ENUM_VALUE'
+        self._entity_source = entity_source
+
+    @property
+    def management_agent_id(self):
+        """
+        **[Required]** Gets the management_agent_id of this ImportableAgentEntitySummary.
+        The `OCID`__ of the Management Agent
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :return: The management_agent_id of this ImportableAgentEntitySummary.
+        :rtype: str
+        """
+        return self._management_agent_id
+
+    @management_agent_id.setter
+    def management_agent_id(self, management_agent_id):
+        """
+        Sets the management_agent_id of this ImportableAgentEntitySummary.
+        The `OCID`__ of the Management Agent
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+
+        :param management_agent_id: The management_agent_id of this ImportableAgentEntitySummary.
+        :type: str
+        """
+        self._management_agent_id = management_agent_id
+
+    @property
+    def management_agent_display_name(self):
+        """
+        **[Required]** Gets the management_agent_display_name of this ImportableAgentEntitySummary.
+        The `Display Name`__ of the Management Agent
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm#Display
+
+
+        :return: The management_agent_display_name of this ImportableAgentEntitySummary.
+        :rtype: str
+        """
+        return self._management_agent_display_name
+
+    @management_agent_display_name.setter
+    def management_agent_display_name(self, management_agent_display_name):
+        """
+        Sets the management_agent_display_name of this ImportableAgentEntitySummary.
+        The `Display Name`__ of the Management Agent
+
+        __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm#Display
+
+
+        :param management_agent_display_name: The management_agent_display_name of this ImportableAgentEntitySummary.
+        :type: str
+        """
+        self._management_agent_display_name = management_agent_display_name
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/opsi/models/importable_agent_entity_summary_collection.py
+++ b/src/oci/opsi/models/importable_agent_entity_summary_collection.py
@@ -1,0 +1,70 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ImportableAgentEntitySummaryCollection(object):
+    """
+    Collection of importable agent entity objects.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ImportableAgentEntitySummaryCollection object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param items:
+            The value to assign to the items property of this ImportableAgentEntitySummaryCollection.
+        :type items: list[oci.opsi.models.ImportableAgentEntitySummary]
+
+        """
+        self.swagger_types = {
+            'items': 'list[ImportableAgentEntitySummary]'
+        }
+
+        self.attribute_map = {
+            'items': 'items'
+        }
+
+        self._items = None
+
+    @property
+    def items(self):
+        """
+        **[Required]** Gets the items of this ImportableAgentEntitySummaryCollection.
+        Array of importable agent entity objects.
+
+
+        :return: The items of this ImportableAgentEntitySummaryCollection.
+        :rtype: list[oci.opsi.models.ImportableAgentEntitySummary]
+        """
+        return self._items
+
+    @items.setter
+    def items(self, items):
+        """
+        Sets the items of this ImportableAgentEntitySummaryCollection.
+        Array of importable agent entity objects.
+
+
+        :param items: The items of this ImportableAgentEntitySummaryCollection.
+        :type: list[oci.opsi.models.ImportableAgentEntitySummary]
+        """
+        self._items = items
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/opsi/operations_insights_client.py
+++ b/src/oci/opsi/operations_insights_client.py
@@ -3065,6 +3065,131 @@ class OperationsInsightsClient(object):
                 header_params=header_params,
                 response_type="HostedEntityCollection")
 
+    def list_importable_agent_entities(self, compartment_id, **kwargs):
+        """
+        Gets a list of agent entities available to add a new hostInsight.  An agent entity is \"available\"
+        and will be shown if all the following conditions are true:
+           1.  The agent OCID is not already being used for an existing hostInsight.
+           2.  The agent availabilityStatus = 'ACTIVE'
+           3.  The agent lifecycleState = 'ACTIVE'
+
+
+        :param str compartment_id: (required)
+            The `OCID`__ of the compartment.
+
+            __ https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm
+
+        :param int limit: (optional)
+            For list pagination. The maximum number of results per page, or items to
+            return in a paginated \"List\" call.
+            For important details about how pagination works, see
+            `List Pagination`__.
+            Example: `50`
+
+            __ https://docs.cloud.oracle.com/Content/API/Concepts/usingapi.htm#nine
+
+        :param str page: (optional)
+            For list pagination. The value of the `opc-next-page` response header from
+            the previous \"List\" call. For important details about how pagination works,
+            see `List Pagination`__.
+
+            __ https://docs.cloud.oracle.com/Content/API/Concepts/usingapi.htm#nine
+
+        :param str sort_order: (optional)
+            The sort order to use, either ascending (`ASC`) or descending (`DESC`).
+
+            Allowed values are: "ASC", "DESC"
+
+        :param str sort_by: (optional)
+            Hosted entity list sort options.
+
+            Allowed values are: "entityName", "entityType"
+
+        :param str opc_request_id: (optional)
+            Unique Oracle-assigned identifier for the request. If you need to contact
+            Oracle about a particular request, please provide the request ID.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. A convenience :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY`
+            is also available. The specifics of the default retry strategy are described `here <https://docs.oracle.com/en-us/iaas/tools/python/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.opsi.models.ImportableAgentEntitySummaryCollection`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/opsi/list_importable_agent_entities.py.html>`__ to see an example of how to use list_importable_agent_entities API.
+        """
+        resource_path = "/importableAgentEntities"
+        method = "GET"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "limit",
+            "page",
+            "sort_order",
+            "sort_by",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "list_importable_agent_entities got unknown kwargs: {!r}".format(extra_kwargs))
+
+        if 'sort_order' in kwargs:
+            sort_order_allowed_values = ["ASC", "DESC"]
+            if kwargs['sort_order'] not in sort_order_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_order`, must be one of {0}".format(sort_order_allowed_values)
+                )
+
+        if 'sort_by' in kwargs:
+            sort_by_allowed_values = ["entityName", "entityType"]
+            if kwargs['sort_by'] not in sort_by_allowed_values:
+                raise ValueError(
+                    "Invalid value for `sort_by`, must be one of {0}".format(sort_by_allowed_values)
+                )
+
+        query_params = {
+            "compartmentId": compartment_id,
+            "limit": kwargs.get("limit", missing),
+            "page": kwargs.get("page", missing),
+            "sortOrder": kwargs.get("sort_order", missing),
+            "sortBy": kwargs.get("sort_by", missing)
+        }
+        query_params = {k: v for (k, v) in six.iteritems(query_params) if v is not missing and v is not None}
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.retry_strategy
+        if kwargs.get('retry_strategy'):
+            retry_strategy = kwargs.get('retry_strategy')
+
+        if retry_strategy:
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="ImportableAgentEntitySummaryCollection")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                query_params=query_params,
+                header_params=header_params,
+                response_type="ImportableAgentEntitySummaryCollection")
+
     def list_importable_enterprise_manager_entities(self, enterprise_manager_bridge_id, **kwargs):
         """
         Gets a list of importable entities for an Operations Insights Enterprise Manager bridge that have not been imported before.

--- a/src/oci/version.py
+++ b/src/oci/version.py
@@ -2,4 +2,4 @@
 # Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
 # This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 
-__version__ = "2.43.2"
+__version__ = "2.44.0"


### PR DESCRIPTION
## Added

* Support for manually copying volume group backups across regions in the Block Volume service

* Support for work requests for the copy volume backup and copy boot volume backup operations in the Block Volume service

* Support for specifying external Hive metastores during application creation in the Data Flow service

* Support for changing the compartment of a backup in the MySQL Database service

* Support for model catalog features including provenance, metadata, schemas, and artifact introspection in the Data Science service

* Support for Exadata system network bonding in the Database service

* Support for creating autonomous databases with early patching enabled in the Database service