### PR TITLE
Fix urllib3 strict parameter warning

### DIFF
--- a/src/oci/base_client.py
+++ b/src/oci/base_client.py
@@ -374,7 +374,6 @@ class OCIHTTPAdapter(requests.adapters.HTTPAdapter):
             num_pools=connections,
             maxsize=maxsize,
             block=block,
-            strict=True,
             **pool_kwargs
         )
 

--- a/tests/unit/test_base_client.py
+++ b/tests/unit/test_base_client.py
@@ -1,0 +1,23 @@
+# coding: utf-8
+# Copyright (c) 2016, 2026, Oracle and/or its affiliates.  All rights reserved.
+# This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+import warnings
+
+from oci.base_client import OCIHTTPAdapter
+
+
+def test_oci_http_adapter_does_not_emit_urllib3_strict_future_warning():
+    with warnings.catch_warnings(record=True) as caught_warnings:
+        warnings.simplefilter("always", FutureWarning)
+
+        adapter = OCIHTTPAdapter()
+        adapter.poolmanager.connection_from_url("https://objectstorage.us-phoenix-1.oraclecloud.com")
+
+    strict_future_warnings = [
+        warning for warning in caught_warnings
+        if issubclass(warning.category, FutureWarning) and
+        "'strict' parameter is no longer needed" in str(warning.message)
+    ]
+
+    assert strict_future_warnings == []


### PR DESCRIPTION
With oci v2.174.0 and urllib3 v2.7.0 we get an annoying FutureWarning hinting to us that the strict parameter is no longer needed.

### Demonstrate Warning
Sample script:
```
$ cat warning.py
import oci

default_config = oci.config.from_file()
client = oci.object_storage.ObjectStorageClient(default_config)
try:
    client.list_buckets(compartment_id="foo", namespace_name="bar")
except oci.exceptions.ServiceError:
    pass
```
Result:
```
$ uv run warning.py
/home/akash/workspace/oci-python-sdk/.venv/lib/python3.12/site-packages/urllib3/poolmanager.py:329: FutureWarning: The 'strict' parameter is no longer needed on Python 3+. This will raise an error in urllib3 v3.0.
  warnings.warn(
```

### Proposed Solution
In `OCIHTTPAdapter` we can delete the `strict=True` parameter, because we have been informed that it is no longer needed.

### Execute Unit Test
```
$ PYTHONWARNINGS=always uv run --with pytest python -m pytest tests/unit/test_base_client.py -v --confcutdir=tests/unit
================================================================================= test session starts ==================================================================================
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0 -- /home/akash/.cache/uv/builds-v0/.tmpCZVuIJ/bin/python
cachedir: .pytest_cache
rootdir: /home/akash/workspace/oci-python-sdk
configfile: pyproject.toml
collected 1 item                                                                                                                                                                       

tests/unit/test_base_client.py::test_oci_http_adapter_does_not_emit_urllib3_strict_future_warning PASSED                                                                         [100%]

================================================================================== 1 passed in 0.32s ===================================================================================
```

### Environment
```
$ uv pip show oci | grep Version
Version: 2.174.0


$ uv pip show urllib3 | grep Version
Version: 2.7.0
```