### PR TITLE
Remove OpenSSL dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ dependencies = [
     "certifi",
     "configparser==4.0.2 ; python_version < '3'",
     "cryptography>=3.2.1,<50.0.0",
-    "pyOpenSSL>=17.5.0,<27.0.0",
     "python-dateutil>=2.5.3,<3.0.0",
     "pytz>=2016.10",
     "circuitbreaker>=1.3.1,<2.0.0; python_version <= '3.6'",

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ cryptography==42.0.8; python_full_version == '3.9.0' or python_full_version == '
 cryptography>=3.2.1,<50.0.0; python_full_version != '3.9.0' and python_full_version != '3.9.1'
 flake8>=3.6.0,<6
 mock==2.0.0
-pyOpenSSL>=17.5.0,<27.0.0
 pytest==4.6.10; python_version <= '3.9'
 pytest==7.1.2; python_version >= '3.10'
 pytest-cov==2.6.1

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ requires = [
     "certifi",
     "configparser==4.0.2 ; python_version < '3'",
     "cryptography>=3.2.1,<50.0.0",
-    "pyOpenSSL>=17.5.0,<27.0.0",
     "python-dateutil>=2.5.3,<3.0.0",
     "pytz>=2016.10",
     "circuitbreaker>=1.3.1,<2.0.0; python_version <= '3.6'",


### PR DESCRIPTION
The only place where `OpenSSL` is used is via an indirect dependency from `urllib3.contrib.pyopenssl`, which itself is only used when the Python built-in SSL module doesn't support SNI (Server Name Indication).

That module itself is only imported via the vendored `requests` init, _iff_ `ssl.HAS_SNI` is `False`, or as an optional import in vendored `requests.help` (which is never imported by code; in the original `requests` library, it's supposed to be run as a command-line module, but it's unlikely `python -m oci._vendor.requests.help` is a real use case).

The `urllib3.contrib.pyopenssl` module's docstring says:

> This module was relevant before the standard library ``ssl``
> module supported SNI, but now that we've dropped support for
> Python 2.7 all relevant Python versions support SNI so
> **this module is no longer recommended**.

This is related to https://github.com/oracle/oci-python-sdk/pull/802; right now there are upper version pins on `pyOpenSSL`, which prevent downstream users from upgrading to e.g. non-vulnerable versions of that library downstream.