### PR TITLE
Releasing version 2.50.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_.
 ====================
+2.50.0 - 2021-11-09
+====================
+
+Added
+-----
+* Support for drill down metadata in the Management Dashboard service
+* Support for operator access control on dedicated autonomous databases in the Operator Access Control service
+
+Breaking
+--------
+* Property `resource_type` and `is_enforced_always` from model `CreateOperatorControlAssignmentDetails` changed from optional to required in the Operator Access Control service
+* Property `operator_control_name`, `approver_groups_list` and `is_fully_pre_approved` from model `UpdateOperatorControlDetails` changed from optional to required in the Operator Access Control service
+* Property `is_enforced_always` from model `UpdateOperatorControlAssignmentDetails` changed from optional to required in the Operator Access Control service
+* Property `approver_groups_list` and `is_fully_pre_approved` from model `CreateOperatorControlDetails` changed from optional to required in the Operator Access Control service
+* Data type for response of operation `create_operator_control_assignment` changed to `oci.operator_access_control.models.OperatorControlAssignment` in the Operator Access Control service
+====================
 2.49.1 - 2021-11-02
 ====================
 

--- a/docs/api/operator_access_control.rst
+++ b/docs/api/operator_access_control.rst
@@ -45,6 +45,7 @@ Operator Access Control
     oci.operator_access_control.models.OperatorControlCollection
     oci.operator_access_control.models.OperatorControlSummary
     oci.operator_access_control.models.RejectAccessRequestDetails
+    oci.operator_access_control.models.ReviewAccessRequestDetails
     oci.operator_access_control.models.RevokeAccessRequestDetails
     oci.operator_access_control.models.UpdateOperatorControlAssignmentDetails
     oci.operator_access_control.models.UpdateOperatorControlDetails

--- a/docs/api/operator_access_control/models/oci.operator_access_control.models.ReviewAccessRequestDetails.rst
+++ b/docs/api/operator_access_control/models/oci.operator_access_control.models.ReviewAccessRequestDetails.rst
@@ -1,0 +1,11 @@
+ReviewAccessRequestDetails
+==========================
+
+.. currentmodule:: oci.operator_access_control.models
+
+.. autoclass:: ReviewAccessRequestDetails
+    :show-inheritance:
+    :special-members: __init__
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/examples/drg_attachment_example.py
+++ b/examples/drg_attachment_example.py
@@ -119,10 +119,16 @@ try:
     drg_attachment_2 = create_drg_attachment(virtual_network_client, vcn_2, drg)
 
     print("Creating a new DRG route table.")
-    drg_route_table_1 = virtual_network_client.create_drg_route_table(
+    result = virtual_network_client.create_drg_route_table(
         oci.core.models.CreateDrgRouteTableDetails(
             drg_id=drg.id
         )
+    ).data
+    drg_route_table_1 = oci.wait_until(
+        virtual_network_client,
+        virtual_network_client.get_drg_route_table(result.id),
+        'lifecycle_state',
+        'AVAILABLE'
     ).data
     print(drg_route_table_1)
     print('\n')

--- a/examples/drg_route_distribution_example.py
+++ b/examples/drg_route_distribution_example.py
@@ -169,11 +169,17 @@ try:
     )
 
     print("Create a new DRG route table pointing to the route distribution.")
-    drg_route_table = virtual_network_client.create_drg_route_table(
+    result = virtual_network_client.create_drg_route_table(
         oci.core.models.CreateDrgRouteTableDetails(
             drg_id=drg.id,
             import_drg_route_distribution_id=import_route_distribution.id
         )
+    ).data
+    drg_route_table = oci.wait_until(
+        virtual_network_client,
+        virtual_network_client.get_drg_route_table(result.id),
+        'lifecycle_state',
+        'AVAILABLE'
     ).data
     print(drg_route_table)
     print('\n')

--- a/examples/drg_route_table_example.py
+++ b/examples/drg_route_table_example.py
@@ -125,10 +125,16 @@ try:
     drg_attachment_2 = create_drg_attachment(virtual_network_client, vcn_2, drg)
 
     print("Creating a new DRG route table.")
-    drg_route_table = virtual_network_client.create_drg_route_table(
+    result = virtual_network_client.create_drg_route_table(
         oci.core.models.CreateDrgRouteTableDetails(
             drg_id=drg.id
         )
+    ).data
+    drg_route_table = oci.wait_until(
+        virtual_network_client,
+        virtual_network_client.get_drg_route_table(result.id),
+        'lifecycle_state',
+        'AVAILABLE'
     ).data
     print(drg_route_table)
     print('\n')

--- a/src/oci/management_dashboard/models/create_management_dashboard_details.py
+++ b/src/oci/management_dashboard/models/create_management_dashboard_details.py
@@ -94,6 +94,10 @@ class CreateManagementDashboardDetails(object):
             The value to assign to the parameters_config property of this CreateManagementDashboardDetails.
         :type parameters_config: list[object]
 
+        :param drilldown_config:
+            The value to assign to the drilldown_config property of this CreateManagementDashboardDetails.
+        :type drilldown_config: list[object]
+
         :param freeform_tags:
             The value to assign to the freeform_tags property of this CreateManagementDashboardDetails.
         :type freeform_tags: dict(str, str)
@@ -123,6 +127,7 @@ class CreateManagementDashboardDetails(object):
             'type': 'str',
             'is_favorite': 'bool',
             'parameters_config': 'list[object]',
+            'drilldown_config': 'list[object]',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))'
         }
@@ -147,6 +152,7 @@ class CreateManagementDashboardDetails(object):
             'type': 'type',
             'is_favorite': 'isFavorite',
             'parameters_config': 'parametersConfig',
+            'drilldown_config': 'drilldownConfig',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags'
         }
@@ -170,6 +176,7 @@ class CreateManagementDashboardDetails(object):
         self._type = None
         self._is_favorite = None
         self._parameters_config = None
+        self._drilldown_config = None
         self._freeform_tags = None
         self._defined_tags = None
 
@@ -628,6 +635,30 @@ class CreateManagementDashboardDetails(object):
         :type: list[object]
         """
         self._parameters_config = parameters_config
+
+    @property
+    def drilldown_config(self):
+        """
+        Gets the drilldown_config of this CreateManagementDashboardDetails.
+        Drill-down configuration to define the destination of a drill-down action.
+
+
+        :return: The drilldown_config of this CreateManagementDashboardDetails.
+        :rtype: list[object]
+        """
+        return self._drilldown_config
+
+    @drilldown_config.setter
+    def drilldown_config(self, drilldown_config):
+        """
+        Sets the drilldown_config of this CreateManagementDashboardDetails.
+        Drill-down configuration to define the destination of a drill-down action.
+
+
+        :param drilldown_config: The drilldown_config of this CreateManagementDashboardDetails.
+        :type: list[object]
+        """
+        self._drilldown_config = drilldown_config
 
     @property
     def freeform_tags(self):

--- a/src/oci/management_dashboard/models/create_management_saved_search_details.py
+++ b/src/oci/management_dashboard/models/create_management_saved_search_details.py
@@ -103,6 +103,10 @@ class CreateManagementSavedSearchDetails(object):
             The value to assign to the parameters_config property of this CreateManagementSavedSearchDetails.
         :type parameters_config: list[object]
 
+        :param drilldown_config:
+            The value to assign to the drilldown_config property of this CreateManagementSavedSearchDetails.
+        :type drilldown_config: list[object]
+
         :param freeform_tags:
             The value to assign to the freeform_tags property of this CreateManagementSavedSearchDetails.
         :type freeform_tags: dict(str, str)
@@ -130,6 +134,7 @@ class CreateManagementSavedSearchDetails(object):
             'widget_template': 'str',
             'widget_vm': 'str',
             'parameters_config': 'list[object]',
+            'drilldown_config': 'list[object]',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))'
         }
@@ -152,6 +157,7 @@ class CreateManagementSavedSearchDetails(object):
             'widget_template': 'widgetTemplate',
             'widget_vm': 'widgetVM',
             'parameters_config': 'parametersConfig',
+            'drilldown_config': 'drilldownConfig',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags'
         }
@@ -173,6 +179,7 @@ class CreateManagementSavedSearchDetails(object):
         self._widget_template = None
         self._widget_vm = None
         self._parameters_config = None
+        self._drilldown_config = None
         self._freeform_tags = None
         self._defined_tags = None
 
@@ -591,6 +598,30 @@ class CreateManagementSavedSearchDetails(object):
         :type: list[object]
         """
         self._parameters_config = parameters_config
+
+    @property
+    def drilldown_config(self):
+        """
+        Gets the drilldown_config of this CreateManagementSavedSearchDetails.
+        Drill-down configuration to define the destination of a drill-down action.
+
+
+        :return: The drilldown_config of this CreateManagementSavedSearchDetails.
+        :rtype: list[object]
+        """
+        return self._drilldown_config
+
+    @drilldown_config.setter
+    def drilldown_config(self, drilldown_config):
+        """
+        Sets the drilldown_config of this CreateManagementSavedSearchDetails.
+        Drill-down configuration to define the destination of a drill-down action.
+
+
+        :param drilldown_config: The drilldown_config of this CreateManagementSavedSearchDetails.
+        :type: list[object]
+        """
+        self._drilldown_config = drilldown_config
 
     @property
     def freeform_tags(self):

--- a/src/oci/management_dashboard/models/management_dashboard.py
+++ b/src/oci/management_dashboard/models/management_dashboard.py
@@ -128,6 +128,10 @@ class ManagementDashboard(object):
             The value to assign to the parameters_config property of this ManagementDashboard.
         :type parameters_config: list[object]
 
+        :param drilldown_config:
+            The value to assign to the drilldown_config property of this ManagementDashboard.
+        :type drilldown_config: list[object]
+
         :param freeform_tags:
             The value to assign to the freeform_tags property of this ManagementDashboard.
         :type freeform_tags: dict(str, str)
@@ -164,6 +168,7 @@ class ManagementDashboard(object):
             'saved_searches': 'list[ManagementSavedSearch]',
             'lifecycle_state': 'str',
             'parameters_config': 'list[object]',
+            'drilldown_config': 'list[object]',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))'
         }
@@ -195,6 +200,7 @@ class ManagementDashboard(object):
             'saved_searches': 'savedSearches',
             'lifecycle_state': 'lifecycleState',
             'parameters_config': 'parametersConfig',
+            'drilldown_config': 'drilldownConfig',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags'
         }
@@ -225,6 +231,7 @@ class ManagementDashboard(object):
         self._saved_searches = None
         self._lifecycle_state = None
         self._parameters_config = None
+        self._drilldown_config = None
         self._freeform_tags = None
         self._defined_tags = None
 
@@ -857,6 +864,30 @@ class ManagementDashboard(object):
         :type: list[object]
         """
         self._parameters_config = parameters_config
+
+    @property
+    def drilldown_config(self):
+        """
+        Gets the drilldown_config of this ManagementDashboard.
+        Drill-down configuration to define the destination of a drill-down action.
+
+
+        :return: The drilldown_config of this ManagementDashboard.
+        :rtype: list[object]
+        """
+        return self._drilldown_config
+
+    @drilldown_config.setter
+    def drilldown_config(self, drilldown_config):
+        """
+        Sets the drilldown_config of this ManagementDashboard.
+        Drill-down configuration to define the destination of a drill-down action.
+
+
+        :param drilldown_config: The drilldown_config of this ManagementDashboard.
+        :type: list[object]
+        """
+        self._drilldown_config = drilldown_config
 
     @property
     def freeform_tags(self):

--- a/src/oci/management_dashboard/models/management_dashboard_for_import_export_details.py
+++ b/src/oci/management_dashboard/models/management_dashboard_for_import_export_details.py
@@ -98,6 +98,10 @@ class ManagementDashboardForImportExportDetails(object):
             The value to assign to the parameters_config property of this ManagementDashboardForImportExportDetails.
         :type parameters_config: list[object]
 
+        :param drilldown_config:
+            The value to assign to the drilldown_config property of this ManagementDashboardForImportExportDetails.
+        :type drilldown_config: list[object]
+
         :param freeform_tags:
             The value to assign to the freeform_tags property of this ManagementDashboardForImportExportDetails.
         :type freeform_tags: dict(str, str)
@@ -128,6 +132,7 @@ class ManagementDashboardForImportExportDetails(object):
             'is_favorite': 'bool',
             'saved_searches': 'list[ManagementSavedSearchForImportDetails]',
             'parameters_config': 'list[object]',
+            'drilldown_config': 'list[object]',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))'
         }
@@ -153,6 +158,7 @@ class ManagementDashboardForImportExportDetails(object):
             'is_favorite': 'isFavorite',
             'saved_searches': 'savedSearches',
             'parameters_config': 'parametersConfig',
+            'drilldown_config': 'drilldownConfig',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags'
         }
@@ -177,6 +183,7 @@ class ManagementDashboardForImportExportDetails(object):
         self._is_favorite = None
         self._saved_searches = None
         self._parameters_config = None
+        self._drilldown_config = None
         self._freeform_tags = None
         self._defined_tags = None
 
@@ -659,6 +666,30 @@ class ManagementDashboardForImportExportDetails(object):
         :type: list[object]
         """
         self._parameters_config = parameters_config
+
+    @property
+    def drilldown_config(self):
+        """
+        Gets the drilldown_config of this ManagementDashboardForImportExportDetails.
+        Drill-down configuration to define the destination of a drill-down action.
+
+
+        :return: The drilldown_config of this ManagementDashboardForImportExportDetails.
+        :rtype: list[object]
+        """
+        return self._drilldown_config
+
+    @drilldown_config.setter
+    def drilldown_config(self, drilldown_config):
+        """
+        Sets the drilldown_config of this ManagementDashboardForImportExportDetails.
+        Drill-down configuration to define the destination of a drill-down action.
+
+
+        :param drilldown_config: The drilldown_config of this ManagementDashboardForImportExportDetails.
+        :type: list[object]
+        """
+        self._drilldown_config = drilldown_config
 
     @property
     def freeform_tags(self):

--- a/src/oci/management_dashboard/models/management_saved_search.py
+++ b/src/oci/management_dashboard/models/management_saved_search.py
@@ -130,6 +130,10 @@ class ManagementSavedSearch(object):
             The value to assign to the parameters_config property of this ManagementSavedSearch.
         :type parameters_config: list[object]
 
+        :param drilldown_config:
+            The value to assign to the drilldown_config property of this ManagementSavedSearch.
+        :type drilldown_config: list[object]
+
         :param freeform_tags:
             The value to assign to the freeform_tags property of this ManagementSavedSearch.
         :type freeform_tags: dict(str, str)
@@ -162,6 +166,7 @@ class ManagementSavedSearch(object):
             'widget_vm': 'str',
             'lifecycle_state': 'str',
             'parameters_config': 'list[object]',
+            'drilldown_config': 'list[object]',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))'
         }
@@ -189,6 +194,7 @@ class ManagementSavedSearch(object):
             'widget_vm': 'widgetVM',
             'lifecycle_state': 'lifecycleState',
             'parameters_config': 'parametersConfig',
+            'drilldown_config': 'drilldownConfig',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags'
         }
@@ -215,6 +221,7 @@ class ManagementSavedSearch(object):
         self._widget_vm = None
         self._lifecycle_state = None
         self._parameters_config = None
+        self._drilldown_config = None
         self._freeform_tags = None
         self._defined_tags = None
 
@@ -757,6 +764,30 @@ class ManagementSavedSearch(object):
         :type: list[object]
         """
         self._parameters_config = parameters_config
+
+    @property
+    def drilldown_config(self):
+        """
+        Gets the drilldown_config of this ManagementSavedSearch.
+        Drill-down configuration to define the destination of a drill-down action.
+
+
+        :return: The drilldown_config of this ManagementSavedSearch.
+        :rtype: list[object]
+        """
+        return self._drilldown_config
+
+    @drilldown_config.setter
+    def drilldown_config(self, drilldown_config):
+        """
+        Sets the drilldown_config of this ManagementSavedSearch.
+        Drill-down configuration to define the destination of a drill-down action.
+
+
+        :param drilldown_config: The drilldown_config of this ManagementSavedSearch.
+        :type: list[object]
+        """
+        self._drilldown_config = drilldown_config
 
     @property
     def freeform_tags(self):

--- a/src/oci/management_dashboard/models/management_saved_search_for_import_details.py
+++ b/src/oci/management_dashboard/models/management_saved_search_for_import_details.py
@@ -112,6 +112,10 @@ class ManagementSavedSearchForImportDetails(object):
             The value to assign to the parameters_config property of this ManagementSavedSearchForImportDetails.
         :type parameters_config: list[object]
 
+        :param drilldown_config:
+            The value to assign to the drilldown_config property of this ManagementSavedSearchForImportDetails.
+        :type drilldown_config: list[object]
+
         """
         self.swagger_types = {
             'id': 'str',
@@ -132,7 +136,8 @@ class ManagementSavedSearchForImportDetails(object):
             'widget_vm': 'str',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))',
-            'parameters_config': 'list[object]'
+            'parameters_config': 'list[object]',
+            'drilldown_config': 'list[object]'
         }
 
         self.attribute_map = {
@@ -154,7 +159,8 @@ class ManagementSavedSearchForImportDetails(object):
             'widget_vm': 'widgetVM',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags',
-            'parameters_config': 'parametersConfig'
+            'parameters_config': 'parametersConfig',
+            'drilldown_config': 'drilldownConfig'
         }
 
         self._id = None
@@ -176,6 +182,7 @@ class ManagementSavedSearchForImportDetails(object):
         self._freeform_tags = None
         self._defined_tags = None
         self._parameters_config = None
+        self._drilldown_config = None
 
     @property
     def id(self):
