### PR TITLE
Fix typos and improve grammar in ADK module

### DIFF
--- a/src/oci/addons/adk/agent.py
+++ b/src/oci/addons/adk/agent.py
@@ -82,7 +82,7 @@ class Agent:
         self.name = name
         self.description = description
 
-        # variables not set up user
+        # variables not set by user
         self._agent_details: Dict[str, Any] = {}
         self._local_handler_functions: List[FunctionTool] = (
             self._process_function_tools()

--- a/src/oci/addons/adk/agent_client.py
+++ b/src/oci/addons/adk/agent_client.py
@@ -500,7 +500,7 @@ class AgentClient:
 
         add_tool_response: Response = self._invoke(
             method=self._mgmt_client.create_tool,
-            success_message="Add sql tool successful",
+            success_message="SQL tool addition succeeded",
             error_message="Failed to add sql tool",
             debug=self.debug,
             create_tool_details=create_tool_details,
@@ -633,7 +633,7 @@ class AgentClient:
         )
         self._invoke(
             method=self._mgmt_client.update_tool,
-            success_message="Update sql tool successful",
+            success_message="SQL tool update succeeded",
             error_message="Failed to update sql tool",
             debug=self.debug,
             tool_id=tool_id,

--- a/src/oci/addons/adk/run/types.py
+++ b/src/oci/addons/adk/run/types.py
@@ -131,7 +131,7 @@ class RawResponse(BaseModel):
 
 
 class InputLocationType(str, Enum):
-    """Represents teh type of input location."""
+    """Represents the type of input location."""
 
     INLINE = "INLINE"
     OBJECT_STORAGE_PREFIX = "OBJECT_STORAGE_PREFIX"


### PR DESCRIPTION
Fix minor typos and grammar issues in the ADK module:
- Fix typo "teh" -> "the" in run/types.py
- Fix grammar "not set up user" -> "not set by user" in agent.py
- Improve success message grammar in agent_client.py.
