### PR TITLE
Fix KeyError for oci.resource_manager.ResourceManagerClientCompositeOperations.create_stack_and_wait_for_state by using stack_id

### DIFF
--- a/docs/known-issues.rst
+++ b/docs/known-issues.rst
@@ -34,12 +34,6 @@ We are actively working on fixing this issue, but in the mean time, if you are e
 
 If you have any questions, please feel free to comment on `this GitHub issue <https://github.com/oracle/oci-python-sdk/issues/367>`_ and we will be happy to help.
 
-create_job_and_wait_for_state() fails with KeyError for ResourceManagerClientCompositeOperations (versions 2.20.0 and above)
-============================================================================================================================
-`ResourceManagerClientCompositeOperations.create_job_and_wait_for_state() <https://docs.cloud.oracle.com/en-us/iaas/tools/python/latest/api/resource_manager/client/oci.resource_manager.ResourceManagerClientCompositeOperations.html#oci.resource_manager.ResourceManagerClientCompositeOperations.create_stack_and_wait_for_state>`_ fails with KeyError: 'opc-work-request-id'.
-
-**Workaround:** Use `create_stack() <https://docs.cloud.oracle.com/en-us/iaas/tools/python/latest/api/resource_manager/client/oci.resource_manager.ResourceManagerClient.html#oci.resource_manager.ResourceManagerClient.create_stack>`_ and then implement `waiters <https://docs.cloud.oracle.com/en-us/iaas/tools/python/latest/api/waiters.html#oci.wait_until>`_. You can find an example to use waiters `here <https://github.com/oracle/oci-python-sdk/blob/master/examples/wait_for_resource_in_state.py>`_.
-
 UploadManager.upload_stream() raises MultipartUploadError in oci v2.23.2
 ========================================================================
 `UploadManager.upload_stream() <https://docs.cloud.oracle.com/en-us/iaas/tools/python/latest/api/upload_manager.html#oci.object_storage.UploadManager.upload_stream>`_ raises MultipartUploadError when a timeout is set on the underlying object storage client, and the operation takes more than the read timeout to complete. Prior to v2.23.2, we were overwriting the timeout to None in the operations (please see this `known issue <https://docs.cloud.oracle.com/en-us/iaas/tools/python/latest/known-issues.html#uploadmanager-generates-ssl3-write-pending-error-when-a-read-timeout-is-set-for-the-object-storage-client>`_). The default timeout is a read timeout of 60 seconds, hence this scenario will be triggered by default in v2.23.2 on any use of this operation where the operation takes 60 or more seconds to complete.

--- a/src/oci/resource_manager/resource_manager_client_composite_operations.py
+++ b/src/oci/resource_manager/resource_manager_client_composite_operations.py
@@ -200,7 +200,7 @@ class ResourceManagerClientCompositeOperations(object):
             The properties for creating a stack.
 
         :param list[str] wait_for_states:
-            An array of states to wait on. These should be valid values for :py:attr:`~oci.resource_manager.models.WorkRequest.status`
+            An array of states to wait on. These should be valid values for :py:attr:`~oci.resource_manager.models.Stack.lifecycle_state`
 
         :param dict operation_kwargs:
             A dictionary of keyword arguments to pass to :py:func:`~oci.resource_manager.ResourceManagerClient.create_stack`

--- a/src/oci/resource_manager/resource_manager_client_composite_operations.py
+++ b/src/oci/resource_manager/resource_manager_client_composite_operations.py
@@ -214,13 +214,13 @@ class ResourceManagerClientCompositeOperations(object):
             return operation_result
 
         lowered_wait_for_states = [w.lower() for w in wait_for_states]
-        wait_for_resource_id = operation_result.headers['opc-work-request-id']
+        wait_for_resource_id = operation_result.data.id
 
         try:
             waiter_result = oci.wait_until(
                 self.client,
-                self.client.get_work_request(wait_for_resource_id),
-                evaluate_response=lambda r: getattr(r.data, 'status') and getattr(r.data, 'status').lower() in lowered_wait_for_states,
+                self.client.get_stack(wait_for_resource_id),
+                evaluate_response=lambda r: getattr(r.data, 'lifecycle_state') and getattr(r.data, 'lifecycle_state').lower() in lowered_wait_for_states,
                 **waiter_kwargs
             )
             result_to_return = waiter_result


### PR DESCRIPTION
# Summary
- Fixed Bug
- Addressed corresponding documentation updates.

# Overview
This bug is documented in [oracle-cloud-infrastructure-python-sdk.readthedocs.io](https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/known-issues.html#create-job-and-wait-for-state-fails-with-keyerror-for-resourcemanagerclientcompositeoperations-versions-2-20-0-and-above).

Changed to use `oci.resource_manager.ResourceManagerClient.get_stack()` instead of `oci.resource_manager.ResourceManagerClient.get_work_request()` as a valid GET operation for `oci.wait_until()` for the `oci.resource_manager.ResourceManagerClientCompositeOperations.create_stack_and_wait_for_state()` method.

# Detailed Bug

- Package Version: 2.66.0

```bash
Traceback (most recent call last):
  File "/Users/js071996/oci/oci/test.py", line 7, in <module>
    oci_api_utils.resource_manager.cicd()
  File "/Users/js071996/oci/oci/oci_api_utils/resource_manager.py", line 181, in cicd
    response = create_or_update_stack(clients["resource_manager_client"], clients["resource_manager_composite_client"], stack_details)
  File "/Users/js071996/oci/oci/oci_api_utils/resource_manager.py", line 133, in create_or_update_stack
    response: oci.Response = composite_client.create_stack_and_wait_for_state(
  File "/Users/js071996/oci/oci/.venv/lib/python3.10/site-packages/oci/resource_manager/resource_manager_client_composite_operations.py", line 217, in create_stack_and_wait_for_state
    wait_for_resource_id = operation_result.headers['opc-work-request-id']
  File "/Users/js071996/oci/oci/.venv/lib/python3.10/site-packages/oci/_vendor/requests/structures.py", line 59, in __getitem__
    return self._store[key.lower()][1]
KeyError: 'opc-work-request-id'
```

# Investigation

Headers:
```
 {'Date': 'Fri, 20 May 2022 14:36:41 GMT', 'opc-request-id': 'REDACTED', 'Strict-Transport-Security': 'max-age=31536000; includeSubDomains;', 'Cache-Control': 'no-cache, no-store, must-revalidate', 'ETag': 'REDACTED', 'Pragma': 'no-cache', 'X-XSS-Protection': '1; mode=block', 'Content-Type': 'application/json', 'X-Content-Type-Options': 'nosniff', 'Content-Length': '673'}
```
As per the error: 'opc-work-request-id' is not a valid header.

Data:
```
{
  "compartment_id": "REDACTED",
  "config_source": {
    "config_source_type": "ZIP_UPLOAD",
    "working_directory": "config"
  },
  "defined_tags": {},
  "description": "REDACTED",
  "display_name": "REDACTED",
  "freeform_tags": {},
  "id": "REDACTED",
  "lifecycle_state": "ACTIVE",
  "stack_drift_status": "NOT_CHECKED",
  "terraform_version": "1.0.x",
  "time_created": "2022-05-20T14:36:41.918000+00:00",
  "time_drift_last_checked": null,
  "variables": {}
}
```
- The stack id (OCID) is contained in the data property of the oci.Response object. This can be paired with a `oci.resource_manager.ResourceManagerClient.get_stack()`
- `status` is not a valid attribute. `lifecycle_state` is equivalent.


Signed-off-by: jacobsnapp <7643439+jacobsnapp@users.noreply.github.com>