@@ -642,6 +649,30 @@ class ManagementSavedSearchForImportDetails(object):
         :type: list[object]
         """
         self._parameters_config = parameters_config
+
+    @property
+    def drilldown_config(self):
+        """
+        Gets the drilldown_config of this ManagementSavedSearchForImportDetails.
+        Drill-down configuration to define the destination of a drill-down action.
+
+
+        :return: The drilldown_config of this ManagementSavedSearchForImportDetails.
+        :rtype: list[object]
+        """
+        return self._drilldown_config
+
+    @drilldown_config.setter
+    def drilldown_config(self, drilldown_config):
+        """
+        Sets the drilldown_config of this ManagementSavedSearchForImportDetails.
+        Drill-down configuration to define the destination of a drill-down action.
+
+
+        :param drilldown_config: The drilldown_config of this ManagementSavedSearchForImportDetails.
+        :type: list[object]
+        """
+        self._drilldown_config = drilldown_config
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/management_dashboard/models/update_management_dashboard_details.py
+++ b/src/oci/management_dashboard/models/update_management_dashboard_details.py
@@ -90,6 +90,10 @@ class UpdateManagementDashboardDetails(object):
             The value to assign to the parameters_config property of this UpdateManagementDashboardDetails.
         :type parameters_config: list[object]
 
+        :param drilldown_config:
+            The value to assign to the drilldown_config property of this UpdateManagementDashboardDetails.
+        :type drilldown_config: list[object]
+
         :param freeform_tags:
             The value to assign to the freeform_tags property of this UpdateManagementDashboardDetails.
         :type freeform_tags: dict(str, str)
@@ -118,6 +122,7 @@ class UpdateManagementDashboardDetails(object):
             'type': 'str',
             'is_favorite': 'bool',
             'parameters_config': 'list[object]',
+            'drilldown_config': 'list[object]',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))'
         }
@@ -141,6 +146,7 @@ class UpdateManagementDashboardDetails(object):
             'type': 'type',
             'is_favorite': 'isFavorite',
             'parameters_config': 'parametersConfig',
+            'drilldown_config': 'drilldownConfig',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags'
         }
@@ -163,6 +169,7 @@ class UpdateManagementDashboardDetails(object):
         self._type = None
         self._is_favorite = None
         self._parameters_config = None
+        self._drilldown_config = None
         self._freeform_tags = None
         self._defined_tags = None
 
@@ -597,6 +604,30 @@ class UpdateManagementDashboardDetails(object):
         :type: list[object]
         """
         self._parameters_config = parameters_config
+
+    @property
+    def drilldown_config(self):
+        """
+        Gets the drilldown_config of this UpdateManagementDashboardDetails.
+        Drill-down configuration to define the destination of a drill-down action.
+
+
+        :return: The drilldown_config of this UpdateManagementDashboardDetails.
+        :rtype: list[object]
+        """
+        return self._drilldown_config
+
+    @drilldown_config.setter
+    def drilldown_config(self, drilldown_config):
+        """
+        Sets the drilldown_config of this UpdateManagementDashboardDetails.
+        Drill-down configuration to define the destination of a drill-down action.
+
+
+        :param drilldown_config: The drilldown_config of this UpdateManagementDashboardDetails.
+        :type: list[object]
+        """
+        self._drilldown_config = drilldown_config
 
     @property
     def freeform_tags(self):

--- a/src/oci/management_dashboard/models/update_management_saved_search_details.py
+++ b/src/oci/management_dashboard/models/update_management_saved_search_details.py
@@ -99,6 +99,10 @@ class UpdateManagementSavedSearchDetails(object):
             The value to assign to the parameters_config property of this UpdateManagementSavedSearchDetails.
         :type parameters_config: list[object]
 
+        :param drilldown_config:
+            The value to assign to the drilldown_config property of this UpdateManagementSavedSearchDetails.
+        :type drilldown_config: list[object]
+
         :param freeform_tags:
             The value to assign to the freeform_tags property of this UpdateManagementSavedSearchDetails.
         :type freeform_tags: dict(str, str)
@@ -125,6 +129,7 @@ class UpdateManagementSavedSearchDetails(object):
             'widget_template': 'str',
             'widget_vm': 'str',
             'parameters_config': 'list[object]',
+            'drilldown_config': 'list[object]',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))'
         }
@@ -146,6 +151,7 @@ class UpdateManagementSavedSearchDetails(object):
             'widget_template': 'widgetTemplate',
             'widget_vm': 'widgetVM',
             'parameters_config': 'parametersConfig',
+            'drilldown_config': 'drilldownConfig',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags'
         }
@@ -166,6 +172,7 @@ class UpdateManagementSavedSearchDetails(object):
         self._widget_template = None
         self._widget_vm = None
         self._parameters_config = None
+        self._drilldown_config = None
         self._freeform_tags = None
         self._defined_tags = None
 
@@ -560,6 +567,30 @@ class UpdateManagementSavedSearchDetails(object):
         :type: list[object]
         """
         self._parameters_config = parameters_config
+
+    @property
+    def drilldown_config(self):
+        """
+        Gets the drilldown_config of this UpdateManagementSavedSearchDetails.
+        Drill-down configuration to define the destination of a drill-down action.
+
+
+        :return: The drilldown_config of this UpdateManagementSavedSearchDetails.
+        :rtype: list[object]
+        """
+        return self._drilldown_config
+
+    @drilldown_config.setter
+    def drilldown_config(self, drilldown_config):
+        """
+        Sets the drilldown_config of this UpdateManagementSavedSearchDetails.
+        Drill-down configuration to define the destination of a drill-down action.
+
+
+        :param drilldown_config: The drilldown_config of this UpdateManagementSavedSearchDetails.
+        :type: list[object]
+        """
+        self._drilldown_config = drilldown_config
 
     @property
     def freeform_tags(self):

--- a/src/oci/operator_access_control/access_requests_client.py
+++ b/src/oci/operator_access_control/access_requests_client.py
@@ -385,10 +385,23 @@ class AccessRequestsClient(object):
         :param str resource_name: (optional)
             A filter to return only resources that match the given ResourceName.
 
+        :param str resource_type: (optional)
+            A filter to return only lists of resources that match the entire given service type.
+
         :param str lifecycle_state: (optional)
             A filter to return only resources whose lifecycleState matches the given AccessRequest lifecycleState.
 
-            Allowed values are: "CREATED", "APPROVALWAITING", "PREAPPROVED", "APPROVED", "REJECTED", "DEPLOYED", "DEPLOYFAILED", "UNDEPLOYED", "UNDEPLOYFAILED", "CLOSEFAILED", "REVOKEFAILED", "EXPIRYFAILED", "REVOKING", "REVOKED", "EXTENDING", "EXTENDED", "EXTENSIONREJECTED", "COMPLETING", "COMPLETED", "EXPIRED"
+            Allowed values are: "CREATED", "APPROVALWAITING", "PREAPPROVED", "APPROVED", "REJECTED", "DEPLOYED", "DEPLOYFAILED", "UNDEPLOYED", "UNDEPLOYFAILED", "CLOSEFAILED", "REVOKEFAILED", "EXPIRYFAILED", "REVOKING", "REVOKED", "EXTENDING", "EXTENDED", "EXTENSIONREJECTED", "COMPLETING", "COMPLETED", "EXPIRED", "APPROVEDFORFUTURE", "INREVIEW"
+
+        :param datetime time_start: (optional)
+            Query start time in UTC in ISO 8601 format(inclusive).
+            Example 2019-10-30T00:00:00Z (yyyy-MM-ddThh:mm:ssZ).
+            timeIntervalStart and timeIntervalEnd parameters are used together.
+
+        :param datetime time_end: (optional)
+            Query start time in UTC in ISO 8601 format(inclusive).
+            Example 2019-10-30T00:00:00Z (yyyy-MM-ddThh:mm:ssZ).
+            timeIntervalStart and timeIntervalEnd parameters are used together.
 
         :param int limit: (optional)
             The maximum number of items to return.
@@ -430,7 +443,10 @@ class AccessRequestsClient(object):
         expected_kwargs = [
             "retry_strategy",
             "resource_name",
+            "resource_type",
             "lifecycle_state",
+            "time_start",
+            "time_end",
             "limit",
             "page",
             "sort_order",
@@ -443,7 +459,7 @@ class AccessRequestsClient(object):
                 "list_access_requests got unknown kwargs: {!r}".format(extra_kwargs))
 
         if 'lifecycle_state' in kwargs:
-            lifecycle_state_allowed_values = ["CREATED", "APPROVALWAITING", "PREAPPROVED", "APPROVED", "REJECTED", "DEPLOYED", "DEPLOYFAILED", "UNDEPLOYED", "UNDEPLOYFAILED", "CLOSEFAILED", "REVOKEFAILED", "EXPIRYFAILED", "REVOKING", "REVOKED", "EXTENDING", "EXTENDED", "EXTENSIONREJECTED", "COMPLETING", "COMPLETED", "EXPIRED"]
+            lifecycle_state_allowed_values = ["CREATED", "APPROVALWAITING", "PREAPPROVED", "APPROVED", "REJECTED", "DEPLOYED", "DEPLOYFAILED", "UNDEPLOYED", "UNDEPLOYFAILED", "CLOSEFAILED", "REVOKEFAILED", "EXPIRYFAILED", "REVOKING", "REVOKED", "EXTENDING", "EXTENDED", "EXTENSIONREJECTED", "COMPLETING", "COMPLETED", "EXPIRED", "APPROVEDFORFUTURE", "INREVIEW"]
             if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
                 raise ValueError(
                     "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
@@ -466,7 +482,10 @@ class AccessRequestsClient(object):
         query_params = {
             "compartmentId": compartment_id,
             "resourceName": kwargs.get("resource_name", missing),
+            "resourceType": kwargs.get("resource_type", missing),
             "lifecycleState": kwargs.get("lifecycle_state", missing),
+            "timeStart": kwargs.get("time_start", missing),
+            "timeEnd": kwargs.get("time_end", missing),
             "limit": kwargs.get("limit", missing),
             "page": kwargs.get("page", missing),
             "sortOrder": kwargs.get("sort_order", missing),
@@ -605,6 +624,109 @@ class AccessRequestsClient(object):
                 path_params=path_params,
                 header_params=header_params,
                 body=reject_access_request_details)
+
+    def review_access_request(self, access_request_id, review_access_request_details, **kwargs):
+        """
+        Reviews the access request.
+
+
+        :param str access_request_id: (required)
+            unique AccessRequest identifier
+
+        :param oci.operator_access_control.models.ReviewAccessRequestDetails review_access_request_details: (required)
+            Details regarding the approval of an access request created by the operator.
+
+        :param str opc_retry_token: (optional)
+            A token that uniquely identifies a request so it can be retried in case of a timeout or
+            server error without risk of executing that same action again. Retry tokens expire after 24
+            hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+            has been deleted and purged from the system, then a retry of the original creation request
+            might be rejected.
+
+        :param str if_match: (optional)
+            For optimistic concurrency control. In the PUT or DELETE call
+            for a resource, set the `if-match` parameter to the value of the
+            etag from a previous GET or POST response for that resource.
+            The resource will be updated or deleted only if the etag you
+            provide matches the resource's current etag value.
+
+        :param str opc_request_id: (optional)
+            The client request ID for tracing.
+
+        :param obj retry_strategy: (optional)
+            A retry strategy to apply to this specific operation/call. This will override any retry strategy set at the client-level.
+
+            This should be one of the strategies available in the :py:mod:`~oci.retry` module. This operation will not retry by default, users can also use the convenient :py:data:`~oci.retry.DEFAULT_RETRY_STRATEGY` provided by the SDK to enable retries for it.
+            The specifics of the default retry strategy are described `here <https://docs.oracle.com/en-us/iaas/tools/python/latest/sdk_behaviors/retries.html>`__.
+
+            To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
+
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.operator_access_control.models.AccessRequest`
+        :rtype: :class:`~oci.response.Response`
+
+        :example:
+        Click `here <https://docs.cloud.oracle.com/en-us/iaas/tools/python-sdk-examples/latest/operatoraccesscontrol/review_access_request.py.html>`__ to see an example of how to use review_access_request API.
+        """
+        resource_path = "/accessRequests/{accessRequestId}/action/review"
+        method = "POST"
+
+        # Don't accept unknown kwargs
+        expected_kwargs = [
+            "retry_strategy",
+            "opc_retry_token",
+            "if_match",
+            "opc_request_id"
+        ]
+        extra_kwargs = [_key for _key in six.iterkeys(kwargs) if _key not in expected_kwargs]
+        if extra_kwargs:
+            raise ValueError(
+                "review_access_request got unknown kwargs: {!r}".format(extra_kwargs))
+
+        path_params = {
+            "accessRequestId": access_request_id
+        }
+
+        path_params = {k: v for (k, v) in six.iteritems(path_params) if v is not missing}
+
+        for (k, v) in six.iteritems(path_params):
+            if v is None or (isinstance(v, six.string_types) and len(v.strip()) == 0):
+                raise ValueError('Parameter {} cannot be None, whitespace or empty string'.format(k))
+
+        header_params = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "opc-retry-token": kwargs.get("opc_retry_token", missing),
+            "if-match": kwargs.get("if_match", missing),
+            "opc-request-id": kwargs.get("opc_request_id", missing)
+        }
+        header_params = {k: v for (k, v) in six.iteritems(header_params) if v is not missing and v is not None}
+
+        retry_strategy = self.base_client.get_preferred_retry_strategy(
+            operation_retry_strategy=kwargs.get('retry_strategy'),
+            client_retry_strategy=self.retry_strategy
+        )
+
+        if retry_strategy:
+            if not isinstance(retry_strategy, retry.NoneRetryStrategy):
+                self.base_client.add_opc_retry_token_if_needed(header_params)
+                self.base_client.add_opc_client_retries_header(header_params)
+                retry_strategy.add_circuit_breaker_callback(self.circuit_breaker_callback)
+            return retry_strategy.make_retrying_call(
+                self.base_client.call_api,
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=review_access_request_details,
+                response_type="AccessRequest")
+        else:
+            return self.base_client.call_api(
+                resource_path=resource_path,
+                method=method,
+                path_params=path_params,
+                header_params=header_params,
+                body=review_access_request_details,
+                response_type="AccessRequest")
 
     def revoke_access_request(self, access_request_id, revoke_access_request_details, **kwargs):
         """

--- a/src/oci/operator_access_control/access_requests_client_composite_operations.py
+++ b/src/oci/operator_access_control/access_requests_client_composite_operations.py
@@ -22,3 +22,44 @@ class AccessRequestsClientCompositeOperations(object):
             The service client which will be wrapped by this object
         """
         self.client = client
+
+    def review_access_request_and_wait_for_state(self, access_request_id, review_access_request_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.operator_access_control.AccessRequestsClient.review_access_request` and waits for the :py:class:`~oci.operator_access_control.models.AccessRequest` acted upon
+        to enter the given state(s).
+
+        :param str access_request_id: (required)
+            unique AccessRequest identifier
+
+        :param oci.operator_access_control.models.ReviewAccessRequestDetails review_access_request_details: (required)
+            Details regarding the approval of an access request created by the operator.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.operator_access_control.models.AccessRequest.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.operator_access_control.AccessRequestsClient.review_access_request`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.review_access_request(access_request_id, review_access_request_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_access_request(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)

--- a/src/oci/operator_access_control/models/__init__.py
+++ b/src/oci/operator_access_control/models/__init__.py
@@ -25,6 +25,7 @@ from .operator_control_assignment_summary import OperatorControlAssignmentSummar
 from .operator_control_collection import OperatorControlCollection
 from .operator_control_summary import OperatorControlSummary
 from .reject_access_request_details import RejectAccessRequestDetails
+from .review_access_request_details import ReviewAccessRequestDetails
 from .revoke_access_request_details import RevokeAccessRequestDetails
 from .update_operator_control_assignment_details import UpdateOperatorControlAssignmentDetails
 from .update_operator_control_details import UpdateOperatorControlDetails
@@ -52,6 +53,7 @@ operator_access_control_type_mapping = {
     "OperatorControlCollection": OperatorControlCollection,
     "OperatorControlSummary": OperatorControlSummary,
     "RejectAccessRequestDetails": RejectAccessRequestDetails,
+    "ReviewAccessRequestDetails": ReviewAccessRequestDetails,
     "RevokeAccessRequestDetails": RevokeAccessRequestDetails,
     "UpdateOperatorControlAssignmentDetails": UpdateOperatorControlAssignmentDetails,
     "UpdateOperatorControlDetails": UpdateOperatorControlDetails

--- a/src/oci/operator_access_control/models/access_request.py
+++ b/src/oci/operator_access_control/models/access_request.py
@@ -21,6 +21,18 @@ class AccessRequest(object):
     An operator can also request for an extension. The approval for such an extension is processed the same way the original access request was processed.
     """
 
+    #: A constant which can be used with the resource_type property of a AccessRequest.
+    #: This constant has a value of "EXACC"
+    RESOURCE_TYPE_EXACC = "EXACC"
+
+    #: A constant which can be used with the resource_type property of a AccessRequest.
+    #: This constant has a value of "EXADATAINFRASTRUCTURE"
+    RESOURCE_TYPE_EXADATAINFRASTRUCTURE = "EXADATAINFRASTRUCTURE"
+
+    #: A constant which can be used with the resource_type property of a AccessRequest.
+    #: This constant has a value of "AUTONOMOUSVMCLUSTER"
+    RESOURCE_TYPE_AUTONOMOUSVMCLUSTER = "AUTONOMOUSVMCLUSTER"
+
     #: A constant which can be used with the severity property of a AccessRequest.
     #: This constant has a value of "S1"
     SEVERITY_S1 = "S1"
@@ -117,6 +129,14 @@ class AccessRequest(object):
     #: This constant has a value of "EXPIRED"
     LIFECYCLE_STATE_EXPIRED = "EXPIRED"
 
