### PR TITLE
Allow control characters inside strings.

### DIFF
--- a/src/oci/base_client.py
+++ b/src/oci/base_client.py
@@ -782,7 +782,7 @@ class BaseClient(object):
         response_data = response_data.decode('utf8')
 
         try:
-            json_response = json.loads(response_data)
+            json_response = json.loads(response_data, strict=False)
             # Load everything as JSON and then verify that the object returned
             # is a string (six.text_type) if the response type is a string.
             # This is matches the previous behavior, which happens to strip


### PR DESCRIPTION
By the definition of python json loads method:

```python
"""
        If ``strict`` is false (true is the default), then control
        characters will be allowed inside strings.  Control characters in
        this context are those with character codes in the 0-31 range,
        including ``'\\t'`` (tab), ``'\\n'``, ``'\\r'`` and ``'\\0'``.
"""
```

By some reason, the OCI NoSQL Tables that I'm interacting with has those types of characters registered. So the only way I can get access to it is by using this parameter as `False`.

Associated issue #404 