### PR TITLE
Issue 504: Make sure wheels do not indicate they support python 2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal = 1
-
 [flake8]
 ignore = D203,E501,W504
 exclude =


### PR DESCRIPTION
After this change wheels will be suffixed py3-none-any.whl, not py2.py3-none-any.whl