+    #: A constant which can be used with the lifecycle_state property of a AccessRequest.
+    #: This constant has a value of "APPROVEDFORFUTURE"
+    LIFECYCLE_STATE_APPROVEDFORFUTURE = "APPROVEDFORFUTURE"
+
+    #: A constant which can be used with the lifecycle_state property of a AccessRequest.
+    #: This constant has a value of "INREVIEW"
+    LIFECYCLE_STATE_INREVIEW = "INREVIEW"
+
     def __init__(self, **kwargs):
         """
         Initializes a new AccessRequest object with values from keyword arguments.
@@ -150,6 +170,12 @@ class AccessRequest(object):
             The value to assign to the compartment_id property of this AccessRequest.
         :type compartment_id: str
 
+        :param resource_type:
+            The value to assign to the resource_type property of this AccessRequest.
+            Allowed values for this property are: "EXACC", "EXADATAINFRASTRUCTURE", "AUTONOMOUSVMCLUSTER", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type resource_type: str
+
         :param action_requests_list:
             The value to assign to the action_requests_list property of this AccessRequest.
         :type action_requests_list: list[str]
@@ -182,7 +208,7 @@ class AccessRequest(object):
 
         :param lifecycle_state:
             The value to assign to the lifecycle_state property of this AccessRequest.
-            Allowed values for this property are: "CREATED", "APPROVALWAITING", "PREAPPROVED", "APPROVED", "REJECTED", "DEPLOYED", "DEPLOYFAILED", "UNDEPLOYED", "UNDEPLOYFAILED", "CLOSEFAILED", "REVOKEFAILED", "EXPIRYFAILED", "REVOKING", "REVOKED", "EXTENDING", "EXTENDED", "EXTENSIONREJECTED", "COMPLETING", "COMPLETED", "EXPIRED", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "CREATED", "APPROVALWAITING", "PREAPPROVED", "APPROVED", "REJECTED", "DEPLOYED", "DEPLOYFAILED", "UNDEPLOYED", "UNDEPLOYFAILED", "CLOSEFAILED", "REVOKEFAILED", "EXPIRYFAILED", "REVOKING", "REVOKED", "EXTENDING", "EXTENDED", "EXTENSIONREJECTED", "COMPLETING", "COMPLETED", "EXPIRED", "APPROVEDFORFUTURE", "INREVIEW", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type lifecycle_state: str
 
@@ -193,6 +219,10 @@ class AccessRequest(object):
         :param time_of_modification:
             The value to assign to the time_of_modification property of this AccessRequest.
         :type time_of_modification: datetime
+
+        :param time_of_user_creation:
+            The value to assign to the time_of_user_creation property of this AccessRequest.
+        :type time_of_user_creation: datetime
 
         :param user_id:
             The value to assign to the user_id property of this AccessRequest.
@@ -243,6 +273,7 @@ class AccessRequest(object):
             'resource_id': 'str',
             'resource_name': 'str',
             'compartment_id': 'str',
+            'resource_type': 'str',
             'action_requests_list': 'list[str]',
             'reason': 'str',
             'severity': 'str',
@@ -253,6 +284,7 @@ class AccessRequest(object):
             'lifecycle_state': 'str',
             'time_of_creation': 'datetime',
             'time_of_modification': 'datetime',
+            'time_of_user_creation': 'datetime',
             'user_id': 'str',
             'approver_comment': 'str',
             'closure_comment': 'str',
@@ -273,6 +305,7 @@ class AccessRequest(object):
             'resource_id': 'resourceId',
             'resource_name': 'resourceName',
             'compartment_id': 'compartmentId',
+            'resource_type': 'resourceType',
             'action_requests_list': 'actionRequestsList',
             'reason': 'reason',
             'severity': 'severity',
@@ -283,6 +316,7 @@ class AccessRequest(object):
             'lifecycle_state': 'lifecycleState',
             'time_of_creation': 'timeOfCreation',
             'time_of_modification': 'timeOfModification',
+            'time_of_user_creation': 'timeOfUserCreation',
             'user_id': 'userId',
             'approver_comment': 'approverComment',
             'closure_comment': 'closureComment',
@@ -302,6 +336,7 @@ class AccessRequest(object):
         self._resource_id = None
         self._resource_name = None
         self._compartment_id = None
+        self._resource_type = None
         self._action_requests_list = None
         self._reason = None
         self._severity = None
@@ -312,6 +347,7 @@ class AccessRequest(object):
         self._lifecycle_state = None
         self._time_of_creation = None
         self._time_of_modification = None
+        self._time_of_user_creation = None
         self._user_id = None
         self._approver_comment = None
         self._closure_comment = None
@@ -496,6 +532,36 @@ class AccessRequest(object):
         self._compartment_id = compartment_id
 
     @property
+    def resource_type(self):
+        """
+        Gets the resource_type of this AccessRequest.
+        resourceType for which the AccessRequest is applicable
+
+        Allowed values for this property are: "EXACC", "EXADATAINFRASTRUCTURE", "AUTONOMOUSVMCLUSTER", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The resource_type of this AccessRequest.
+        :rtype: str
+        """
+        return self._resource_type
+
+    @resource_type.setter
+    def resource_type(self, resource_type):
+        """
+        Sets the resource_type of this AccessRequest.
+        resourceType for which the AccessRequest is applicable
+
+
+        :param resource_type: The resource_type of this AccessRequest.
+        :type: str
+        """
+        allowed_values = ["EXACC", "EXADATAINFRASTRUCTURE", "AUTONOMOUSVMCLUSTER"]
+        if not value_allowed_none_or_none_sentinel(resource_type, allowed_values):
+            resource_type = 'UNKNOWN_ENUM_VALUE'
+        self._resource_type = resource_type
+
+    @property
     def action_requests_list(self):
         """
         Gets the action_requests_list of this AccessRequest.
@@ -677,7 +743,7 @@ class AccessRequest(object):
         Gets the lifecycle_state of this AccessRequest.
         The current state of the AccessRequest.
 
-        Allowed values for this property are: "CREATED", "APPROVALWAITING", "PREAPPROVED", "APPROVED", "REJECTED", "DEPLOYED", "DEPLOYFAILED", "UNDEPLOYED", "UNDEPLOYFAILED", "CLOSEFAILED", "REVOKEFAILED", "EXPIRYFAILED", "REVOKING", "REVOKED", "EXTENDING", "EXTENDED", "EXTENSIONREJECTED", "COMPLETING", "COMPLETED", "EXPIRED", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "CREATED", "APPROVALWAITING", "PREAPPROVED", "APPROVED", "REJECTED", "DEPLOYED", "DEPLOYFAILED", "UNDEPLOYED", "UNDEPLOYFAILED", "CLOSEFAILED", "REVOKEFAILED", "EXPIRYFAILED", "REVOKING", "REVOKED", "EXTENDING", "EXTENDED", "EXTENSIONREJECTED", "COMPLETING", "COMPLETED", "EXPIRED", "APPROVEDFORFUTURE", "INREVIEW", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -696,7 +762,7 @@ class AccessRequest(object):
         :param lifecycle_state: The lifecycle_state of this AccessRequest.
         :type: str
         """
-        allowed_values = ["CREATED", "APPROVALWAITING", "PREAPPROVED", "APPROVED", "REJECTED", "DEPLOYED", "DEPLOYFAILED", "UNDEPLOYED", "UNDEPLOYFAILED", "CLOSEFAILED", "REVOKEFAILED", "EXPIRYFAILED", "REVOKING", "REVOKED", "EXTENDING", "EXTENDED", "EXTENSIONREJECTED", "COMPLETING", "COMPLETED", "EXPIRED"]
+        allowed_values = ["CREATED", "APPROVALWAITING", "PREAPPROVED", "APPROVED", "REJECTED", "DEPLOYED", "DEPLOYFAILED", "UNDEPLOYED", "UNDEPLOYFAILED", "CLOSEFAILED", "REVOKEFAILED", "EXPIRYFAILED", "REVOKING", "REVOKED", "EXTENDING", "EXTENDED", "EXTENSIONREJECTED", "COMPLETING", "COMPLETED", "EXPIRED", "APPROVEDFORFUTURE", "INREVIEW"]
         if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
             lifecycle_state = 'UNKNOWN_ENUM_VALUE'
         self._lifecycle_state = lifecycle_state
@@ -756,6 +822,34 @@ class AccessRequest(object):
         :type: datetime
         """
         self._time_of_modification = time_of_modification
+
+    @property
+    def time_of_user_creation(self):
+        """
+        Gets the time_of_user_creation of this AccessRequest.
+        The time when access request is scheduled to be approved in `RFC 3339`__ timestamp format.Example: '2020-05-22T21:10:29.600Z'
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :return: The time_of_user_creation of this AccessRequest.
+        :rtype: datetime
+        """
+        return self._time_of_user_creation
+
+    @time_of_user_creation.setter
+    def time_of_user_creation(self, time_of_user_creation):
+        """
+        Sets the time_of_user_creation of this AccessRequest.
+        The time when access request is scheduled to be approved in `RFC 3339`__ timestamp format.Example: '2020-05-22T21:10:29.600Z'
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :param time_of_user_creation: The time_of_user_creation of this AccessRequest.
+        :type: datetime
+        """
+        self._time_of_user_creation = time_of_user_creation
 
     @property
     def user_id(self):

--- a/src/oci/operator_access_control/models/access_request_history_summary.py
+++ b/src/oci/operator_access_control/models/access_request_history_summary.py
@@ -93,6 +93,14 @@ class AccessRequestHistorySummary(object):
     #: This constant has a value of "EXPIRED"
     LIFECYCLE_STATE_EXPIRED = "EXPIRED"
 
+    #: A constant which can be used with the lifecycle_state property of a AccessRequestHistorySummary.
+    #: This constant has a value of "APPROVEDFORFUTURE"
+    LIFECYCLE_STATE_APPROVEDFORFUTURE = "APPROVEDFORFUTURE"
+
+    #: A constant which can be used with the lifecycle_state property of a AccessRequestHistorySummary.
+    #: This constant has a value of "INREVIEW"
+    LIFECYCLE_STATE_INREVIEW = "INREVIEW"
+
     def __init__(self, **kwargs):
         """
         Initializes a new AccessRequestHistorySummary object with values from keyword arguments.
@@ -100,7 +108,7 @@ class AccessRequestHistorySummary(object):
 
         :param lifecycle_state:
             The value to assign to the lifecycle_state property of this AccessRequestHistorySummary.
-            Allowed values for this property are: "CREATED", "APPROVALWAITING", "PREAPPROVED", "APPROVED", "REJECTED", "DEPLOYED", "DEPLOYFAILED", "UNDEPLOYED", "UNDEPLOYFAILED", "CLOSEFAILED", "REVOKEFAILED", "EXPIRYFAILED", "REVOKING", "REVOKED", "EXTENDING", "EXTENDED", "EXTENSIONREJECTED", "COMPLETING", "COMPLETED", "EXPIRED", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "CREATED", "APPROVALWAITING", "PREAPPROVED", "APPROVED", "REJECTED", "DEPLOYED", "DEPLOYFAILED", "UNDEPLOYED", "UNDEPLOYFAILED", "CLOSEFAILED", "REVOKEFAILED", "EXPIRYFAILED", "REVOKING", "REVOKED", "EXTENDING", "EXTENDED", "EXTENSIONREJECTED", "COMPLETING", "COMPLETED", "EXPIRED", "APPROVEDFORFUTURE", "INREVIEW", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type lifecycle_state: str
 
@@ -163,7 +171,7 @@ class AccessRequestHistorySummary(object):
         Gets the lifecycle_state of this AccessRequestHistorySummary.
         The current state of the AccessRequest.
 
-        Allowed values for this property are: "CREATED", "APPROVALWAITING", "PREAPPROVED", "APPROVED", "REJECTED", "DEPLOYED", "DEPLOYFAILED", "UNDEPLOYED", "UNDEPLOYFAILED", "CLOSEFAILED", "REVOKEFAILED", "EXPIRYFAILED", "REVOKING", "REVOKED", "EXTENDING", "EXTENDED", "EXTENSIONREJECTED", "COMPLETING", "COMPLETED", "EXPIRED", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "CREATED", "APPROVALWAITING", "PREAPPROVED", "APPROVED", "REJECTED", "DEPLOYED", "DEPLOYFAILED", "UNDEPLOYED", "UNDEPLOYFAILED", "CLOSEFAILED", "REVOKEFAILED", "EXPIRYFAILED", "REVOKING", "REVOKED", "EXTENDING", "EXTENDED", "EXTENSIONREJECTED", "COMPLETING", "COMPLETED", "EXPIRED", "APPROVEDFORFUTURE", "INREVIEW", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -182,7 +190,7 @@ class AccessRequestHistorySummary(object):
         :param lifecycle_state: The lifecycle_state of this AccessRequestHistorySummary.
         :type: str
         """
-        allowed_values = ["CREATED", "APPROVALWAITING", "PREAPPROVED", "APPROVED", "REJECTED", "DEPLOYED", "DEPLOYFAILED", "UNDEPLOYED", "UNDEPLOYFAILED", "CLOSEFAILED", "REVOKEFAILED", "EXPIRYFAILED", "REVOKING", "REVOKED", "EXTENDING", "EXTENDED", "EXTENSIONREJECTED", "COMPLETING", "COMPLETED", "EXPIRED"]
+        allowed_values = ["CREATED", "APPROVALWAITING", "PREAPPROVED", "APPROVED", "REJECTED", "DEPLOYED", "DEPLOYFAILED", "UNDEPLOYED", "UNDEPLOYFAILED", "CLOSEFAILED", "REVOKEFAILED", "EXPIRYFAILED", "REVOKING", "REVOKED", "EXTENDING", "EXTENDED", "EXTENSIONREJECTED", "COMPLETING", "COMPLETED", "EXPIRED", "APPROVEDFORFUTURE", "INREVIEW"]
         if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
             lifecycle_state = 'UNKNOWN_ENUM_VALUE'
         self._lifecycle_state = lifecycle_state

--- a/src/oci/operator_access_control/models/access_request_summary.py
+++ b/src/oci/operator_access_control/models/access_request_summary.py
@@ -13,6 +13,18 @@ class AccessRequestSummary(object):
     Summary of access request.
     """
 
+    #: A constant which can be used with the resource_type property of a AccessRequestSummary.
+    #: This constant has a value of "EXACC"
+    RESOURCE_TYPE_EXACC = "EXACC"
+
+    #: A constant which can be used with the resource_type property of a AccessRequestSummary.
+    #: This constant has a value of "EXADATAINFRASTRUCTURE"
+    RESOURCE_TYPE_EXADATAINFRASTRUCTURE = "EXADATAINFRASTRUCTURE"
+
+    #: A constant which can be used with the resource_type property of a AccessRequestSummary.
+    #: This constant has a value of "AUTONOMOUSVMCLUSTER"
+    RESOURCE_TYPE_AUTONOMOUSVMCLUSTER = "AUTONOMOUSVMCLUSTER"
+
     #: A constant which can be used with the lifecycle_state property of a AccessRequestSummary.
     #: This constant has a value of "CREATED"
     LIFECYCLE_STATE_CREATED = "CREATED"
@@ -93,6 +105,14 @@ class AccessRequestSummary(object):
     #: This constant has a value of "EXPIRED"
     LIFECYCLE_STATE_EXPIRED = "EXPIRED"
 
+    #: A constant which can be used with the lifecycle_state property of a AccessRequestSummary.
+    #: This constant has a value of "APPROVEDFORFUTURE"
+    LIFECYCLE_STATE_APPROVEDFORFUTURE = "APPROVEDFORFUTURE"
+
+    #: A constant which can be used with the lifecycle_state property of a AccessRequestSummary.
+    #: This constant has a value of "INREVIEW"
+    LIFECYCLE_STATE_INREVIEW = "INREVIEW"
+
     #: A constant which can be used with the severity property of a AccessRequestSummary.
     #: This constant has a value of "S1"
     SEVERITY_S1 = "S1"
@@ -138,9 +158,15 @@ class AccessRequestSummary(object):
             The value to assign to the resource_name property of this AccessRequestSummary.
         :type resource_name: str
 
+        :param resource_type:
+            The value to assign to the resource_type property of this AccessRequestSummary.
+            Allowed values for this property are: "EXACC", "EXADATAINFRASTRUCTURE", "AUTONOMOUSVMCLUSTER", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type resource_type: str
+
         :param lifecycle_state:
             The value to assign to the lifecycle_state property of this AccessRequestSummary.
-            Allowed values for this property are: "CREATED", "APPROVALWAITING", "PREAPPROVED", "APPROVED", "REJECTED", "DEPLOYED", "DEPLOYFAILED", "UNDEPLOYED", "UNDEPLOYFAILED", "CLOSEFAILED", "REVOKEFAILED", "EXPIRYFAILED", "REVOKING", "REVOKED", "EXTENDING", "EXTENDED", "EXTENSIONREJECTED", "COMPLETING", "COMPLETED", "EXPIRED", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "CREATED", "APPROVALWAITING", "PREAPPROVED", "APPROVED", "REJECTED", "DEPLOYED", "DEPLOYFAILED", "UNDEPLOYED", "UNDEPLOYFAILED", "CLOSEFAILED", "REVOKEFAILED", "EXPIRYFAILED", "REVOKING", "REVOKED", "EXTENDING", "EXTENDED", "EXTENSIONREJECTED", "COMPLETING", "COMPLETED", "EXPIRED", "APPROVEDFORFUTURE", "INREVIEW", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type lifecycle_state: str
 
@@ -151,6 +177,10 @@ class AccessRequestSummary(object):
         :param time_of_modification:
             The value to assign to the time_of_modification property of this AccessRequestSummary.
         :type time_of_modification: datetime
+
+        :param time_of_user_creation:
+            The value to assign to the time_of_user_creation property of this AccessRequestSummary.
+        :type time_of_user_creation: datetime
 
         :param duration:
             The value to assign to the duration property of this AccessRequestSummary.
@@ -186,9 +216,11 @@ class AccessRequestSummary(object):
             'compartment_id': 'str',
             'resource_id': 'str',
             'resource_name': 'str',
+            'resource_type': 'str',
             'lifecycle_state': 'str',
             'time_of_creation': 'datetime',
             'time_of_modification': 'datetime',
+            'time_of_user_creation': 'datetime',
             'duration': 'int',
             'extend_duration': 'int',
             'severity': 'str',
@@ -204,9 +236,11 @@ class AccessRequestSummary(object):
             'compartment_id': 'compartmentId',
             'resource_id': 'resourceId',
             'resource_name': 'resourceName',
+            'resource_type': 'resourceType',
             'lifecycle_state': 'lifecycleState',
             'time_of_creation': 'timeOfCreation',
             'time_of_modification': 'timeOfModification',
+            'time_of_user_creation': 'timeOfUserCreation',
             'duration': 'duration',
             'extend_duration': 'extendDuration',
             'severity': 'severity',
@@ -221,9 +255,11 @@ class AccessRequestSummary(object):
         self._compartment_id = None
         self._resource_id = None
         self._resource_name = None
+        self._resource_type = None
         self._lifecycle_state = None
         self._time_of_creation = None
         self._time_of_modification = None
+        self._time_of_user_creation = None
         self._duration = None
         self._extend_duration = None
         self._severity = None
@@ -378,12 +414,42 @@ class AccessRequestSummary(object):
         self._resource_name = resource_name
 
     @property
+    def resource_type(self):
+        """
+        Gets the resource_type of this AccessRequestSummary.
+        resourceType for which the AccessRequest is applicable
+
+        Allowed values for this property are: "EXACC", "EXADATAINFRASTRUCTURE", "AUTONOMOUSVMCLUSTER", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The resource_type of this AccessRequestSummary.
+        :rtype: str
+        """
+        return self._resource_type
+
+    @resource_type.setter
+    def resource_type(self, resource_type):
+        """
+        Sets the resource_type of this AccessRequestSummary.
+        resourceType for which the AccessRequest is applicable
+
+
+        :param resource_type: The resource_type of this AccessRequestSummary.
+        :type: str
+        """
+        allowed_values = ["EXACC", "EXADATAINFRASTRUCTURE", "AUTONOMOUSVMCLUSTER"]
+        if not value_allowed_none_or_none_sentinel(resource_type, allowed_values):
+            resource_type = 'UNKNOWN_ENUM_VALUE'
+        self._resource_type = resource_type
+
+    @property
     def lifecycle_state(self):
         """
         Gets the lifecycle_state of this AccessRequestSummary.
         The current state of the AccessRequest.
 
