### PR TITLE
Fixes a bug where the source region is always picked up from the conf…

### DIFF
--- a/examples/object_storage/object_storage_bulk_copy.py
+++ b/examples/object_storage/object_storage_bulk_copy.py
@@ -41,6 +41,7 @@ import argparse
 import datetime
 import sys
 import os
+import deepcopy
 
 
 ##########################################################################
@@ -437,12 +438,17 @@ def connect_to_object_storage():
 
     # get signer
     config, signer = create_signer(cmd.config_file, cmd.config_profile, cmd.is_instance_principals, cmd.is_delegation_token)
-
+    config_destination = copy.deepcopy(config)
+    
     # assign region from config file
     if not source_region:
         source_region = config['region']
+    else:
+        config['region'] = source_region
     if not destination_region:
         destination_region = config['region']
+    else:
+        config_destination['region'] = destination_region
 
     try:
         # connect to source region
@@ -463,8 +469,6 @@ def connect_to_object_storage():
     try:
         # connect to destination object storage
         print("\nConnecting to Object Storage Service for destination region - " + destination_region)
-        config_destination = config
-        config_destination['region'] = destination_region
         object_storage_client_dest = oci.object_storage.ObjectStorageClient(config_destination, signer=signer)
         if cmd.proxy:
             object_storage_client_dest.base_client.session.proxies = {'https': cmd.proxy}


### PR DESCRIPTION
…ig file.

While creating the source region ObjectStorageClient, the current code uses the region which is set in the `config` object which was created by reading the config file(which may have a different region set). The log lines print the source_region variable but never set it inside the config object.