### PR TITLE
Fix ADK tag filtering for function tool sync

### DIFF
--- a/src/oci/addons/adk/agent.py
+++ b/src/oci/addons/adk/agent.py
@@ -567,7 +567,7 @@ class Agent:
     def _sync_function_tools_to_remote(self) -> None:
         """
         Synchronize local and remote function tools.
-
+        Only remote tools that have ADK freeform tags are considered (tools created by ADK).
         """
         logger.info("Checking synchronization of local and remote function tools...")
         local_func_tools = self._local_handler_functions
@@ -575,11 +575,13 @@ class Agent:
             compartment_id=self.agent_details["compartment_id"],
             agent_id=self.agent_details["agent_id"],
         )
+        # Filter for active function tools with ADK tags
         remote_func_tools = [
             tool
             for tool in remote_func_tools
-            if tool.get("lifecycle_state") == "ACTIVE" and tool.get("tool_config", {})
-            .get("tool_config_type") == "FUNCTION_CALLING_TOOL_CONFIG"
+            if (tool.get("lifecycle_state") == "ACTIVE"
+                and set(FREEFORM_TAGS.keys()).issubset(tool.get("freeform_tags", {}).keys())
+                and tool.get("tool_config", {}).get("tool_config_type") == "FUNCTION_CALLING_TOOL_CONFIG")
         ]
         self._log_tool_counts(local_func_tools, remote_func_tools)
         self._sync_local_and_remote_tools(local_func_tools, remote_func_tools)


### PR DESCRIPTION
When `agent.setup()` ran function-tool sync (`_sync_function_tools_to_remote`), it treated **all** remote function-calling tools as sync targets. That included tools created outside ADK (e.g. in the OCI console or by other clients) that do not have ADK freeform tags (`ConfiguredByADK`).

As a result:

- Sync tried to reconcile local ADK tools with **non-ADK** remote tools, as if they were managed by ADK.
- Non-ADK tools could be considered for update/delete during sync, even though ADK did not create them.

## Root Cause
In `agent.py`, `_sync_function_tools_to_remote()` used every tool returned by `find_tools()` that had `tool_config_type == "FUNCTION_CALLING_TOOL_CONFIG"`, without checking ADK ownership. RAG and SQL tool sync already filtered by ADK freeform tags; function tool sync did not.

## Fix

Function tool sync now uses the same ADK tag filter as RAG and SQL sync. Before calling `_sync_local_and_remote_tools()`, we restrict `remote_func_tools` to tools that:

1. Have `lifecycle_state == "ACTIVE"`, and
2. Have ADK freeform tags (i.e. `FREEFORM_TAGS` keys are present in `freeform_tags`), and
3. Have `tool_config_type == "FUNCTION_CALLING_TOOL_CONFIG"`.

Only those remote tools are passed into sync. Tools created outside ADK (e.g. in the console, without ADK tags) are no longer part of the sync list and are left unchanged by ADK.