-        Allowed values for this property are: "CREATED", "APPROVALWAITING", "PREAPPROVED", "APPROVED", "REJECTED", "DEPLOYED", "DEPLOYFAILED", "UNDEPLOYED", "UNDEPLOYFAILED", "CLOSEFAILED", "REVOKEFAILED", "EXPIRYFAILED", "REVOKING", "REVOKED", "EXTENDING", "EXTENDED", "EXTENSIONREJECTED", "COMPLETING", "COMPLETED", "EXPIRED", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "CREATED", "APPROVALWAITING", "PREAPPROVED", "APPROVED", "REJECTED", "DEPLOYED", "DEPLOYFAILED", "UNDEPLOYED", "UNDEPLOYFAILED", "CLOSEFAILED", "REVOKEFAILED", "EXPIRYFAILED", "REVOKING", "REVOKED", "EXTENDING", "EXTENDED", "EXTENSIONREJECTED", "COMPLETING", "COMPLETED", "EXPIRED", "APPROVEDFORFUTURE", "INREVIEW", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -402,7 +468,7 @@ class AccessRequestSummary(object):
         :param lifecycle_state: The lifecycle_state of this AccessRequestSummary.
         :type: str
         """
-        allowed_values = ["CREATED", "APPROVALWAITING", "PREAPPROVED", "APPROVED", "REJECTED", "DEPLOYED", "DEPLOYFAILED", "UNDEPLOYED", "UNDEPLOYFAILED", "CLOSEFAILED", "REVOKEFAILED", "EXPIRYFAILED", "REVOKING", "REVOKED", "EXTENDING", "EXTENDED", "EXTENSIONREJECTED", "COMPLETING", "COMPLETED", "EXPIRED"]
+        allowed_values = ["CREATED", "APPROVALWAITING", "PREAPPROVED", "APPROVED", "REJECTED", "DEPLOYED", "DEPLOYFAILED", "UNDEPLOYED", "UNDEPLOYFAILED", "CLOSEFAILED", "REVOKEFAILED", "EXPIRYFAILED", "REVOKING", "REVOKED", "EXTENDING", "EXTENDED", "EXTENSIONREJECTED", "COMPLETING", "COMPLETED", "EXPIRED", "APPROVEDFORFUTURE", "INREVIEW"]
         if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
             lifecycle_state = 'UNKNOWN_ENUM_VALUE'
         self._lifecycle_state = lifecycle_state
@@ -462,6 +528,34 @@ class AccessRequestSummary(object):
         :type: datetime
         """
         self._time_of_modification = time_of_modification
+
+    @property
+    def time_of_user_creation(self):
+        """
+        Gets the time_of_user_creation of this AccessRequestSummary.
+        The time when access request is scheduled to be approved in `RFC 3339`__ timestamp format.Example: '2020-05-22T21:10:29.600Z'
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :return: The time_of_user_creation of this AccessRequestSummary.
+        :rtype: datetime
+        """
+        return self._time_of_user_creation
+
+    @time_of_user_creation.setter
+    def time_of_user_creation(self, time_of_user_creation):
+        """
+        Sets the time_of_user_creation of this AccessRequestSummary.
+        The time when access request is scheduled to be approved in `RFC 3339`__ timestamp format.Example: '2020-05-22T21:10:29.600Z'
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :param time_of_user_creation: The time_of_user_creation of this AccessRequestSummary.
+        :type: datetime
+        """
+        self._time_of_user_creation = time_of_user_creation
 
     @property
     def duration(self):

--- a/src/oci/operator_access_control/models/approve_access_request_details.py
+++ b/src/oci/operator_access_control/models/approve_access_request_details.py
@@ -30,22 +30,29 @@ class ApproveAccessRequestDetails(object):
             The value to assign to the additional_message property of this ApproveAccessRequestDetails.
         :type additional_message: str
 
+        :param time_of_user_creation:
+            The value to assign to the time_of_user_creation property of this ApproveAccessRequestDetails.
+        :type time_of_user_creation: datetime
+
         """
         self.swagger_types = {
             'approver_comment': 'str',
             'audit_type': 'list[str]',
-            'additional_message': 'str'
+            'additional_message': 'str',
+            'time_of_user_creation': 'datetime'
         }
 
         self.attribute_map = {
             'approver_comment': 'approverComment',
             'audit_type': 'auditType',
-            'additional_message': 'additionalMessage'
+            'additional_message': 'additionalMessage',
+            'time_of_user_creation': 'timeOfUserCreation'
         }
 
         self._approver_comment = None
         self._audit_type = None
         self._additional_message = None
+        self._time_of_user_creation = None
 
     @property
     def approver_comment(self):
@@ -122,6 +129,34 @@ class ApproveAccessRequestDetails(object):
         :type: str
         """
         self._additional_message = additional_message
+
+    @property
+    def time_of_user_creation(self):
+        """
+        Gets the time_of_user_creation of this ApproveAccessRequestDetails.
+        The time when access request is scheduled to be approved in `RFC 3339`__ timestamp format.Example: '2020-05-22T21:10:29.600Z'
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :return: The time_of_user_creation of this ApproveAccessRequestDetails.
+        :rtype: datetime
+        """
+        return self._time_of_user_creation
+
+    @time_of_user_creation.setter
+    def time_of_user_creation(self, time_of_user_creation):
+        """
+        Sets the time_of_user_creation of this ApproveAccessRequestDetails.
+        The time when access request is scheduled to be approved in `RFC 3339`__ timestamp format.Example: '2020-05-22T21:10:29.600Z'
+
+        __ https://tools.ietf.org/html/rfc3339
+
+
+        :param time_of_user_creation: The time_of_user_creation of this ApproveAccessRequestDetails.
+        :type: datetime
+        """
+        self._time_of_user_creation = time_of_user_creation
 
     def __repr__(self):
         return formatted_flat_dict(self)

--- a/src/oci/operator_access_control/models/create_operator_control_assignment_details.py
+++ b/src/oci/operator_access_control/models/create_operator_control_assignment_details.py
@@ -18,6 +18,14 @@ class CreateOperatorControlAssignmentDetails(object):
     #: This constant has a value of "EXACC"
     RESOURCE_TYPE_EXACC = "EXACC"
 
+    #: A constant which can be used with the resource_type property of a CreateOperatorControlAssignmentDetails.
+    #: This constant has a value of "EXADATAINFRASTRUCTURE"
+    RESOURCE_TYPE_EXADATAINFRASTRUCTURE = "EXADATAINFRASTRUCTURE"
+
+    #: A constant which can be used with the resource_type property of a CreateOperatorControlAssignmentDetails.
+    #: This constant has a value of "AUTONOMOUSVMCLUSTER"
+    RESOURCE_TYPE_AUTONOMOUSVMCLUSTER = "AUTONOMOUSVMCLUSTER"
+
     def __init__(self, **kwargs):
         """
         Initializes a new CreateOperatorControlAssignmentDetails object with values from keyword arguments.
@@ -37,7 +45,7 @@ class CreateOperatorControlAssignmentDetails(object):
 
         :param resource_type:
             The value to assign to the resource_type property of this CreateOperatorControlAssignmentDetails.
-            Allowed values for this property are: "EXACC"
+            Allowed values for this property are: "EXACC", "EXADATAINFRASTRUCTURE", "AUTONOMOUSVMCLUSTER"
         :type resource_type: str
 
         :param resource_compartment_id:
@@ -64,6 +72,26 @@ class CreateOperatorControlAssignmentDetails(object):
             The value to assign to the comment property of this CreateOperatorControlAssignmentDetails.
         :type comment: str
 
+        :param is_log_forwarded:
+            The value to assign to the is_log_forwarded property of this CreateOperatorControlAssignmentDetails.
+        :type is_log_forwarded: bool
+
+        :param remote_syslog_server_address:
+            The value to assign to the remote_syslog_server_address property of this CreateOperatorControlAssignmentDetails.
+        :type remote_syslog_server_address: str
+
+        :param remote_syslog_server_port:
+            The value to assign to the remote_syslog_server_port property of this CreateOperatorControlAssignmentDetails.
+        :type remote_syslog_server_port: int
+
+        :param remote_syslog_server_ca_cert:
+            The value to assign to the remote_syslog_server_ca_cert property of this CreateOperatorControlAssignmentDetails.
+        :type remote_syslog_server_ca_cert: str
+
+        :param is_auto_approve_during_maintenance:
+            The value to assign to the is_auto_approve_during_maintenance property of this CreateOperatorControlAssignmentDetails.
+        :type is_auto_approve_during_maintenance: bool
+
         :param freeform_tags:
             The value to assign to the freeform_tags property of this CreateOperatorControlAssignmentDetails.
         :type freeform_tags: dict(str, str)
@@ -84,6 +112,11 @@ class CreateOperatorControlAssignmentDetails(object):
             'compartment_id': 'str',
             'is_enforced_always': 'bool',
             'comment': 'str',
+            'is_log_forwarded': 'bool',
+            'remote_syslog_server_address': 'str',
+            'remote_syslog_server_port': 'int',
+            'remote_syslog_server_ca_cert': 'str',
+            'is_auto_approve_during_maintenance': 'bool',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))'
         }
@@ -99,6 +132,11 @@ class CreateOperatorControlAssignmentDetails(object):
             'compartment_id': 'compartmentId',
             'is_enforced_always': 'isEnforcedAlways',
             'comment': 'comment',
+            'is_log_forwarded': 'isLogForwarded',
+            'remote_syslog_server_address': 'remoteSyslogServerAddress',
+            'remote_syslog_server_port': 'remoteSyslogServerPort',
+            'remote_syslog_server_ca_cert': 'remoteSyslogServerCACert',
+            'is_auto_approve_during_maintenance': 'isAutoApproveDuringMaintenance',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags'
         }
@@ -113,6 +151,11 @@ class CreateOperatorControlAssignmentDetails(object):
         self._compartment_id = None
         self._is_enforced_always = None
         self._comment = None
+        self._is_log_forwarded = None
+        self._remote_syslog_server_address = None
+        self._remote_syslog_server_port = None
+        self._remote_syslog_server_ca_cert = None
+        self._is_auto_approve_during_maintenance = None
         self._freeform_tags = None
         self._defined_tags = None
 
@@ -191,10 +234,10 @@ class CreateOperatorControlAssignmentDetails(object):
     @property
     def resource_type(self):
         """
-        Gets the resource_type of this CreateOperatorControlAssignmentDetails.
+        **[Required]** Gets the resource_type of this CreateOperatorControlAssignmentDetails.
         Type of the target resource.
 
-        Allowed values for this property are: "EXACC"
+        Allowed values for this property are: "EXACC", "EXADATAINFRASTRUCTURE", "AUTONOMOUSVMCLUSTER"
 
 
         :return: The resource_type of this CreateOperatorControlAssignmentDetails.
@@ -212,7 +255,7 @@ class CreateOperatorControlAssignmentDetails(object):
         :param resource_type: The resource_type of this CreateOperatorControlAssignmentDetails.
         :type: str
         """
-        allowed_values = ["EXACC"]
+        allowed_values = ["EXACC", "EXADATAINFRASTRUCTURE", "AUTONOMOUSVMCLUSTER"]
         if not value_allowed_none_or_none_sentinel(resource_type, allowed_values):
             raise ValueError(
                 "Invalid value for `resource_type`, must be None or one of {0}"
@@ -327,7 +370,7 @@ class CreateOperatorControlAssignmentDetails(object):
     @property
     def is_enforced_always(self):
         """
-        Gets the is_enforced_always of this CreateOperatorControlAssignmentDetails.
+        **[Required]** Gets the is_enforced_always of this CreateOperatorControlAssignmentDetails.
         If set, then the target resource is always governed by the operator control.
 
 
@@ -371,6 +414,126 @@ class CreateOperatorControlAssignmentDetails(object):
         :type: str
         """
         self._comment = comment
+
+    @property
+    def is_log_forwarded(self):
+        """
+        Gets the is_log_forwarded of this CreateOperatorControlAssignmentDetails.
+        If set, then the audit logs will be forwarded to the relevant remote logging server
+
+
+        :return: The is_log_forwarded of this CreateOperatorControlAssignmentDetails.
+        :rtype: bool
+        """
+        return self._is_log_forwarded
+
+    @is_log_forwarded.setter
+    def is_log_forwarded(self, is_log_forwarded):
+        """
+        Sets the is_log_forwarded of this CreateOperatorControlAssignmentDetails.
+        If set, then the audit logs will be forwarded to the relevant remote logging server
+
+
+        :param is_log_forwarded: The is_log_forwarded of this CreateOperatorControlAssignmentDetails.
+        :type: bool
+        """
+        self._is_log_forwarded = is_log_forwarded
+
+    @property
+    def remote_syslog_server_address(self):
+        """
+        Gets the remote_syslog_server_address of this CreateOperatorControlAssignmentDetails.
+        The address of the remote syslog server where the audit logs will be forwarded to. Address in host or IP format.
+
+
+        :return: The remote_syslog_server_address of this CreateOperatorControlAssignmentDetails.
+        :rtype: str
+        """
+        return self._remote_syslog_server_address
+
+    @remote_syslog_server_address.setter
+    def remote_syslog_server_address(self, remote_syslog_server_address):
+        """
+        Sets the remote_syslog_server_address of this CreateOperatorControlAssignmentDetails.
+        The address of the remote syslog server where the audit logs will be forwarded to. Address in host or IP format.
+
+
+        :param remote_syslog_server_address: The remote_syslog_server_address of this CreateOperatorControlAssignmentDetails.
+        :type: str
+        """
+        self._remote_syslog_server_address = remote_syslog_server_address
+
+    @property
+    def remote_syslog_server_port(self):
+        """
+        Gets the remote_syslog_server_port of this CreateOperatorControlAssignmentDetails.
+        The listening port of the remote syslog server. The port range is 0 - 65535. Only TCP supported.
+
+
+        :return: The remote_syslog_server_port of this CreateOperatorControlAssignmentDetails.
+        :rtype: int
+        """
+        return self._remote_syslog_server_port
+
+    @remote_syslog_server_port.setter
+    def remote_syslog_server_port(self, remote_syslog_server_port):
+        """
+        Sets the remote_syslog_server_port of this CreateOperatorControlAssignmentDetails.
+        The listening port of the remote syslog server. The port range is 0 - 65535. Only TCP supported.
+
+
+        :param remote_syslog_server_port: The remote_syslog_server_port of this CreateOperatorControlAssignmentDetails.
+        :type: int
+        """
+        self._remote_syslog_server_port = remote_syslog_server_port
+
+    @property
+    def remote_syslog_server_ca_cert(self):
+        """
+        Gets the remote_syslog_server_ca_cert of this CreateOperatorControlAssignmentDetails.
+        The CA certificate of the remote syslog server. Identity of the remote syslog server will be asserted based on this certificate.
+
+
+        :return: The remote_syslog_server_ca_cert of this CreateOperatorControlAssignmentDetails.
+        :rtype: str
+        """
+        return self._remote_syslog_server_ca_cert
+
+    @remote_syslog_server_ca_cert.setter
+    def remote_syslog_server_ca_cert(self, remote_syslog_server_ca_cert):
+        """
+        Sets the remote_syslog_server_ca_cert of this CreateOperatorControlAssignmentDetails.
+        The CA certificate of the remote syslog server. Identity of the remote syslog server will be asserted based on this certificate.
+
+
+        :param remote_syslog_server_ca_cert: The remote_syslog_server_ca_cert of this CreateOperatorControlAssignmentDetails.
+        :type: str
+        """
+        self._remote_syslog_server_ca_cert = remote_syslog_server_ca_cert
+
+    @property
+    def is_auto_approve_during_maintenance(self):
+        """
+        Gets the is_auto_approve_during_maintenance of this CreateOperatorControlAssignmentDetails.
+        The boolean if true would autoApprove during maintenance.
+
+
+        :return: The is_auto_approve_during_maintenance of this CreateOperatorControlAssignmentDetails.
+        :rtype: bool
+        """
+        return self._is_auto_approve_during_maintenance
+
+    @is_auto_approve_during_maintenance.setter
+    def is_auto_approve_during_maintenance(self, is_auto_approve_during_maintenance):
+        """
+        Sets the is_auto_approve_during_maintenance of this CreateOperatorControlAssignmentDetails.
+        The boolean if true would autoApprove during maintenance.
+
+
+        :param is_auto_approve_during_maintenance: The is_auto_approve_during_maintenance of this CreateOperatorControlAssignmentDetails.
+        :type: bool
+        """
+        self._is_auto_approve_during_maintenance = is_auto_approve_during_maintenance
 
     @property
     def freeform_tags(self):

--- a/src/oci/operator_access_control/models/create_operator_control_details.py
+++ b/src/oci/operator_access_control/models/create_operator_control_details.py
@@ -17,6 +17,18 @@ class CreateOperatorControlDetails(object):
     You must name your Operator Control appropriately so it reflects the resources that will be governed by the Operator Control. Neither the Operator Controls nor their assignments to resources are visible to the Oracle operators.
     """
 
