### PR TITLE
test: Change --config-file to config

### DIFF
--- a/README-development.rst
+++ b/README-development.rst
@@ -49,12 +49,12 @@ By default, the tests will look for a config file, 'config' in 'tests/resources'
 If 'tests/resources' does not exist, the tests will try attempt to use
 'tests/configuration/config'.
 The default profile is ``DEFAULT``.  You can change this with the
-``--config-file`` and ``--config-profile`` options.
+``--config`` and ``--config-profile`` options.
 
 .. code-block:: sh
 
     # Use a different config file, still using the DEFAULT profile
-    tox -- --config-file ~/.oci/config
+    tox -- --config ~/.oci/config
 
     # Using a different profile in the default config file
     tox -- --config-profile IAD_PROFILE

--- a/tests/configuration/config.sample
+++ b/tests/configuration/config.sample
@@ -1,7 +1,7 @@
 ; Copy this file to file named `config` and fill in the values to run tests
 ; which require cloud resources.  You can also run the tests using a different
-; configuration by passing the path to pytest with ``--config-file``.
-; For more information on using ``--config-file`` see README-developement.rst
+; configuration by passing the path to pytest with ``--config``.
+; For more information on using ``--config`` see README-developement.rst
 ; For more information on how to configure the SDK see
 ; https://docs.cloud.oracle.com/iaas/Content/API/Concepts/sdkconfig.htm
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ from . import test_config_container
 
 
 def pytest_addoption(parser):
-    parser.addoption("--config-file", action="store", help="location of the config file",
+    parser.addoption("--config", action="store", help="location of the config file",
                      default=get_resource_path('config'))
     parser.addoption("--config-profile", action="store",
                      help="profile to use from the config file",
@@ -30,7 +30,7 @@ def pytest_configure(config):
 
 @pytest.fixture(scope="session")
 def config_file(request):
-    return request.config.getoption("--config-file")
+    return request.config.getoption("--config")
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
This patch changes the --config-file option to --config to avoid conflict with pytest >= 7.4.0

Fix https://github.com/oracle/oci-python-sdk/issues/565