### PR TITLE
Raise cryptography upper bound to <50.0.0 (allow 48.x/49.x); unblocks GHSA-537c security fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 certifi
 coverage==4.5.2
 cryptography==42.0.8; python_full_version == '3.9.0' or python_full_version == '3.9.1'
-cryptography>=3.2.1,<47.0.0; python_full_version != '3.9.0' and python_full_version != '3.9.1'
+cryptography>=3.2.1,<50.0.0; python_full_version != '3.9.0' and python_full_version != '3.9.1'
 flake8>=3.6.0,<6
 mock==2.0.0
 pyOpenSSL>=17.5.0,<27.0.0

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ with open_relative("README.rst") as f:
 requires = [
     "certifi",
     "configparser==4.0.2 ; python_version < '3'",
-    "cryptography>=3.2.1,<47.0.0",
+    "cryptography>=3.2.1,<50.0.0",
     "pyOpenSSL>=17.5.0,<27.0.0",
     "python-dateutil>=2.5.3,<3.0.0",
     "pytz>=2016.10",


### PR DESCRIPTION
Raise the ⁠ cryptography ⁠ upper-bound constraint from ⁠ <47.0.0 ⁠ to ⁠ <50.0.0 ⁠ in ⁠ setup.py ⁠ and ⁠ requirements.txt ⁠.
 
cryptography 48.0.1 ships the fix for *GHSA-537c-gmf6-5ccf* (CVE-2026-9076 — a heap out-of-bounds read in the OpenSSL statically linked into cryptography's wheels; OpenSSL advisory 2026-06-09). The current ⁠ <47.0.0 ⁠ cap pins downstream applications at cryptography 46.0.7 — the highest version below the fix — so they cannot remediate this HIGH advisory while ⁠ oci ⁠ is a dependency. This also affects Python 3.14 free-threaded installs (see #805).
 
The SDK uses only stable cryptography APIs (RSA signing, key serialization, hashes/HMAC, EC/Ed25519/Ed448, ciphers). Verified in a clean virtualenv: ⁠ oci==2.180.0 ⁠ imports and runs on
  ⁠ cryptography==48.0.1 ⁠ *and* ⁠ 49.0.0 ⁠:
  - ⁠ oci.core.ComputeClient ⁠ / ⁠ oci.core.VirtualNetworkClient ⁠ import cleanly
  - ⁠ oci.signer.Signer ⁠ RSA request-signing path works
  - ⁠ oci.signer.load_private_key ⁠ works
  - the pyOpenSSL ↔️ cryptography bridge is intact
 
pip check ⁠ reports no issues beyond the (now-raised) cap itself.
 
Scope
  - ⁠ setup.py ⁠: ⁠ cryptography>=3.2.1,<47.0.0 ⁠ → ⁠ <50.0.0 ⁠
  - ⁠ requirements.txt ⁠: same bound on the non-3.9.0/3.9.1 line
  - The py3.9.0/3.9.1 pin (⁠ cryptography==42.0.8 ⁠) and ⁠ pyOpenSSL<27.0.0 ⁠ are unchanged.
 
  If a smaller increment is preferred, ⁠ <49.0.0 ⁠ would still unblock the security fix (cryptography 48.0.1).
 
  Refs: #805