+    #: A constant which can be used with the resource_type property of a CreateOperatorControlDetails.
+    #: This constant has a value of "EXACC"
+    RESOURCE_TYPE_EXACC = "EXACC"
+
+    #: A constant which can be used with the resource_type property of a CreateOperatorControlDetails.
+    #: This constant has a value of "EXADATAINFRASTRUCTURE"
+    RESOURCE_TYPE_EXADATAINFRASTRUCTURE = "EXADATAINFRASTRUCTURE"
+
+    #: A constant which can be used with the resource_type property of a CreateOperatorControlDetails.
+    #: This constant has a value of "AUTONOMOUSVMCLUSTER"
+    RESOURCE_TYPE_AUTONOMOUSVMCLUSTER = "AUTONOMOUSVMCLUSTER"
+
     def __init__(self, **kwargs):
         """
         Initializes a new CreateOperatorControlDetails object with values from keyword arguments.
@@ -46,6 +58,11 @@ class CreateOperatorControlDetails(object):
             The value to assign to the is_fully_pre_approved property of this CreateOperatorControlDetails.
         :type is_fully_pre_approved: bool
 
+        :param resource_type:
+            The value to assign to the resource_type property of this CreateOperatorControlDetails.
+            Allowed values for this property are: "EXACC", "EXADATAINFRASTRUCTURE", "AUTONOMOUSVMCLUSTER"
+        :type resource_type: str
+
         :param email_id_list:
             The value to assign to the email_id_list property of this CreateOperatorControlDetails.
         :type email_id_list: list[str]
@@ -74,6 +91,7 @@ class CreateOperatorControlDetails(object):
             'approver_groups_list': 'list[str]',
             'pre_approved_op_action_list': 'list[str]',
             'is_fully_pre_approved': 'bool',
+            'resource_type': 'str',
             'email_id_list': 'list[str]',
             'system_message': 'str',
             'compartment_id': 'str',
@@ -88,6 +106,7 @@ class CreateOperatorControlDetails(object):
             'approver_groups_list': 'approverGroupsList',
             'pre_approved_op_action_list': 'preApprovedOpActionList',
             'is_fully_pre_approved': 'isFullyPreApproved',
+            'resource_type': 'resourceType',
             'email_id_list': 'emailIdList',
             'system_message': 'systemMessage',
             'compartment_id': 'compartmentId',
@@ -101,6 +120,7 @@ class CreateOperatorControlDetails(object):
         self._approver_groups_list = None
         self._pre_approved_op_action_list = None
         self._is_fully_pre_approved = None
+        self._resource_type = None
         self._email_id_list = None
         self._system_message = None
         self._compartment_id = None
@@ -182,7 +202,7 @@ class CreateOperatorControlDetails(object):
     @property
     def approver_groups_list(self):
         """
-        Gets the approver_groups_list of this CreateOperatorControlDetails.
+        **[Required]** Gets the approver_groups_list of this CreateOperatorControlDetails.
         List of user groups who can approve an access request associated with a resource governed by this operator control.
 
 
@@ -232,7 +252,7 @@ class CreateOperatorControlDetails(object):
     @property
     def is_fully_pre_approved(self):
         """
-        Gets the is_fully_pre_approved of this CreateOperatorControlDetails.
+        **[Required]** Gets the is_fully_pre_approved of this CreateOperatorControlDetails.
         Whether all the operator actions have been pre-approved. If yes, all access requests associated with a resource governed by this operator control
         will be auto-approved.
 
@@ -254,6 +274,38 @@ class CreateOperatorControlDetails(object):
         :type: bool
         """
         self._is_fully_pre_approved = is_fully_pre_approved
+
+    @property
+    def resource_type(self):
+        """
+        **[Required]** Gets the resource_type of this CreateOperatorControlDetails.
+        resourceType for which the OperatorControl is applicable
+
+        Allowed values for this property are: "EXACC", "EXADATAINFRASTRUCTURE", "AUTONOMOUSVMCLUSTER"
+
+
+        :return: The resource_type of this CreateOperatorControlDetails.
+        :rtype: str
+        """
+        return self._resource_type
+
+    @resource_type.setter
+    def resource_type(self, resource_type):
+        """
+        Sets the resource_type of this CreateOperatorControlDetails.
+        resourceType for which the OperatorControl is applicable
+
+
+        :param resource_type: The resource_type of this CreateOperatorControlDetails.
+        :type: str
+        """
+        allowed_values = ["EXACC", "EXADATAINFRASTRUCTURE", "AUTONOMOUSVMCLUSTER"]
+        if not value_allowed_none_or_none_sentinel(resource_type, allowed_values):
+            raise ValueError(
+                "Invalid value for `resource_type`, must be None or one of {0}"
+                .format(allowed_values)
+            )
+        self._resource_type = resource_type
 
     @property
     def email_id_list(self):

--- a/src/oci/operator_access_control/models/operator_action.py
+++ b/src/oci/operator_access_control/models/operator_action.py
@@ -18,6 +18,18 @@ class OperatorAction(object):
     The following infrastructure layers are controlled by the operator actions x-obmcs-top-level-enum: '#/definitions/InfrastructureLayers' enum: *INFRASTRUCTURELAYERS
     """
 
+    #: A constant which can be used with the resource_type property of a OperatorAction.
+    #: This constant has a value of "EXACC"
+    RESOURCE_TYPE_EXACC = "EXACC"
+
+    #: A constant which can be used with the resource_type property of a OperatorAction.
+    #: This constant has a value of "EXADATAINFRASTRUCTURE"
+    RESOURCE_TYPE_EXADATAINFRASTRUCTURE = "EXADATAINFRASTRUCTURE"
+
+    #: A constant which can be used with the resource_type property of a OperatorAction.
+    #: This constant has a value of "AUTONOMOUSVMCLUSTER"
+    RESOURCE_TYPE_AUTONOMOUSVMCLUSTER = "AUTONOMOUSVMCLUSTER"
+
     def __init__(self, **kwargs):
         """
         Initializes a new OperatorAction object with values from keyword arguments.
@@ -31,9 +43,19 @@ class OperatorAction(object):
             The value to assign to the name property of this OperatorAction.
         :type name: str
 
+        :param customer_display_name:
+            The value to assign to the customer_display_name property of this OperatorAction.
+        :type customer_display_name: str
+
         :param component:
             The value to assign to the component property of this OperatorAction.
         :type component: str
+
+        :param resource_type:
+            The value to assign to the resource_type property of this OperatorAction.
+            Allowed values for this property are: "EXACC", "EXADATAINFRASTRUCTURE", "AUTONOMOUSVMCLUSTER", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type resource_type: str
 
         :param description:
             The value to assign to the description property of this OperatorAction.
@@ -47,7 +69,9 @@ class OperatorAction(object):
         self.swagger_types = {
             'id': 'str',
             'name': 'str',
+            'customer_display_name': 'str',
             'component': 'str',
+            'resource_type': 'str',
             'description': 'str',
             'properties': 'list[OperatorActionProperties]'
         }
@@ -55,14 +79,18 @@ class OperatorAction(object):
         self.attribute_map = {
             'id': 'id',
             'name': 'name',
+            'customer_display_name': 'customerDisplayName',
             'component': 'component',
+            'resource_type': 'resourceType',
             'description': 'description',
             'properties': 'properties'
         }
 
         self._id = None
         self._name = None
+        self._customer_display_name = None
         self._component = None
+        self._resource_type = None
         self._description = None
         self._properties = None
 
@@ -94,7 +122,7 @@ class OperatorAction(object):
     def name(self):
         """
         **[Required]** Gets the name of this OperatorAction.
-        Name of the operator action.
+        Unique name of the operator action.
 
 
         :return: The name of this OperatorAction.
@@ -106,13 +134,37 @@ class OperatorAction(object):
     def name(self, name):
         """
         Sets the name of this OperatorAction.
-        Name of the operator action.
+        Unique name of the operator action.
 
 
         :param name: The name of this OperatorAction.
         :type: str
         """
         self._name = name
+
+    @property
+    def customer_display_name(self):
+        """
+        Gets the customer_display_name of this OperatorAction.
+        Display Name of the operator action.
+
+
+        :return: The customer_display_name of this OperatorAction.
+        :rtype: str
+        """
+        return self._customer_display_name
+
+    @customer_display_name.setter
+    def customer_display_name(self, customer_display_name):
+        """
+        Sets the customer_display_name of this OperatorAction.
+        Display Name of the operator action.
+
+
+        :param customer_display_name: The customer_display_name of this OperatorAction.
+        :type: str
+        """
+        self._customer_display_name = customer_display_name
 
     @property
     def component(self):
@@ -137,6 +189,36 @@ class OperatorAction(object):
         :type: str
         """
         self._component = component
+
+    @property
+    def resource_type(self):
+        """
+        Gets the resource_type of this OperatorAction.
+        resourceType for which the OperatorAction is applicable
+
+        Allowed values for this property are: "EXACC", "EXADATAINFRASTRUCTURE", "AUTONOMOUSVMCLUSTER", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The resource_type of this OperatorAction.
+        :rtype: str
+        """
+        return self._resource_type
+
+    @resource_type.setter
+    def resource_type(self, resource_type):
+        """
+        Sets the resource_type of this OperatorAction.
+        resourceType for which the OperatorAction is applicable
+
+
+        :param resource_type: The resource_type of this OperatorAction.
+        :type: str
+        """
+        allowed_values = ["EXACC", "EXADATAINFRASTRUCTURE", "AUTONOMOUSVMCLUSTER"]
+        if not value_allowed_none_or_none_sentinel(resource_type, allowed_values):
+            resource_type = 'UNKNOWN_ENUM_VALUE'
+        self._resource_type = resource_type
 
     @property
     def description(self):

--- a/src/oci/operator_access_control/models/operator_action_summary.py
+++ b/src/oci/operator_access_control/models/operator_action_summary.py
@@ -13,6 +13,18 @@ class OperatorActionSummary(object):
     Details of the operator action. Operator actions are pre-defined set of commands available to the operator on different layers of the infrastructure.
     """
 
+    #: A constant which can be used with the resource_type property of a OperatorActionSummary.
+    #: This constant has a value of "EXACC"
+    RESOURCE_TYPE_EXACC = "EXACC"
+
+    #: A constant which can be used with the resource_type property of a OperatorActionSummary.
+    #: This constant has a value of "EXADATAINFRASTRUCTURE"
+    RESOURCE_TYPE_EXADATAINFRASTRUCTURE = "EXADATAINFRASTRUCTURE"
+
+    #: A constant which can be used with the resource_type property of a OperatorActionSummary.
+    #: This constant has a value of "AUTONOMOUSVMCLUSTER"
+    RESOURCE_TYPE_AUTONOMOUSVMCLUSTER = "AUTONOMOUSVMCLUSTER"
+
     #: A constant which can be used with the lifecycle_state property of a OperatorActionSummary.
     #: This constant has a value of "ACTIVE"
     LIFECYCLE_STATE_ACTIVE = "ACTIVE"
@@ -42,6 +54,12 @@ class OperatorActionSummary(object):
             The value to assign to the compartment_id property of this OperatorActionSummary.
         :type compartment_id: str
 
+        :param resource_type:
+            The value to assign to the resource_type property of this OperatorActionSummary.
+            Allowed values for this property are: "EXACC", "EXADATAINFRASTRUCTURE", "AUTONOMOUSVMCLUSTER", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type resource_type: str
+
         :param lifecycle_state:
             The value to assign to the lifecycle_state property of this OperatorActionSummary.
             Allowed values for this property are: "ACTIVE", "INACTIVE", 'UNKNOWN_ENUM_VALUE'.
@@ -58,6 +76,7 @@ class OperatorActionSummary(object):
             'name': 'str',
             'component': 'str',
             'compartment_id': 'str',
+            'resource_type': 'str',
             'lifecycle_state': 'str',
             'description': 'str'
         }
@@ -67,6 +86,7 @@ class OperatorActionSummary(object):
             'name': 'name',
             'component': 'component',
             'compartment_id': 'compartmentId',
+            'resource_type': 'resourceType',
             'lifecycle_state': 'lifecycleState',
             'description': 'description'
         }
@@ -75,6 +95,7 @@ class OperatorActionSummary(object):
         self._name = None
         self._component = None
         self._compartment_id = None
+        self._resource_type = None
         self._lifecycle_state = None
         self._description = None
 
@@ -173,6 +194,36 @@ class OperatorActionSummary(object):
         :type: str
         """
         self._compartment_id = compartment_id
+
+    @property
+    def resource_type(self):
+        """
+        Gets the resource_type of this OperatorActionSummary.
+        resourceType for which the OperatorAction is applicable
+
+        Allowed values for this property are: "EXACC", "EXADATAINFRASTRUCTURE", "AUTONOMOUSVMCLUSTER", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The resource_type of this OperatorActionSummary.
+        :rtype: str
+        """
+        return self._resource_type
+
+    @resource_type.setter
+    def resource_type(self, resource_type):
+        """
+        Sets the resource_type of this OperatorActionSummary.
+        resourceType for which the OperatorAction is applicable
+
+
+        :param resource_type: The resource_type of this OperatorActionSummary.
+        :type: str
+        """
+        allowed_values = ["EXACC", "EXADATAINFRASTRUCTURE", "AUTONOMOUSVMCLUSTER"]
+        if not value_allowed_none_or_none_sentinel(resource_type, allowed_values):
+            resource_type = 'UNKNOWN_ENUM_VALUE'
+        self._resource_type = resource_type
 
     @property
     def lifecycle_state(self):

--- a/src/oci/operator_access_control/models/operator_control.py
+++ b/src/oci/operator_access_control/models/operator_control.py
@@ -13,6 +13,18 @@ class OperatorControl(object):
     Operator Access Control enables you to grant, audit, or revoke the access Oracle has to your Exadata Cloud@Customer infrastructure, and obtain audit reports of all actions taken by a human operator, in a near real-time manner.
     """
 
+    #: A constant which can be used with the resource_type property of a OperatorControl.
+    #: This constant has a value of "EXACC"
+    RESOURCE_TYPE_EXACC = "EXACC"
+
+    #: A constant which can be used with the resource_type property of a OperatorControl.
+    #: This constant has a value of "EXADATAINFRASTRUCTURE"
+    RESOURCE_TYPE_EXADATAINFRASTRUCTURE = "EXADATAINFRASTRUCTURE"
+
+    #: A constant which can be used with the resource_type property of a OperatorControl.
+    #: This constant has a value of "AUTONOMOUSVMCLUSTER"
+    RESOURCE_TYPE_AUTONOMOUSVMCLUSTER = "AUTONOMOUSVMCLUSTER"
+
     #: A constant which can be used with the lifecycle_state property of a OperatorControl.
     #: This constant has a value of "CREATED"
     LIFECYCLE_STATE_CREATED = "CREATED"
@@ -66,6 +78,16 @@ class OperatorControl(object):
             The value to assign to the is_fully_pre_approved property of this OperatorControl.
         :type is_fully_pre_approved: bool
 
+        :param email_id_list:
+            The value to assign to the email_id_list property of this OperatorControl.
+        :type email_id_list: list[str]
+
+        :param resource_type:
+            The value to assign to the resource_type property of this OperatorControl.
+            Allowed values for this property are: "EXACC", "EXADATAINFRASTRUCTURE", "AUTONOMOUSVMCLUSTER", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type resource_type: str
+
         :param system_message:
             The value to assign to the system_message property of this OperatorControl.
         :type system_message: str
@@ -114,6 +136,8 @@ class OperatorControl(object):
             'pre_approved_op_action_list': 'list[str]',
             'approval_required_op_action_list': 'list[str]',
             'is_fully_pre_approved': 'bool',
+            'email_id_list': 'list[str]',
+            'resource_type': 'str',
             'system_message': 'str',
             'compartment_id': 'str',
             'lifecycle_state': 'str',
@@ -134,6 +158,8 @@ class OperatorControl(object):
             'pre_approved_op_action_list': 'preApprovedOpActionList',
             'approval_required_op_action_list': 'approvalRequiredOpActionList',
             'is_fully_pre_approved': 'isFullyPreApproved',
+            'email_id_list': 'emailIdList',
+            'resource_type': 'resourceType',
             'system_message': 'systemMessage',
             'compartment_id': 'compartmentId',
             'lifecycle_state': 'lifecycleState',
@@ -153,6 +179,8 @@ class OperatorControl(object):
         self._pre_approved_op_action_list = None
         self._approval_required_op_action_list = None
         self._is_fully_pre_approved = None
+        self._email_id_list = None
+        self._resource_type = None
         self._system_message = None
         self._compartment_id = None
         self._lifecycle_state = None
@@ -362,6 +390,60 @@ class OperatorControl(object):
         :type: bool
         """
         self._is_fully_pre_approved = is_fully_pre_approved
+
+    @property
+    def email_id_list(self):
+        """
+        Gets the email_id_list of this OperatorControl.
+        List of emailId.
+
+
+        :return: The email_id_list of this OperatorControl.
+        :rtype: list[str]
+        """
+        return self._email_id_list
+
+    @email_id_list.setter
+    def email_id_list(self, email_id_list):
+        """
+        Sets the email_id_list of this OperatorControl.
+        List of emailId.
+
+
+        :param email_id_list: The email_id_list of this OperatorControl.
+        :type: list[str]
+        """
+        self._email_id_list = email_id_list
+
+    @property
+    def resource_type(self):
+        """
+        Gets the resource_type of this OperatorControl.
+        resourceType for which the OperatorControl is applicable
+
+        Allowed values for this property are: "EXACC", "EXADATAINFRASTRUCTURE", "AUTONOMOUSVMCLUSTER", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The resource_type of this OperatorControl.
+        :rtype: str
+        """
+        return self._resource_type
+
+    @resource_type.setter
+    def resource_type(self, resource_type):
+        """
+        Sets the resource_type of this OperatorControl.
+        resourceType for which the OperatorControl is applicable
+
+
+        :param resource_type: The resource_type of this OperatorControl.
+        :type: str
+        """
+        allowed_values = ["EXACC", "EXADATAINFRASTRUCTURE", "AUTONOMOUSVMCLUSTER"]
+        if not value_allowed_none_or_none_sentinel(resource_type, allowed_values):
+            resource_type = 'UNKNOWN_ENUM_VALUE'
+        self._resource_type = resource_type
 
     @property
     def system_message(self):

--- a/src/oci/operator_access_control/models/operator_control_assignment.py
+++ b/src/oci/operator_access_control/models/operator_control_assignment.py
@@ -18,6 +18,14 @@ class OperatorControlAssignment(object):
     #: This constant has a value of "EXACC"
     RESOURCE_TYPE_EXACC = "EXACC"
 
+    #: A constant which can be used with the resource_type property of a OperatorControlAssignment.
+    #: This constant has a value of "EXADATAINFRASTRUCTURE"
+    RESOURCE_TYPE_EXADATAINFRASTRUCTURE = "EXADATAINFRASTRUCTURE"
+
+    #: A constant which can be used with the resource_type property of a OperatorControlAssignment.
+    #: This constant has a value of "AUTONOMOUSVMCLUSTER"
+    RESOURCE_TYPE_AUTONOMOUSVMCLUSTER = "AUTONOMOUSVMCLUSTER"
+
     #: A constant which can be used with the lifecycle_state property of a OperatorControlAssignment.
     #: This constant has a value of "CREATED"
     LIFECYCLE_STATE_CREATED = "CREATED"
