### PR TITLE
private_key_file_location is not required when private_key_content specified for Signer class

### DIFF
--- a/src/oci/signer.py
+++ b/src/oci/signer.py
@@ -246,13 +246,15 @@ class Signer(AbstractBaseSigner):
 
     """
 
-    def __init__(self, tenancy, user, fingerprint, private_key_file_location, pass_phrase=None, private_key_content=None):
+    def __init__(self, tenancy, user, fingerprint, private_key_file_location=None, pass_phrase=None, private_key_content=None):
         self.api_key = tenancy + "/" + user + "/" + fingerprint
 
         if private_key_content:
             self.private_key = load_private_key(private_key_content, pass_phrase)
-        else:
+        elif private_key_file_location:
             self.private_key = load_private_key_from_file(private_key_file_location, pass_phrase)
+        else:
+            raise ValueError("Must supply either a private key content or a private key file path.")
 
         generic_headers = ["date", "(request-target)", "host"]
         body_headers = ["content-length", "content-type", "x-content-sha256"]


### PR DESCRIPTION
The private_key_file_location is not required when private_key_content is specified for Signer class and vice versa.

DOCS: https://docs.oracle.com/en-us/iaas/tools/python/2.136.0/api/signing.html
> The private key can be sourced from a file (private_key_file_location) or the PEM string can be provided directly (private_key_content).
