### PR TITLE
Drop upper bounds on cryptography and pyopenssl

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,8 @@ classifiers=[
 dependencies = [
     "certifi",
     "configparser==4.0.2 ; python_version < '3'",
-    "cryptography>=3.2.1,<47.0.0",
-    "pyOpenSSL>=17.5.0,<=25.3.0",
+    "cryptography>=3.2.1",
+    "pyOpenSSL>=17.5.0",
     "python-dateutil>=2.5.3,<3.0.0",
     "pytz>=2016.10",
     "circuitbreaker>=1.3.1,<2.0.0; python_version <= '3.6'",

--- a/setup.py
+++ b/setup.py
@@ -32,8 +32,8 @@ with open_relative("README.rst") as f:
 requires = [
     "certifi",
     "configparser==4.0.2 ; python_version < '3'",
-    "cryptography>=3.2.1,<47.0.0",
-    "pyOpenSSL>=17.5.0,<=25.3.0",
+    "cryptography>=3.2.1",
+    "pyOpenSSL>=17.5.0",
     "python-dateutil>=2.5.3,<3.0.0",
     "pytz>=2016.10",
     "circuitbreaker>=1.3.1,<2.0.0; python_version <= '3.6'",


### PR DESCRIPTION
These are security critical dependencies. Bounds here limit people's ability to respond to vulnerabilities.
See also https://github.com/oracle/oci-python-sdk/issues/700 https://github.com/oracle/oci-python-sdk/issues/692 https://github.com/oracle/oci-python-sdk/issues/681 https://github.com/oracle/oci-python-sdk/issues/618 https://github.com/oracle/oci-python-sdk/issues/568 https://github.com/oracle/oci-python-sdk/issues/548 https://github.com/oracle/oci-python-sdk/issues/515
See also https://iscinumpy.dev/post/bound-version-constraints/