@@ -31,8 +39,20 @@ class OperatorControlAssignment(object):
     LIFECYCLE_STATE_APPLYFAILED = "APPLYFAILED"
 
     #: A constant which can be used with the lifecycle_state property of a OperatorControlAssignment.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a OperatorControlAssignment.
+    #: This constant has a value of "DELETING"
+    LIFECYCLE_STATE_DELETING = "DELETING"
+
+    #: A constant which can be used with the lifecycle_state property of a OperatorControlAssignment.
     #: This constant has a value of "DELETED"
     LIFECYCLE_STATE_DELETED = "DELETED"
+
+    #: A constant which can be used with the lifecycle_state property of a OperatorControlAssignment.
+    #: This constant has a value of "DELETIONFAILED"
+    LIFECYCLE_STATE_DELETIONFAILED = "DELETIONFAILED"
 
     def __init__(self, **kwargs):
         """
@@ -55,12 +75,6 @@ class OperatorControlAssignment(object):
             The value to assign to the resource_name property of this OperatorControlAssignment.
         :type resource_name: str
 
-        :param resource_type:
-            The value to assign to the resource_type property of this OperatorControlAssignment.
-            Allowed values for this property are: "EXACC", 'UNKNOWN_ENUM_VALUE'.
-            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
-        :type resource_type: str
-
         :param resource_compartment_id:
             The value to assign to the resource_compartment_id property of this OperatorControlAssignment.
         :type resource_compartment_id: str
@@ -68,6 +82,12 @@ class OperatorControlAssignment(object):
         :param compartment_id:
             The value to assign to the compartment_id property of this OperatorControlAssignment.
         :type compartment_id: str
+
+        :param resource_type:
+            The value to assign to the resource_type property of this OperatorControlAssignment.
+            Allowed values for this property are: "EXACC", "EXADATAINFRASTRUCTURE", "AUTONOMOUSVMCLUSTER", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type resource_type: str
 
         :param time_assignment_from:
             The value to assign to the time_assignment_from property of this OperatorControlAssignment.
@@ -83,7 +103,7 @@ class OperatorControlAssignment(object):
 
         :param lifecycle_state:
             The value to assign to the lifecycle_state property of this OperatorControlAssignment.
-            Allowed values for this property are: "CREATED", "APPLIED", "APPLYFAILED", "DELETED", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "CREATED", "APPLIED", "APPLYFAILED", "UPDATING", "DELETING", "DELETED", "DELETIONFAILED", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type lifecycle_state: str
 
@@ -111,6 +131,34 @@ class OperatorControlAssignment(object):
             The value to assign to the detachment_description property of this OperatorControlAssignment.
         :type detachment_description: str
 
+        :param is_log_forwarded:
+            The value to assign to the is_log_forwarded property of this OperatorControlAssignment.
+        :type is_log_forwarded: bool
+
+        :param remote_syslog_server_address:
+            The value to assign to the remote_syslog_server_address property of this OperatorControlAssignment.
+        :type remote_syslog_server_address: str
+
+        :param remote_syslog_server_port:
+            The value to assign to the remote_syslog_server_port property of this OperatorControlAssignment.
+        :type remote_syslog_server_port: int
+
+        :param remote_syslog_server_ca_cert:
+            The value to assign to the remote_syslog_server_ca_cert property of this OperatorControlAssignment.
+        :type remote_syslog_server_ca_cert: str
+
+        :param is_auto_approve_during_maintenance:
+            The value to assign to the is_auto_approve_during_maintenance property of this OperatorControlAssignment.
+        :type is_auto_approve_during_maintenance: bool
+
+        :param error_code:
+            The value to assign to the error_code property of this OperatorControlAssignment.
+        :type error_code: int
+
+        :param error_message:
+            The value to assign to the error_message property of this OperatorControlAssignment.
+        :type error_message: str
+
         :param freeform_tags:
             The value to assign to the freeform_tags property of this OperatorControlAssignment.
         :type freeform_tags: dict(str, str)
@@ -125,9 +173,9 @@ class OperatorControlAssignment(object):
             'operator_control_id': 'str',
             'resource_id': 'str',
             'resource_name': 'str',
-            'resource_type': 'str',
             'resource_compartment_id': 'str',
             'compartment_id': 'str',
+            'resource_type': 'str',
             'time_assignment_from': 'datetime',
             'time_assignment_to': 'datetime',
             'is_enforced_always': 'bool',
@@ -138,6 +186,13 @@ class OperatorControlAssignment(object):
             'unassigner_id': 'str',
             'time_of_deletion': 'datetime',
             'detachment_description': 'str',
+            'is_log_forwarded': 'bool',
+            'remote_syslog_server_address': 'str',
+            'remote_syslog_server_port': 'int',
+            'remote_syslog_server_ca_cert': 'str',
+            'is_auto_approve_during_maintenance': 'bool',
+            'error_code': 'int',
+            'error_message': 'str',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))'
         }
@@ -147,9 +202,9 @@ class OperatorControlAssignment(object):
             'operator_control_id': 'operatorControlId',
             'resource_id': 'resourceId',
             'resource_name': 'resourceName',
-            'resource_type': 'resourceType',
             'resource_compartment_id': 'resourceCompartmentId',
             'compartment_id': 'compartmentId',
+            'resource_type': 'resourceType',
             'time_assignment_from': 'timeAssignmentFrom',
             'time_assignment_to': 'timeAssignmentTo',
             'is_enforced_always': 'isEnforcedAlways',
@@ -160,6 +215,13 @@ class OperatorControlAssignment(object):
             'unassigner_id': 'unassignerId',
             'time_of_deletion': 'timeOfDeletion',
             'detachment_description': 'detachmentDescription',
+            'is_log_forwarded': 'isLogForwarded',
+            'remote_syslog_server_address': 'remoteSyslogServerAddress',
+            'remote_syslog_server_port': 'remoteSyslogServerPort',
+            'remote_syslog_server_ca_cert': 'remoteSyslogServerCACert',
+            'is_auto_approve_during_maintenance': 'isAutoApproveDuringMaintenance',
+            'error_code': 'errorCode',
+            'error_message': 'errorMessage',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags'
         }
@@ -168,9 +230,9 @@ class OperatorControlAssignment(object):
         self._operator_control_id = None
         self._resource_id = None
         self._resource_name = None
-        self._resource_type = None
         self._resource_compartment_id = None
         self._compartment_id = None
+        self._resource_type = None
         self._time_assignment_from = None
         self._time_assignment_to = None
         self._is_enforced_always = None
@@ -181,6 +243,13 @@ class OperatorControlAssignment(object):
         self._unassigner_id = None
         self._time_of_deletion = None
         self._detachment_description = None
+        self._is_log_forwarded = None
+        self._remote_syslog_server_address = None
+        self._remote_syslog_server_port = None
+        self._remote_syslog_server_ca_cert = None
+        self._is_auto_approve_during_maintenance = None
+        self._error_code = None
+        self._error_message = None
         self._freeform_tags = None
         self._defined_tags = None
 
@@ -281,36 +350,6 @@ class OperatorControlAssignment(object):
         self._resource_name = resource_name
 
     @property
-    def resource_type(self):
-        """
-        Gets the resource_type of this OperatorControlAssignment.
-        Type of the target resource.
-
-        Allowed values for this property are: "EXACC", 'UNKNOWN_ENUM_VALUE'.
-        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
-
-
-        :return: The resource_type of this OperatorControlAssignment.
-        :rtype: str
-        """
-        return self._resource_type
-
-    @resource_type.setter
-    def resource_type(self, resource_type):
-        """
-        Sets the resource_type of this OperatorControlAssignment.
-        Type of the target resource.
-
-
-        :param resource_type: The resource_type of this OperatorControlAssignment.
-        :type: str
-        """
-        allowed_values = ["EXACC"]
-        if not value_allowed_none_or_none_sentinel(resource_type, allowed_values):
-            resource_type = 'UNKNOWN_ENUM_VALUE'
-        self._resource_type = resource_type
-
-    @property
     def resource_compartment_id(self):
         """
         Gets the resource_compartment_id of this OperatorControlAssignment.
@@ -357,6 +396,36 @@ class OperatorControlAssignment(object):
         :type: str
         """
         self._compartment_id = compartment_id
+
+    @property
+    def resource_type(self):
+        """
+        Gets the resource_type of this OperatorControlAssignment.
+        resourceType for which the OperatorControlAssignment is applicable
+
+        Allowed values for this property are: "EXACC", "EXADATAINFRASTRUCTURE", "AUTONOMOUSVMCLUSTER", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The resource_type of this OperatorControlAssignment.
+        :rtype: str
+        """
+        return self._resource_type
+
+    @resource_type.setter
+    def resource_type(self, resource_type):
+        """
+        Sets the resource_type of this OperatorControlAssignment.
+        resourceType for which the OperatorControlAssignment is applicable
+
+
+        :param resource_type: The resource_type of this OperatorControlAssignment.
+        :type: str
+        """
+        allowed_values = ["EXACC", "EXADATAINFRASTRUCTURE", "AUTONOMOUSVMCLUSTER"]
+        if not value_allowed_none_or_none_sentinel(resource_type, allowed_values):
+            resource_type = 'UNKNOWN_ENUM_VALUE'
+        self._resource_type = resource_type
 
     @property
     def time_assignment_from(self):
@@ -448,7 +517,7 @@ class OperatorControlAssignment(object):
         Gets the lifecycle_state of this OperatorControlAssignment.
         The current lifcycle state of the OperatorControl.
 
-        Allowed values for this property are: "CREATED", "APPLIED", "APPLYFAILED", "DELETED", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "CREATED", "APPLIED", "APPLYFAILED", "UPDATING", "DELETING", "DELETED", "DELETIONFAILED", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -467,7 +536,7 @@ class OperatorControlAssignment(object):
         :param lifecycle_state: The lifecycle_state of this OperatorControlAssignment.
         :type: str
         """
-        allowed_values = ["CREATED", "APPLIED", "APPLYFAILED", "DELETED"]
+        allowed_values = ["CREATED", "APPLIED", "APPLYFAILED", "UPDATING", "DELETING", "DELETED", "DELETIONFAILED"]
         if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
             lifecycle_state = 'UNKNOWN_ENUM_VALUE'
         self._lifecycle_state = lifecycle_state
@@ -623,6 +692,174 @@ class OperatorControlAssignment(object):
         :type: str
         """
         self._detachment_description = detachment_description
+
+    @property
+    def is_log_forwarded(self):
+        """
+        Gets the is_log_forwarded of this OperatorControlAssignment.
+        If set indicates that the audit logs are being forwarded to the relevant remote logging server
+
+
+        :return: The is_log_forwarded of this OperatorControlAssignment.
+        :rtype: bool
+        """
+        return self._is_log_forwarded
+
+    @is_log_forwarded.setter
+    def is_log_forwarded(self, is_log_forwarded):
+        """
+        Sets the is_log_forwarded of this OperatorControlAssignment.
+        If set indicates that the audit logs are being forwarded to the relevant remote logging server
+
+
+        :param is_log_forwarded: The is_log_forwarded of this OperatorControlAssignment.
+        :type: bool
+        """
+        self._is_log_forwarded = is_log_forwarded
+
+    @property
+    def remote_syslog_server_address(self):
+        """
+        Gets the remote_syslog_server_address of this OperatorControlAssignment.
+        The address of the remote syslog server where the audit logs are being forwarded to. Address in host or IP format.
+
+
+        :return: The remote_syslog_server_address of this OperatorControlAssignment.
+        :rtype: str
+        """
+        return self._remote_syslog_server_address
+
+    @remote_syslog_server_address.setter
+    def remote_syslog_server_address(self, remote_syslog_server_address):
+        """
+        Sets the remote_syslog_server_address of this OperatorControlAssignment.
+        The address of the remote syslog server where the audit logs are being forwarded to. Address in host or IP format.
+
+
+        :param remote_syslog_server_address: The remote_syslog_server_address of this OperatorControlAssignment.
+        :type: str
+        """
+        self._remote_syslog_server_address = remote_syslog_server_address
+
+    @property
+    def remote_syslog_server_port(self):
+        """
+        Gets the remote_syslog_server_port of this OperatorControlAssignment.
+        The listening port of the remote syslog server. The port range is 0 - 65535. Only TCP supported.
+
+
+        :return: The remote_syslog_server_port of this OperatorControlAssignment.
+        :rtype: int
+        """
+        return self._remote_syslog_server_port
+
+    @remote_syslog_server_port.setter
+    def remote_syslog_server_port(self, remote_syslog_server_port):
+        """
+        Sets the remote_syslog_server_port of this OperatorControlAssignment.
+        The listening port of the remote syslog server. The port range is 0 - 65535. Only TCP supported.
+
+
+        :param remote_syslog_server_port: The remote_syslog_server_port of this OperatorControlAssignment.
+        :type: int
+        """
+        self._remote_syslog_server_port = remote_syslog_server_port
+
+    @property
+    def remote_syslog_server_ca_cert(self):
+        """
+        Gets the remote_syslog_server_ca_cert of this OperatorControlAssignment.
+        The CA certificate of the remote syslog server.
+
+
+        :return: The remote_syslog_server_ca_cert of this OperatorControlAssignment.
+        :rtype: str
+        """
+        return self._remote_syslog_server_ca_cert
+
+    @remote_syslog_server_ca_cert.setter
+    def remote_syslog_server_ca_cert(self, remote_syslog_server_ca_cert):
+        """
+        Sets the remote_syslog_server_ca_cert of this OperatorControlAssignment.
+        The CA certificate of the remote syslog server.
+
+
+        :param remote_syslog_server_ca_cert: The remote_syslog_server_ca_cert of this OperatorControlAssignment.
+        :type: str
+        """
+        self._remote_syslog_server_ca_cert = remote_syslog_server_ca_cert
+
+    @property
+    def is_auto_approve_during_maintenance(self):
+        """
+        Gets the is_auto_approve_during_maintenance of this OperatorControlAssignment.
+        The boolean if true would autoApprove during maintenance.
+
+
+        :return: The is_auto_approve_during_maintenance of this OperatorControlAssignment.
+        :rtype: bool
+        """
+        return self._is_auto_approve_during_maintenance
+
+    @is_auto_approve_during_maintenance.setter
+    def is_auto_approve_during_maintenance(self, is_auto_approve_during_maintenance):
+        """
+        Sets the is_auto_approve_during_maintenance of this OperatorControlAssignment.
+        The boolean if true would autoApprove during maintenance.
+
+
+        :param is_auto_approve_during_maintenance: The is_auto_approve_during_maintenance of this OperatorControlAssignment.
+        :type: bool
+        """
+        self._is_auto_approve_during_maintenance = is_auto_approve_during_maintenance
+
+    @property
+    def error_code(self):
+        """
+        Gets the error_code of this OperatorControlAssignment.
+        The code identifying the error occurred during Assignment operation.
+
+
+        :return: The error_code of this OperatorControlAssignment.
+        :rtype: int
+        """
+        return self._error_code
+
+    @error_code.setter
+    def error_code(self, error_code):
+        """
+        Sets the error_code of this OperatorControlAssignment.
+        The code identifying the error occurred during Assignment operation.
+
+
+        :param error_code: The error_code of this OperatorControlAssignment.
+        :type: int
+        """
+        self._error_code = error_code
+
+    @property
+    def error_message(self):
+        """
+        Gets the error_message of this OperatorControlAssignment.
+        The message describing the error occurred during Assignment operation.
+
+
+        :return: The error_message of this OperatorControlAssignment.
+        :rtype: str
+        """
+        return self._error_message
+
+    @error_message.setter
+    def error_message(self, error_message):
+        """
+        Sets the error_message of this OperatorControlAssignment.
+        The message describing the error occurred during Assignment operation.
+
+
+        :param error_message: The error_message of this OperatorControlAssignment.
+        :type: str
+        """
+        self._error_message = error_message
 
     @property
     def freeform_tags(self):

--- a/src/oci/operator_access_control/models/operator_control_assignment_summary.py
+++ b/src/oci/operator_access_control/models/operator_control_assignment_summary.py
@@ -13,6 +13,18 @@ class OperatorControlAssignmentSummary(object):
     Details of the operator control assignment.
     """
 
+    #: A constant which can be used with the resource_type property of a OperatorControlAssignmentSummary.
+    #: This constant has a value of "EXACC"
+    RESOURCE_TYPE_EXACC = "EXACC"
+
+    #: A constant which can be used with the resource_type property of a OperatorControlAssignmentSummary.
+    #: This constant has a value of "EXADATAINFRASTRUCTURE"
+    RESOURCE_TYPE_EXADATAINFRASTRUCTURE = "EXADATAINFRASTRUCTURE"
+
+    #: A constant which can be used with the resource_type property of a OperatorControlAssignmentSummary.
+    #: This constant has a value of "AUTONOMOUSVMCLUSTER"
+    RESOURCE_TYPE_AUTONOMOUSVMCLUSTER = "AUTONOMOUSVMCLUSTER"
+
     #: A constant which can be used with the lifecycle_state property of a OperatorControlAssignmentSummary.
     #: This constant has a value of "CREATED"
     LIFECYCLE_STATE_CREATED = "CREATED"
@@ -26,8 +38,20 @@ class OperatorControlAssignmentSummary(object):
     LIFECYCLE_STATE_APPLYFAILED = "APPLYFAILED"
 
     #: A constant which can be used with the lifecycle_state property of a OperatorControlAssignmentSummary.
+    #: This constant has a value of "UPDATING"
+    LIFECYCLE_STATE_UPDATING = "UPDATING"
+
+    #: A constant which can be used with the lifecycle_state property of a OperatorControlAssignmentSummary.
+    #: This constant has a value of "DELETING"
+    LIFECYCLE_STATE_DELETING = "DELETING"
+
+    #: A constant which can be used with the lifecycle_state property of a OperatorControlAssignmentSummary.
     #: This constant has a value of "DELETED"
     LIFECYCLE_STATE_DELETED = "DELETED"
