### PR TITLE
chore: update cryptography max version pins

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 autodocsumm==0.1.11
 certifi
 coverage==4.5.2
-cryptography>=3.2.1,<40.0.0
+cryptography>=3.2.1
 flake8>=3.6.0,<6
 mock==2.0.0
 pyOpenSSL>=17.5.0,<24.0.0

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ with open_relative("README.rst") as f:
 requires = [
     "certifi",
     "configparser==4.0.2 ; python_version < '3'",
-    "cryptography>=3.2.1,<40.0.0",
+    "cryptography>=3.2.1",
     "pyOpenSSL>=17.5.0,<24.0.0",
     "python-dateutil>=2.5.3,<3.0.0",
     "pytz>=2016.10",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py37, py38, py39, flake8
+envlist = py37, py38, py39, py310, py311, flake8
 
 [testenv]
 passenv = PYTHON_TESTS_ADMIN_PASS_PHRASE OCI_PYSDK*


### PR DESCRIPTION
- chore: remove max pin on cryptography lib
- update tox matrix for supported python versions

closes #548 