### PR TITLE
Remove unjustified 2s sleep after tool execution in run_async (ADK module)

### DIFF
--- a/src/oci/addons/adk/agent.py
+++ b/src/oci/addons/adk/agent.py
@@ -268,7 +268,6 @@ class Agent:
                 next_user_message = "null"
                 # next_user_message = None
 
-                time.sleep(2)  # to avoid throttle by GenAI service
                 response = self._handle_chat(
                     user_message=next_user_message,
                     session_id=session_id,


### PR DESCRIPTION
Remove the fixed `time.sleep(2)` that ran after handling `required_actions` (tool execution) and before sending the next chat request in `run_async`. 

Every tool-call round added a fixed 2-second wait for all users. The value 2 seconds is a magic number. It is not specified by the API, not configurable, and not justified by any documented OCI/GenAI requirement or constants.

And retry is already implemented at a lower level:
- `AgentClient` builds `GenerativeAiAgentRuntimeClient` with `retry_strategy=oci.retry.DEFAULT_RETRY_STRATEGY` (agent_client.py ~line 116).
- `DEFAULT_RETRY_STRATEGY` (src/oci/retry/__init__.py) retries on **HTTP 429 (throttles)** with exponential backoff (up to 8 attempts, 600s total).
- So when `_handle_chat` → `client.chat()` → `_rt_client.chat()` is called, the runtime client already retries on 429. The fixed 2s sleep does not replace or improve that; it only adds delay when no throttle occurs.