+
+    #: A constant which can be used with the lifecycle_state property of a OperatorControlAssignmentSummary.
+    #: This constant has a value of "DELETIONFAILED"
+    LIFECYCLE_STATE_DELETIONFAILED = "DELETIONFAILED"
 
     def __init__(self, **kwargs):
         """
@@ -46,13 +70,15 @@ class OperatorControlAssignmentSummary(object):
             The value to assign to the resource_id property of this OperatorControlAssignmentSummary.
         :type resource_id: str
 
-        :param resource_type:
-            The value to assign to the resource_type property of this OperatorControlAssignmentSummary.
-        :type resource_type: str
-
         :param compartment_id:
             The value to assign to the compartment_id property of this OperatorControlAssignmentSummary.
         :type compartment_id: str
+
+        :param resource_type:
+            The value to assign to the resource_type property of this OperatorControlAssignmentSummary.
+            Allowed values for this property are: "EXACC", "EXADATAINFRASTRUCTURE", "AUTONOMOUSVMCLUSTER", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type resource_type: str
 
         :param time_assignment_from:
             The value to assign to the time_assignment_from property of this OperatorControlAssignmentSummary.
@@ -70,9 +96,29 @@ class OperatorControlAssignmentSummary(object):
             The value to assign to the time_of_assignment property of this OperatorControlAssignmentSummary.
         :type time_of_assignment: datetime
 
+        :param error_code:
+            The value to assign to the error_code property of this OperatorControlAssignmentSummary.
+        :type error_code: int
+
+        :param error_message:
+            The value to assign to the error_message property of this OperatorControlAssignmentSummary.
+        :type error_message: str
+
+        :param is_log_forwarded:
+            The value to assign to the is_log_forwarded property of this OperatorControlAssignmentSummary.
+        :type is_log_forwarded: bool
+
+        :param remote_syslog_server_address:
+            The value to assign to the remote_syslog_server_address property of this OperatorControlAssignmentSummary.
+        :type remote_syslog_server_address: str
+
+        :param remote_syslog_server_port:
+            The value to assign to the remote_syslog_server_port property of this OperatorControlAssignmentSummary.
+        :type remote_syslog_server_port: int
+
         :param lifecycle_state:
             The value to assign to the lifecycle_state property of this OperatorControlAssignmentSummary.
-            Allowed values for this property are: "CREATED", "APPLIED", "APPLYFAILED", "DELETED", 'UNKNOWN_ENUM_VALUE'.
+            Allowed values for this property are: "CREATED", "APPLIED", "APPLYFAILED", "UPDATING", "DELETING", "DELETED", "DELETIONFAILED", 'UNKNOWN_ENUM_VALUE'.
             Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
         :type lifecycle_state: str
 
@@ -89,12 +135,17 @@ class OperatorControlAssignmentSummary(object):
             'id': 'str',
             'operator_control_id': 'str',
             'resource_id': 'str',
-            'resource_type': 'str',
             'compartment_id': 'str',
+            'resource_type': 'str',
             'time_assignment_from': 'datetime',
             'time_assignment_to': 'datetime',
             'is_enforced_always': 'bool',
             'time_of_assignment': 'datetime',
+            'error_code': 'int',
+            'error_message': 'str',
+            'is_log_forwarded': 'bool',
+            'remote_syslog_server_address': 'str',
+            'remote_syslog_server_port': 'int',
             'lifecycle_state': 'str',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))'
@@ -104,12 +155,17 @@ class OperatorControlAssignmentSummary(object):
             'id': 'id',
             'operator_control_id': 'operatorControlId',
             'resource_id': 'resourceId',
-            'resource_type': 'resourceType',
             'compartment_id': 'compartmentId',
+            'resource_type': 'resourceType',
             'time_assignment_from': 'timeAssignmentFrom',
             'time_assignment_to': 'timeAssignmentTo',
             'is_enforced_always': 'isEnforcedAlways',
             'time_of_assignment': 'timeOfAssignment',
+            'error_code': 'errorCode',
+            'error_message': 'errorMessage',
+            'is_log_forwarded': 'isLogForwarded',
+            'remote_syslog_server_address': 'remoteSyslogServerAddress',
+            'remote_syslog_server_port': 'remoteSyslogServerPort',
             'lifecycle_state': 'lifecycleState',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags'
@@ -118,12 +174,17 @@ class OperatorControlAssignmentSummary(object):
         self._id = None
         self._operator_control_id = None
         self._resource_id = None
-        self._resource_type = None
         self._compartment_id = None
+        self._resource_type = None
         self._time_assignment_from = None
         self._time_assignment_to = None
         self._is_enforced_always = None
         self._time_of_assignment = None
+        self._error_code = None
+        self._error_message = None
+        self._is_log_forwarded = None
+        self._remote_syslog_server_address = None
+        self._remote_syslog_server_port = None
         self._lifecycle_state = None
         self._freeform_tags = None
         self._defined_tags = None
@@ -201,30 +262,6 @@ class OperatorControlAssignmentSummary(object):
         self._resource_id = resource_id
 
     @property
-    def resource_type(self):
-        """
-        Gets the resource_type of this OperatorControlAssignmentSummary.
-        Type of the target resource being governed by the operator control.
-
-
-        :return: The resource_type of this OperatorControlAssignmentSummary.
-        :rtype: str
-        """
-        return self._resource_type
-
-    @resource_type.setter
-    def resource_type(self, resource_type):
-        """
-        Sets the resource_type of this OperatorControlAssignmentSummary.
-        Type of the target resource being governed by the operator control.
-
-
-        :param resource_type: The resource_type of this OperatorControlAssignmentSummary.
-        :type: str
-        """
-        self._resource_type = resource_type
-
-    @property
     def compartment_id(self):
         """
         **[Required]** Gets the compartment_id of this OperatorControlAssignmentSummary.
@@ -247,6 +284,36 @@ class OperatorControlAssignmentSummary(object):
         :type: str
         """
         self._compartment_id = compartment_id
+
+    @property
+    def resource_type(self):
+        """
+        Gets the resource_type of this OperatorControlAssignmentSummary.
+        resourceType for which the OperatorControlAssignment is applicable
+
+        Allowed values for this property are: "EXACC", "EXADATAINFRASTRUCTURE", "AUTONOMOUSVMCLUSTER", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The resource_type of this OperatorControlAssignmentSummary.
+        :rtype: str
+        """
+        return self._resource_type
+
+    @resource_type.setter
+    def resource_type(self, resource_type):
+        """
+        Sets the resource_type of this OperatorControlAssignmentSummary.
+        resourceType for which the OperatorControlAssignment is applicable
+
+
+        :param resource_type: The resource_type of this OperatorControlAssignmentSummary.
+        :type: str
+        """
+        allowed_values = ["EXACC", "EXADATAINFRASTRUCTURE", "AUTONOMOUSVMCLUSTER"]
+        if not value_allowed_none_or_none_sentinel(resource_type, allowed_values):
+            resource_type = 'UNKNOWN_ENUM_VALUE'
+        self._resource_type = resource_type
 
     @property
     def time_assignment_from(self):
@@ -357,12 +424,132 @@ class OperatorControlAssignmentSummary(object):
         self._time_of_assignment = time_of_assignment
 
     @property
+    def error_code(self):
+        """
+        Gets the error_code of this OperatorControlAssignmentSummary.
+        The code identifying the error occurred during Assignment operation.
+
+
+        :return: The error_code of this OperatorControlAssignmentSummary.
+        :rtype: int
+        """
+        return self._error_code
+
+    @error_code.setter
+    def error_code(self, error_code):
+        """
+        Sets the error_code of this OperatorControlAssignmentSummary.
+        The code identifying the error occurred during Assignment operation.
+
+
+        :param error_code: The error_code of this OperatorControlAssignmentSummary.
+        :type: int
+        """
+        self._error_code = error_code
+
+    @property
+    def error_message(self):
+        """
+        Gets the error_message of this OperatorControlAssignmentSummary.
+        The message describing the error occurred during Assignment operation.
+
+
+        :return: The error_message of this OperatorControlAssignmentSummary.
+        :rtype: str
+        """
+        return self._error_message
+
+    @error_message.setter
+    def error_message(self, error_message):
+        """
+        Sets the error_message of this OperatorControlAssignmentSummary.
+        The message describing the error occurred during Assignment operation.
+
+
+        :param error_message: The error_message of this OperatorControlAssignmentSummary.
+        :type: str
+        """
+        self._error_message = error_message
+
+    @property
+    def is_log_forwarded(self):
+        """
+        Gets the is_log_forwarded of this OperatorControlAssignmentSummary.
+        If set, then the audit logs are being forwarded to the relevant remote logging server
+
+
+        :return: The is_log_forwarded of this OperatorControlAssignmentSummary.
+        :rtype: bool
+        """
+        return self._is_log_forwarded
+
+    @is_log_forwarded.setter
+    def is_log_forwarded(self, is_log_forwarded):
+        """
+        Sets the is_log_forwarded of this OperatorControlAssignmentSummary.
+        If set, then the audit logs are being forwarded to the relevant remote logging server
+
+
+        :param is_log_forwarded: The is_log_forwarded of this OperatorControlAssignmentSummary.
+        :type: bool
+        """
+        self._is_log_forwarded = is_log_forwarded
+
+    @property
+    def remote_syslog_server_address(self):
+        """
+        Gets the remote_syslog_server_address of this OperatorControlAssignmentSummary.
+        The address of the remote syslog server where the audit logs are being forwarded to. Address in host or IP format.
+
+
+        :return: The remote_syslog_server_address of this OperatorControlAssignmentSummary.
+        :rtype: str
+        """
+        return self._remote_syslog_server_address
+
+    @remote_syslog_server_address.setter
+    def remote_syslog_server_address(self, remote_syslog_server_address):
+        """
+        Sets the remote_syslog_server_address of this OperatorControlAssignmentSummary.
+        The address of the remote syslog server where the audit logs are being forwarded to. Address in host or IP format.
+
+
+        :param remote_syslog_server_address: The remote_syslog_server_address of this OperatorControlAssignmentSummary.
+        :type: str
+        """
+        self._remote_syslog_server_address = remote_syslog_server_address
+
+    @property
+    def remote_syslog_server_port(self):
+        """
+        Gets the remote_syslog_server_port of this OperatorControlAssignmentSummary.
+        The listening port of the remote syslog server. The port range is 0 - 65535.
+
+
+        :return: The remote_syslog_server_port of this OperatorControlAssignmentSummary.
+        :rtype: int
+        """
+        return self._remote_syslog_server_port
+
+    @remote_syslog_server_port.setter
+    def remote_syslog_server_port(self, remote_syslog_server_port):
+        """
+        Sets the remote_syslog_server_port of this OperatorControlAssignmentSummary.
+        The listening port of the remote syslog server. The port range is 0 - 65535.
+
+
+        :param remote_syslog_server_port: The remote_syslog_server_port of this OperatorControlAssignmentSummary.
+        :type: int
+        """
+        self._remote_syslog_server_port = remote_syslog_server_port
+
+    @property
     def lifecycle_state(self):
         """
         Gets the lifecycle_state of this OperatorControlAssignmentSummary.
         The current lifcycle state of the OperatorControl.
 
-        Allowed values for this property are: "CREATED", "APPLIED", "APPLYFAILED", "DELETED", 'UNKNOWN_ENUM_VALUE'.
+        Allowed values for this property are: "CREATED", "APPLIED", "APPLYFAILED", "UPDATING", "DELETING", "DELETED", "DELETIONFAILED", 'UNKNOWN_ENUM_VALUE'.
         Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
 
 
@@ -381,7 +568,7 @@ class OperatorControlAssignmentSummary(object):
         :param lifecycle_state: The lifecycle_state of this OperatorControlAssignmentSummary.
         :type: str
         """
-        allowed_values = ["CREATED", "APPLIED", "APPLYFAILED", "DELETED"]
+        allowed_values = ["CREATED", "APPLIED", "APPLYFAILED", "UPDATING", "DELETING", "DELETED", "DELETIONFAILED"]
         if not value_allowed_none_or_none_sentinel(lifecycle_state, allowed_values):
             lifecycle_state = 'UNKNOWN_ENUM_VALUE'
         self._lifecycle_state = lifecycle_state

--- a/src/oci/operator_access_control/models/operator_control_summary.py
+++ b/src/oci/operator_access_control/models/operator_control_summary.py
@@ -13,6 +13,18 @@ class OperatorControlSummary(object):
     Summary of the OperatorControl.
     """
 
+    #: A constant which can be used with the resource_type property of a OperatorControlSummary.
+    #: This constant has a value of "EXACC"
+    RESOURCE_TYPE_EXACC = "EXACC"
+
+    #: A constant which can be used with the resource_type property of a OperatorControlSummary.
+    #: This constant has a value of "EXADATAINFRASTRUCTURE"
+    RESOURCE_TYPE_EXADATAINFRASTRUCTURE = "EXADATAINFRASTRUCTURE"
+
+    #: A constant which can be used with the resource_type property of a OperatorControlSummary.
+    #: This constant has a value of "AUTONOMOUSVMCLUSTER"
+    RESOURCE_TYPE_AUTONOMOUSVMCLUSTER = "AUTONOMOUSVMCLUSTER"
+
     #: A constant which can be used with the lifecycle_state property of a OperatorControlSummary.
     #: This constant has a value of "CREATED"
     LIFECYCLE_STATE_CREATED = "CREATED"
@@ -50,6 +62,12 @@ class OperatorControlSummary(object):
             The value to assign to the is_fully_pre_approved property of this OperatorControlSummary.
         :type is_fully_pre_approved: bool
 
+        :param resource_type:
+            The value to assign to the resource_type property of this OperatorControlSummary.
+            Allowed values for this property are: "EXACC", "EXADATAINFRASTRUCTURE", "AUTONOMOUSVMCLUSTER", 'UNKNOWN_ENUM_VALUE'.
+            Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+        :type resource_type: str
+
         :param time_of_creation:
             The value to assign to the time_of_creation property of this OperatorControlSummary.
         :type time_of_creation: datetime
@@ -82,6 +100,7 @@ class OperatorControlSummary(object):
             'operator_control_name': 'str',
             'compartment_id': 'str',
             'is_fully_pre_approved': 'bool',
+            'resource_type': 'str',
             'time_of_creation': 'datetime',
             'time_of_modification': 'datetime',
             'time_of_deletion': 'datetime',
@@ -95,6 +114,7 @@ class OperatorControlSummary(object):
             'operator_control_name': 'operatorControlName',
             'compartment_id': 'compartmentId',
             'is_fully_pre_approved': 'isFullyPreApproved',
+            'resource_type': 'resourceType',
             'time_of_creation': 'timeOfCreation',
             'time_of_modification': 'timeOfModification',
             'time_of_deletion': 'timeOfDeletion',
@@ -107,6 +127,7 @@ class OperatorControlSummary(object):
         self._operator_control_name = None
         self._compartment_id = None
         self._is_fully_pre_approved = None
+        self._resource_type = None
         self._time_of_creation = None
         self._time_of_modification = None
         self._time_of_deletion = None
@@ -209,6 +230,36 @@ class OperatorControlSummary(object):
         :type: bool
         """
         self._is_fully_pre_approved = is_fully_pre_approved
+
+    @property
+    def resource_type(self):
+        """
+        Gets the resource_type of this OperatorControlSummary.
+        resourceType for which the OperatorControl is applicable
+
+        Allowed values for this property are: "EXACC", "EXADATAINFRASTRUCTURE", "AUTONOMOUSVMCLUSTER", 'UNKNOWN_ENUM_VALUE'.
+        Any unrecognized values returned by a service will be mapped to 'UNKNOWN_ENUM_VALUE'.
+
+
+        :return: The resource_type of this OperatorControlSummary.
+        :rtype: str
+        """
+        return self._resource_type
+
+    @resource_type.setter
+    def resource_type(self, resource_type):
+        """
+        Sets the resource_type of this OperatorControlSummary.
+        resourceType for which the OperatorControl is applicable
+
+
+        :param resource_type: The resource_type of this OperatorControlSummary.
+        :type: str
+        """
+        allowed_values = ["EXACC", "EXADATAINFRASTRUCTURE", "AUTONOMOUSVMCLUSTER"]
+        if not value_allowed_none_or_none_sentinel(resource_type, allowed_values):
+            resource_type = 'UNKNOWN_ENUM_VALUE'
+        self._resource_type = resource_type
 
     @property
     def time_of_creation(self):

--- a/src/oci/operator_access_control/models/review_access_request_details.py
+++ b/src/oci/operator_access_control/models/review_access_request_details.py
@@ -1,0 +1,70 @@
+# coding: utf-8
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+
+from oci.util import formatted_flat_dict, NONE_SENTINEL, value_allowed_none_or_none_sentinel  # noqa: F401
+from oci.decorators import init_model_state_from_kwargs
+
+
+@init_model_state_from_kwargs
+class ReviewAccessRequestDetails(object):
+    """
+    Details to mark access request in review.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes a new ReviewAccessRequestDetails object with values from keyword arguments.
+        The following keyword arguments are supported (corresponding to the getters/setters of this class):
+
+        :param approver_comment:
+            The value to assign to the approver_comment property of this ReviewAccessRequestDetails.
+        :type approver_comment: str
+
+        """
+        self.swagger_types = {
+            'approver_comment': 'str'
+        }
+
+        self.attribute_map = {
+            'approver_comment': 'approverComment'
+        }
+
+        self._approver_comment = None
+
+    @property
+    def approver_comment(self):
+        """
+        Gets the approver_comment of this ReviewAccessRequestDetails.
+        Comment by the approver explaining that the access request is in review.
+
+
+        :return: The approver_comment of this ReviewAccessRequestDetails.
+        :rtype: str
+        """
+        return self._approver_comment
+
+    @approver_comment.setter
+    def approver_comment(self, approver_comment):
+        """
+        Sets the approver_comment of this ReviewAccessRequestDetails.
+        Comment by the approver explaining that the access request is in review.
+
+
+        :param approver_comment: The approver_comment of this ReviewAccessRequestDetails.
+        :type: str
+        """
+        self._approver_comment = approver_comment
+
+    def __repr__(self):
+        return formatted_flat_dict(self)
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/oci/operator_access_control/models/update_operator_control_assignment_details.py
+++ b/src/oci/operator_access_control/models/update_operator_control_assignment_details.py
@@ -34,6 +34,26 @@ class UpdateOperatorControlAssignmentDetails(object):
             The value to assign to the comment property of this UpdateOperatorControlAssignmentDetails.
         :type comment: str
 
+        :param is_log_forwarded:
+            The value to assign to the is_log_forwarded property of this UpdateOperatorControlAssignmentDetails.
+        :type is_log_forwarded: bool
+
+        :param remote_syslog_server_address:
+            The value to assign to the remote_syslog_server_address property of this UpdateOperatorControlAssignmentDetails.
+        :type remote_syslog_server_address: str
+
+        :param remote_syslog_server_port:
+            The value to assign to the remote_syslog_server_port property of this UpdateOperatorControlAssignmentDetails.
+        :type remote_syslog_server_port: int
+
+        :param remote_syslog_server_ca_cert:
+            The value to assign to the remote_syslog_server_ca_cert property of this UpdateOperatorControlAssignmentDetails.
+        :type remote_syslog_server_ca_cert: str
+
+        :param is_auto_approve_during_maintenance:
+            The value to assign to the is_auto_approve_during_maintenance property of this UpdateOperatorControlAssignmentDetails.
+        :type is_auto_approve_during_maintenance: bool
+
         :param freeform_tags:
             The value to assign to the freeform_tags property of this UpdateOperatorControlAssignmentDetails.
         :type freeform_tags: dict(str, str)
@@ -48,6 +68,11 @@ class UpdateOperatorControlAssignmentDetails(object):
             'time_assignment_to': 'datetime',
             'is_enforced_always': 'bool',
             'comment': 'str',
+            'is_log_forwarded': 'bool',
+            'remote_syslog_server_address': 'str',
+            'remote_syslog_server_port': 'int',
+            'remote_syslog_server_ca_cert': 'str',
+            'is_auto_approve_during_maintenance': 'bool',
             'freeform_tags': 'dict(str, str)',
             'defined_tags': 'dict(str, dict(str, object))'
         }
@@ -57,6 +82,11 @@ class UpdateOperatorControlAssignmentDetails(object):
             'time_assignment_to': 'timeAssignmentTo',
             'is_enforced_always': 'isEnforcedAlways',
             'comment': 'comment',
+            'is_log_forwarded': 'isLogForwarded',
+            'remote_syslog_server_address': 'remoteSyslogServerAddress',
+            'remote_syslog_server_port': 'remoteSyslogServerPort',
+            'remote_syslog_server_ca_cert': 'remoteSyslogServerCACert',
+            'is_auto_approve_during_maintenance': 'isAutoApproveDuringMaintenance',
             'freeform_tags': 'freeformTags',
             'defined_tags': 'definedTags'
         }
@@ -65,6 +95,11 @@ class UpdateOperatorControlAssignmentDetails(object):
         self._time_assignment_to = None
         self._is_enforced_always = None
         self._comment = None
+        self._is_log_forwarded = None
+        self._remote_syslog_server_address = None
+        self._remote_syslog_server_port = None
+        self._remote_syslog_server_ca_cert = None
+        self._is_auto_approve_during_maintenance = None
         self._freeform_tags = None
         self._defined_tags = None
 
@@ -127,7 +162,7 @@ class UpdateOperatorControlAssignmentDetails(object):
     @property
     def is_enforced_always(self):
         """
-        Gets the is_enforced_always of this UpdateOperatorControlAssignmentDetails.
+        **[Required]** Gets the is_enforced_always of this UpdateOperatorControlAssignmentDetails.
         If true, then the target resource is always governed by the operator control. Otherwise governance is time-based as specified by timeAssignmentTo and timeAssignmentFrom.
 
 
@@ -171,6 +206,126 @@ class UpdateOperatorControlAssignmentDetails(object):
         :type: str
         """
         self._comment = comment
+
+    @property
+    def is_log_forwarded(self):
+        """
+        Gets the is_log_forwarded of this UpdateOperatorControlAssignmentDetails.
+        If set, then the audit logs will be forwarded to the relevant remote logging server
+
+
+        :return: The is_log_forwarded of this UpdateOperatorControlAssignmentDetails.
+        :rtype: bool
+        """
+        return self._is_log_forwarded
+
+    @is_log_forwarded.setter
+    def is_log_forwarded(self, is_log_forwarded):
+        """
+        Sets the is_log_forwarded of this UpdateOperatorControlAssignmentDetails.
+        If set, then the audit logs will be forwarded to the relevant remote logging server
+
+
+        :param is_log_forwarded: The is_log_forwarded of this UpdateOperatorControlAssignmentDetails.
+        :type: bool
+        """
+        self._is_log_forwarded = is_log_forwarded
+
+    @property
+    def remote_syslog_server_address(self):
+        """
+        Gets the remote_syslog_server_address of this UpdateOperatorControlAssignmentDetails.
+        The address of the remote syslog server where the audit logs will be forwarded to. Address in host or IP format.
+
+
+        :return: The remote_syslog_server_address of this UpdateOperatorControlAssignmentDetails.
+        :rtype: str
+        """
+        return self._remote_syslog_server_address
+
+    @remote_syslog_server_address.setter
+    def remote_syslog_server_address(self, remote_syslog_server_address):
+        """
+        Sets the remote_syslog_server_address of this UpdateOperatorControlAssignmentDetails.
+        The address of the remote syslog server where the audit logs will be forwarded to. Address in host or IP format.
+
+
+        :param remote_syslog_server_address: The remote_syslog_server_address of this UpdateOperatorControlAssignmentDetails.
+        :type: str
+        """
+        self._remote_syslog_server_address = remote_syslog_server_address
+
+    @property
+    def remote_syslog_server_port(self):
+        """
+        Gets the remote_syslog_server_port of this UpdateOperatorControlAssignmentDetails.
+        The listening port of the remote syslog server. The port range is 0 - 65535. Only TCP supported.
+
+
+        :return: The remote_syslog_server_port of this UpdateOperatorControlAssignmentDetails.
+        :rtype: int
+        """
+        return self._remote_syslog_server_port
+
+    @remote_syslog_server_port.setter
+    def remote_syslog_server_port(self, remote_syslog_server_port):
+        """
+        Sets the remote_syslog_server_port of this UpdateOperatorControlAssignmentDetails.
+        The listening port of the remote syslog server. The port range is 0 - 65535. Only TCP supported.
+
+
+        :param remote_syslog_server_port: The remote_syslog_server_port of this UpdateOperatorControlAssignmentDetails.
+        :type: int
+        """
+        self._remote_syslog_server_port = remote_syslog_server_port
+
+    @property
+    def remote_syslog_server_ca_cert(self):
+        """
+        Gets the remote_syslog_server_ca_cert of this UpdateOperatorControlAssignmentDetails.
+        The CA certificate of the remote syslog server. Identity of the remote syslog server will be asserted based on this certificate.
+
+
+        :return: The remote_syslog_server_ca_cert of this UpdateOperatorControlAssignmentDetails.
+        :rtype: str
+        """
+        return self._remote_syslog_server_ca_cert
+
+    @remote_syslog_server_ca_cert.setter
+    def remote_syslog_server_ca_cert(self, remote_syslog_server_ca_cert):
+        """
+        Sets the remote_syslog_server_ca_cert of this UpdateOperatorControlAssignmentDetails.
+        The CA certificate of the remote syslog server. Identity of the remote syslog server will be asserted based on this certificate.
+
+
+        :param remote_syslog_server_ca_cert: The remote_syslog_server_ca_cert of this UpdateOperatorControlAssignmentDetails.
+        :type: str
+        """
+        self._remote_syslog_server_ca_cert = remote_syslog_server_ca_cert
+
+    @property
+    def is_auto_approve_during_maintenance(self):
+        """
+        Gets the is_auto_approve_during_maintenance of this UpdateOperatorControlAssignmentDetails.
+        The boolean if true would autoApprove during maintenance.
+
+
+        :return: The is_auto_approve_during_maintenance of this UpdateOperatorControlAssignmentDetails.
+        :rtype: bool
+        """
+        return self._is_auto_approve_during_maintenance
+
+    @is_auto_approve_during_maintenance.setter
+    def is_auto_approve_during_maintenance(self, is_auto_approve_during_maintenance):
+        """
+        Sets the is_auto_approve_during_maintenance of this UpdateOperatorControlAssignmentDetails.
+        The boolean if true would autoApprove during maintenance.
+
+
+        :param is_auto_approve_during_maintenance: The is_auto_approve_during_maintenance of this UpdateOperatorControlAssignmentDetails.
+        :type: bool
+        """
+        self._is_auto_approve_during_maintenance = is_auto_approve_during_maintenance
 
     @property
     def freeform_tags(self):

--- a/src/oci/operator_access_control/models/update_operator_control_details.py
+++ b/src/oci/operator_access_control/models/update_operator_control_details.py
@@ -99,7 +99,7 @@ class UpdateOperatorControlDetails(object):
     @property
     def operator_control_name(self):
         """
-        Gets the operator_control_name of this UpdateOperatorControlDetails.
+        **[Required]** Gets the operator_control_name of this UpdateOperatorControlDetails.
         Name of the operator control.
 
 
@@ -171,7 +171,7 @@ class UpdateOperatorControlDetails(object):
     @property
     def approver_groups_list(self):
         """
-        Gets the approver_groups_list of this UpdateOperatorControlDetails.
+        **[Required]** Gets the approver_groups_list of this UpdateOperatorControlDetails.
         List of user groups who can approve an access request associated with a target resource under the governance of this operator control.
 
 
@@ -221,7 +221,7 @@ class UpdateOperatorControlDetails(object):
     @property
     def is_fully_pre_approved(self):
         """
-        Gets the is_fully_pre_approved of this UpdateOperatorControlDetails.
+        **[Required]** Gets the is_fully_pre_approved of this UpdateOperatorControlDetails.
         Whether all the operator actions have been pre-approved. If yes, all access requests associated with a resource governed by this operator control
         will be auto-approved.
 

--- a/src/oci/operator_access_control/operator_actions_client.py
+++ b/src/oci/operator_access_control/operator_actions_client.py
@@ -189,6 +189,9 @@ class OperatorActionsClient(object):
         :param str name: (optional)
             A filter to return only resources that match the entire display name given.
 
+        :param str resource_type: (optional)
+            A filter to return only lists of resources that match the entire given service type.
+
         :param str lifecycle_state: (optional)
             A filter to return only resources whose lifecycleState matches the given OperatorAction lifecycleState.
 
@@ -234,6 +237,7 @@ class OperatorActionsClient(object):
         expected_kwargs = [
             "retry_strategy",
             "name",
+            "resource_type",
             "lifecycle_state",
             "limit",
             "page",
@@ -269,6 +273,7 @@ class OperatorActionsClient(object):
 
         query_params = {
             "name": kwargs.get("name", missing),
+            "resourceType": kwargs.get("resource_type", missing),
             "compartmentId": compartment_id,
             "lifecycleState": kwargs.get("lifecycle_state", missing),
             "limit": kwargs.get("limit", missing),

--- a/src/oci/operator_access_control/operator_control_assignment_client.py
+++ b/src/oci/operator_access_control/operator_control_assignment_client.py
@@ -226,7 +226,7 @@ class OperatorControlAssignmentClient(object):
 
             To have this operation explicitly not perform any retries, pass an instance of :py:class:`~oci.retry.NoneRetryStrategy`.
 
-        :return: A :class:`~oci.response.Response` object with data of type None
+        :return: A :class:`~oci.response.Response` object with data of type :class:`~oci.operator_access_control.models.OperatorControlAssignment`
         :rtype: :class:`~oci.response.Response`
 
         :example:
@@ -269,13 +269,15 @@ class OperatorControlAssignmentClient(object):
                 resource_path=resource_path,
                 method=method,
                 header_params=header_params,
-                body=create_operator_control_assignment_details)
+                body=create_operator_control_assignment_details,
+                response_type="OperatorControlAssignment")
         else:
             return self.base_client.call_api(
                 resource_path=resource_path,
                 method=method,
                 header_params=header_params,
-                body=create_operator_control_assignment_details)
+                body=create_operator_control_assignment_details,
+                response_type="OperatorControlAssignment")
 
     def delete_operator_control_assignment(self, operator_control_assignment_id, **kwargs):
         """
@@ -467,10 +469,13 @@ class OperatorControlAssignmentClient(object):
         :param str resource_name: (optional)
             A filter to return only resources that match the given ResourceName.
 
+        :param str resource_type: (optional)
+            A filter to return only lists of resources that match the entire given service type.
+
         :param str lifecycle_state: (optional)
             A filter to return only resources whose lifecycleState matches the given OperatorControlAssignment lifecycleState.
 
-            Allowed values are: "CREATED", "APPLIED", "APPLYFAILED", "DELETED"
+            Allowed values are: "CREATED", "APPLIED", "APPLYFAILED", "UPDATING", "DELETING", "DELETED", "DELETIONFAILED"
 
         :param int limit: (optional)
             The maximum number of items to return.
@@ -513,6 +518,7 @@ class OperatorControlAssignmentClient(object):
             "retry_strategy",
             "operator_control_name",
             "resource_name",
+            "resource_type",
             "lifecycle_state",
             "limit",
             "page",
@@ -526,7 +532,7 @@ class OperatorControlAssignmentClient(object):
                 "list_operator_control_assignments got unknown kwargs: {!r}".format(extra_kwargs))
 
         if 'lifecycle_state' in kwargs:
-            lifecycle_state_allowed_values = ["CREATED", "APPLIED", "APPLYFAILED", "DELETED"]
+            lifecycle_state_allowed_values = ["CREATED", "APPLIED", "APPLYFAILED", "UPDATING", "DELETING", "DELETED", "DELETIONFAILED"]
             if kwargs['lifecycle_state'] not in lifecycle_state_allowed_values:
                 raise ValueError(
                     "Invalid value for `lifecycle_state`, must be one of {0}".format(lifecycle_state_allowed_values)
@@ -550,6 +556,7 @@ class OperatorControlAssignmentClient(object):
             "operatorControlName": kwargs.get("operator_control_name", missing),
             "resourceName": kwargs.get("resource_name", missing),
             "compartmentId": compartment_id,
+            "resourceType": kwargs.get("resource_type", missing),
             "lifecycleState": kwargs.get("lifecycle_state", missing),
             "limit": kwargs.get("limit", missing),
             "page": kwargs.get("page", missing),

--- a/src/oci/operator_access_control/operator_control_assignment_client_composite_operations.py
+++ b/src/oci/operator_access_control/operator_control_assignment_client_composite_operations.py
@@ -23,6 +23,44 @@ class OperatorControlAssignmentClientCompositeOperations(object):
         """
         self.client = client
 
+    def create_operator_control_assignment_and_wait_for_state(self, create_operator_control_assignment_details, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
+        """
+        Calls :py:func:`~oci.operator_access_control.OperatorControlAssignmentClient.create_operator_control_assignment` and waits for the :py:class:`~oci.operator_access_control.models.OperatorControlAssignment` acted upon
+        to enter the given state(s).
+
+        :param oci.operator_access_control.models.CreateOperatorControlAssignmentDetails create_operator_control_assignment_details: (required)
+            Details of the Operator Control Assignment.
+
+        :param list[str] wait_for_states:
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.operator_access_control.models.OperatorControlAssignment.lifecycle_state`
+
+        :param dict operation_kwargs:
+            A dictionary of keyword arguments to pass to :py:func:`~oci.operator_access_control.OperatorControlAssignmentClient.create_operator_control_assignment`
+
+        :param dict waiter_kwargs:
+            A dictionary of keyword arguments to pass to the :py:func:`oci.wait_until` function. For example, you could pass ``max_interval_seconds`` or ``max_interval_seconds``
+            as dictionary keys to modify how long the waiter function will wait between retries and the maximum amount of time it will wait
+        """
+        operation_result = self.client.create_operator_control_assignment(create_operator_control_assignment_details, **operation_kwargs)
+        if not wait_for_states:
+            return operation_result
+
+        lowered_wait_for_states = [w.lower() for w in wait_for_states]
+        wait_for_resource_id = operation_result.data.id
+
+        try:
+            waiter_result = oci.wait_until(
+                self.client,
+                self.client.get_operator_control_assignment(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
+                **waiter_kwargs
+            )
+            result_to_return = waiter_result
+
+            return result_to_return
+        except Exception as e:
+            raise oci.exceptions.CompositeOperationError(partial_results=[operation_result], cause=e)
+
     def delete_operator_control_assignment_and_wait_for_state(self, operator_control_assignment_id, wait_for_states=[], operation_kwargs={}, waiter_kwargs={}):
         """
         Calls :py:func:`~oci.operator_access_control.OperatorControlAssignmentClient.delete_operator_control_assignment` and waits for the :py:class:`~oci.operator_access_control.models.OperatorControlAssignment` acted upon

--- a/src/oci/operator_access_control/operator_control_client.py
+++ b/src/oci/operator_access_control/operator_control_client.py
@@ -475,6 +475,9 @@ class OperatorControlClient(object):
         :param str display_name: (optional)
             A filter to return OperatorControl that match the entire display name given.
 
+        :param str resource_type: (optional)
+            A filter to return only lists of resources that match the entire given service type.
+
         :param int limit: (optional)
             The maximum number of items to return.
 
@@ -516,6 +519,7 @@ class OperatorControlClient(object):
             "retry_strategy",
             "lifecycle_state",
             "display_name",
+            "resource_type",
             "limit",
             "page",
             "sort_order",
@@ -552,6 +556,7 @@ class OperatorControlClient(object):
             "compartmentId": compartment_id,
             "lifecycleState": kwargs.get("lifecycle_state", missing),
             "displayName": kwargs.get("display_name", missing),
+            "resourceType": kwargs.get("resource_type", missing),
             "limit": kwargs.get("limit", missing),
             "page": kwargs.get("page", missing),
             "sortOrder": kwargs.get("sort_order", missing),

--- a/src/oci/version.py
+++ b/src/oci/version.py
@@ -2,4 +2,4 @@
 # Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
 # This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 
-__version__ = "2.49.1"
+__version__ = "2.50.0"


### PR DESCRIPTION
Added

-----

* Support for drill down metadata in the Management Dashboard service

* Support for operator access control on dedicated autonomous databases in the Operator Access Control service



Breaking

--------

* Property `resource_type` and `is_enforced_always` from model `CreateOperatorControlAssignmentDetails` changed from optional to required in the Operator Access Control service

* Property `operator_control_name`, `approver_groups_list` and `is_fully_pre_approved` from model `UpdateOperatorControlDetails` changed from optional to required in the Operator Access Control service

* Property `is_enforced_always` from model `UpdateOperatorControlAssignmentDetails` changed from optional to required in the Operator Access Control service

* Property `approver_groups_list` and `is_fully_pre_approved` from model `CreateOperatorControlDetails` changed from optional to required in the Operator Access Control service

* Data type for response of operation `create_operator_control_assignment` changed to `oci.operator_access_control.models.OperatorControlAssignment` in the Operator Access Control service

====================